### PR TITLE
ASE-49: bind AI chat to workspace/editor context

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -39,9 +39,13 @@ void main() async {
         ChangeNotifierProvider(
           create: (_) => EditorProvider(apiClient: apiClient),
         ),
-        ChangeNotifierProvider(
+        ChangeNotifierProxyProvider<EditorProvider, ChatProvider>(
           create: (_) => ChatProvider(apiClient: chatApiClient)
             ..setWorkspace(workspaceProvider.currentPath),
+          update: (_, editorProvider, chatProvider) {
+            chatProvider!.setEditorContext(editorProvider.chatContext);
+            return chatProvider;
+          },
         ),
         ChangeNotifierProvider(
           create: (_) => GitProvider(apiClient: gitApiClient),

--- a/app/lib/models/chat_message.dart
+++ b/app/lib/models/chat_message.dart
@@ -154,23 +154,3 @@ class ChatMessage {
         .join('\n');
   }
 }
-
-/// Represents a code context attached to a chat message.
-class CodeContext {
-  final String filePath;
-  final int startLine;
-  final int endLine;
-  final String selectedText;
-
-  const CodeContext({
-    required this.filePath,
-    required this.startLine,
-    required this.endLine,
-    required this.selectedText,
-  });
-
-  String get label {
-    final fileName = filePath.split('/').last;
-    return '$fileName:$startLine-$endLine';
-  }
-}

--- a/app/lib/models/editor_context.dart
+++ b/app/lib/models/editor_context.dart
@@ -1,0 +1,97 @@
+class EditorCursor {
+  final int line;
+  final int column;
+
+  const EditorCursor({required this.line, required this.column});
+
+  Map<String, dynamic> toJson() => {'line': line, 'column': column};
+
+  @override
+  bool operator ==(Object other) {
+    return other is EditorCursor &&
+        other.line == line &&
+        other.column == column;
+  }
+
+  @override
+  int get hashCode => Object.hash(line, column);
+}
+
+class EditorSelection {
+  final EditorCursor start;
+  final EditorCursor end;
+
+  const EditorSelection({required this.start, required this.end});
+
+  bool get isCollapsed =>
+      start.line == end.line && start.column == end.column;
+
+  Map<String, dynamic> toJson() => {
+    'start': start.toJson(),
+    'end': end.toJson(),
+  };
+
+  String get lineLabel {
+    if (start.line == end.line) {
+      return 'L${start.line}';
+    }
+    return 'L${start.line}-${end.line}';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is EditorSelection &&
+        other.start == start &&
+        other.end == end;
+  }
+
+  @override
+  int get hashCode => Object.hash(start, end);
+}
+
+class EditorChatContext {
+  final String? activeFile;
+  final EditorCursor? cursor;
+  final EditorSelection? selection;
+
+  const EditorChatContext({
+    required this.activeFile,
+    required this.cursor,
+    required this.selection,
+  });
+
+  bool get hasContext => activeFile != null && activeFile!.isNotEmpty;
+
+  String get label {
+    final filePath = activeFile;
+    if (filePath == null || filePath.isEmpty) {
+      return 'No active file';
+    }
+    final fileName = filePath.split('/').last;
+    if (selection != null) {
+      return '$fileName ${selection!.lineLabel}';
+    }
+    if (cursor != null) {
+      return '$fileName L${cursor!.line}:C${cursor!.column}';
+    }
+    return fileName;
+  }
+
+  Map<String, dynamic> toTransportJson(String workspaceRoot) => {
+    'workspaceRoot': workspaceRoot,
+    'activeFile': activeFile,
+    'cursor': cursor?.toJson(),
+    'selection': selection?.toJson(),
+  };
+
+  @override
+  bool operator ==(Object other) {
+    return other is EditorChatContext &&
+        other.activeFile == activeFile &&
+        other.cursor == cursor &&
+        other.selection == selection;
+  }
+
+  @override
+  int get hashCode => Object.hash(activeFile, cursor, selection);
+}

--- a/app/lib/providers/chat_provider.dart
+++ b/app/lib/providers/chat_provider.dart
@@ -5,8 +5,8 @@ import 'package:flutter/foundation.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../models/chat_message.dart';
+import '../models/editor_context.dart';
 import '../models/session.dart';
-import '../providers/workspace_provider.dart';
 import '../services/chat_api_client.dart';
 
 /// State management for chat functionality.
@@ -15,6 +15,7 @@ import '../services/chat_api_client.dart';
 /// clears the active conversation and reloads sessions for the new workspace.
 class ChatProvider extends ChangeNotifier {
   final ChatApiClient _apiClient;
+  EditorChatContext? _editorContext;
 
   ChatProvider({required ChatApiClient apiClient}) : _apiClient = apiClient;
 
@@ -40,9 +41,8 @@ class ChatProvider extends ChangeNotifier {
   bool _isStreaming = false;
   bool get isStreaming => _isStreaming;
 
-  // -- Code context (for contextual chat / REQ-009) --
-  CodeContext? _codeContext;
-  CodeContext? get codeContext => _codeContext;
+  // -- Editor context shared by contextual + full chat --
+  EditorChatContext? get editorContext => _editorContext;
 
   // -- Session list --
   List<SessionMeta> _sessions = [];
@@ -68,15 +68,15 @@ class ChatProvider extends ChangeNotifier {
     _conversationId = null;
     _pendingMessage = null;
     _isStreaming = false;
-    _codeContext = null;
     _error = null;
     notifyListeners();
     loadSessions();
   }
 
-  /// Set code context for contextual chat.
-  void setCodeContext(CodeContext? context) {
-    _codeContext = context;
+  /// Update the active editor context shared across chat surfaces.
+  void setEditorContext(EditorChatContext? context) {
+    if (_editorContext == context) return;
+    _editorContext = context;
     notifyListeners();
   }
 
@@ -87,7 +87,6 @@ class ChatProvider extends ChangeNotifier {
     _conversationId = null;
     _pendingMessage = null;
     _isStreaming = false;
-    _codeContext = null;
     _error = null;
     notifyListeners();
   }
@@ -122,7 +121,7 @@ class ChatProvider extends ChangeNotifier {
     _error = null;
 
     final dir = workDir ?? _workspacePath;
-    _channel!.sink.add(jsonEncode({'type': 'start', 'workDir': dir}));
+    _channel!.sink.add(jsonEncode({'type': 'start', 'workspaceRoot': dir}));
     notifyListeners();
   }
 
@@ -139,7 +138,13 @@ class ChatProvider extends ChangeNotifier {
     _streamingBlocks.clear();
     _error = null;
 
-    _channel!.sink.add(jsonEncode({'type': 'resume', 'sessionId': sessionId}));
+    _channel!.sink.add(
+      jsonEncode({
+        'type': 'resume',
+        'sessionId': sessionId,
+        'workspaceRoot': _workspacePath,
+      }),
+    );
     notifyListeners();
   }
 
@@ -151,22 +156,11 @@ class ChatProvider extends ChangeNotifier {
       return;
     }
 
-    // Build user message text, including code context if present
-    String messageText = text;
-    if (_codeContext != null) {
-      final ctx = _codeContext!;
-      messageText =
-          'Regarding the code in ${ctx.filePath} '
-          '(lines ${ctx.startLine}-${ctx.endLine}):\n'
-          '```\n${ctx.selectedText}\n```\n\n$text';
-      _codeContext = null; // Clear after sending
-    }
-
     // Add user message locally
     _messages.add(
       ChatMessage(
         role: 'user',
-        content: [ContentBlock(type: 'text', text: messageText)],
+        content: [ContentBlock(type: 'text', text: text)],
       ),
     );
 
@@ -178,7 +172,11 @@ class ChatProvider extends ChangeNotifier {
       jsonEncode({
         'type': 'send',
         'sessionId': _conversationId,
-        'message': messageText,
+        'message': text,
+        'workspaceRoot': _workspacePath,
+        'activeFile': _editorContext?.activeFile,
+        'cursor': _editorContext?.cursor?.toJson(),
+        'selection': _editorContext?.selection?.toJson(),
       }),
     );
     notifyListeners();
@@ -294,11 +292,11 @@ class ChatProvider extends ChangeNotifier {
   }
 
   /// Fetch session list from REST API.
-  /// Defaults to filtering by the current workspace project name.
+  /// Defaults to filtering by the exact current workspace root.
   /// Pass [allProjects] = true to show sessions from all workspaces.
   Future<void> loadSessions({
     String? query,
-    String? project,
+    String? workspaceRoot,
     bool allProjects = false,
   }) async {
     _isLoadingSessions = true;
@@ -306,11 +304,11 @@ class ChatProvider extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final effectiveProject =
-          allProjects ? null : (project ?? WorkspaceProvider.nameForPath(_workspacePath));
+      final effectiveWorkspaceRoot =
+          allProjects ? null : (workspaceRoot ?? _workspacePath);
       _sessions = await _apiClient.getSessions(
         query: query,
-        project: effectiveProject,
+        workspaceRoot: effectiveWorkspaceRoot,
       );
     } catch (e) {
       _error = e.toString();

--- a/app/lib/providers/editor_provider.dart
+++ b/app/lib/providers/editor_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import '../models/diagnostic.dart';
+import '../models/editor_context.dart';
 import '../services/api_client.dart';
 
 /// Represents an open file with its content and edit state.
@@ -26,7 +27,8 @@ class EditorProvider extends ChangeNotifier {
 
   final List<OpenFile> _openFiles = [];
   int _currentFileIndex = -1;
-  String? _selectedText;
+  EditorCursor? _cursor;
+  EditorSelection? _selection;
   bool _isLoading = false;
   String? _error;
 
@@ -44,15 +46,22 @@ class EditorProvider extends ChangeNotifier {
       ? _openFiles[_currentFileIndex]
       : null;
   int get currentFileIndex => _currentFileIndex;
-  String? get selectedText => _selectedText;
+  EditorCursor? get cursor => _cursor;
+  EditorSelection? get selection => _selection;
   bool get isLoading => _isLoading;
   String? get error => _error;
+  EditorChatContext get chatContext => EditorChatContext(
+    activeFile: currentFile?.path,
+    cursor: _cursor,
+    selection: _selection,
+  );
 
   /// Open a file by path. If already open, switch to it.
   Future<void> openFile(String path) async {
     final existingIndex = _openFiles.indexWhere((f) => f.path == path);
     if (existingIndex >= 0) {
       _currentFileIndex = existingIndex;
+      _resetContextForCurrentFile();
       notifyListeners();
       return;
     }
@@ -67,6 +76,7 @@ class EditorProvider extends ChangeNotifier {
       final file = OpenFile(path: path, name: name, originalContent: content);
       _openFiles.add(file);
       _currentFileIndex = _openFiles.length - 1;
+      _resetContextForCurrentFile();
       loadDiagnostics();
     } catch (e) {
       _error = e.toString();
@@ -82,12 +92,14 @@ class EditorProvider extends ChangeNotifier {
     if (_currentFileIndex >= _openFiles.length) {
       _currentFileIndex = _openFiles.length - 1;
     }
+    _resetContextForCurrentFile();
     notifyListeners();
   }
 
   void switchToFile(int index) {
     if (index >= 0 && index < _openFiles.length) {
       _currentFileIndex = index;
+      _resetContextForCurrentFile();
       notifyListeners();
     }
   }
@@ -120,8 +132,24 @@ class EditorProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  void setSelectedText(String? text) {
-    _selectedText = text;
+  void updateCursor(EditorCursor? cursor) {
+    _cursor = cursor;
+    if (cursor == null) {
+      _selection = null;
+    }
+    notifyListeners();
+  }
+
+  void updateSelection(EditorSelection? selection, {EditorCursor? cursor}) {
+    _selection = selection;
+    if (cursor != null) {
+      _cursor = cursor;
+    }
+    notifyListeners();
+  }
+
+  void clearSelection() {
+    _selection = null;
     notifyListeners();
   }
 
@@ -190,5 +218,15 @@ class EditorProvider extends ChangeNotifier {
       return parts.sublist(0, parts.length - 1).join('/');
     }
     return '/';
+  }
+
+  void _resetContextForCurrentFile() {
+    if (currentFile == null) {
+      _cursor = null;
+      _selection = null;
+      return;
+    }
+    _cursor = const EditorCursor(line: 1, column: 1);
+    _selection = null;
   }
 }

--- a/app/lib/screens/chat_screen.dart
+++ b/app/lib/screens/chat_screen.dart
@@ -102,7 +102,7 @@ class _ChatScreenState extends State<ChatScreen> {
           body: Column(
             children: [
               if (provider.error != null) _buildErrorBanner(context, provider),
-              if (provider.codeContext != null)
+              if (provider.editorContext?.hasContext ?? false)
                 _buildContextBadge(context, provider),
               Expanded(child: _buildMessageList(context, provider)),
               _buildInputBar(context, provider),
@@ -131,7 +131,7 @@ class _ChatScreenState extends State<ChatScreen> {
   Widget _buildContextBadge(BuildContext context, ChatProvider provider) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final ctx = provider.codeContext!;
+    final ctx = provider.editorContext!;
 
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -154,14 +154,15 @@ class _ChatScreenState extends State<ChatScreen> {
               overflow: TextOverflow.ellipsis,
             ),
           ),
-          InkWell(
-            onTap: () => provider.setCodeContext(null),
-            child: Icon(
-              Icons.close,
-              size: 18,
-              color: colorScheme.onSecondaryContainer,
+          if (ctx.selection != null)
+            InkWell(
+              onTap: () => context.read<EditorProvider>().clearSelection(),
+              child: Icon(
+                Icons.close,
+                size: 18,
+                color: colorScheme.onSecondaryContainer,
+              ),
             ),
-          ),
         ],
       ),
     );

--- a/app/lib/screens/chat_screen.dart
+++ b/app/lib/screens/chat_screen.dart
@@ -99,11 +99,11 @@ class _ChatScreenState extends State<ChatScreen> {
               ),
             ],
           ),
-          body: Column(
+              body: Column(
             children: [
               if (provider.error != null) _buildErrorBanner(context, provider),
               if (provider.editorContext?.hasContext ?? false)
-                _buildContextBadge(context, provider),
+                _buildContextSummary(context, provider),
               Expanded(child: _buildMessageList(context, provider)),
               _buildInputBar(context, provider),
             ],
@@ -128,30 +128,42 @@ class _ChatScreenState extends State<ChatScreen> {
     );
   }
 
-  Widget _buildContextBadge(BuildContext context, ChatProvider provider) {
+  Widget _buildContextSummary(BuildContext context, ChatProvider provider) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final ctx = provider.editorContext!;
+    final workspace = context.read<WorkspaceProvider>();
+    final fileName = (ctx.activeFile ?? '').split('/').last;
+    final selectionLabel = ctx.selection?.lineLabel ?? 'No selection';
 
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       decoration: BoxDecoration(
         color: colorScheme.secondaryContainer,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Icon(Icons.code, size: 18, color: colorScheme.onSecondaryContainer),
           const SizedBox(width: 8),
           Expanded(
-            child: Text(
-              'Context: ${ctx.label}',
-              style: theme.textTheme.labelMedium?.copyWith(
+            child: DefaultTextStyle(
+              style: theme.textTheme.labelMedium!.copyWith(
                 color: colorScheme.onSecondaryContainer,
-                fontFamily: 'monospace',
               ),
-              overflow: TextOverflow.ellipsis,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Workspace: ${workspace.displayName}'),
+                  Text(
+                    'File: $fileName',
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text('Selection: $selectionLabel'),
+                ],
+              ),
             ),
           ),
           if (ctx.selection != null)

--- a/app/lib/screens/code_screen.dart
+++ b/app/lib/screens/code_screen.dart
@@ -162,7 +162,12 @@ class _CodeScreenState extends State<CodeScreen> {
                         editorProvider.updateContent(content);
                       },
                       onCursorChanged: editorProvider.updateCursor,
-                      onSelectionChanged: editorProvider.updateSelection,
+                      onSelectionChanged: (selection, cursor) {
+                        editorProvider.updateSelection(
+                          selection,
+                          cursor: cursor,
+                        );
+                      },
                       onSave: hasChanges
                           ? () => editorProvider.saveCurrentFile()
                           : null,

--- a/app/lib/screens/code_screen.dart
+++ b/app/lib/screens/code_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../models/chat_message.dart';
 import '../providers/chat_provider.dart';
 import '../providers/editor_provider.dart';
+import 'chat_screen.dart';
 import '../widgets/code_viewer.dart';
 import '../widgets/code_editor.dart';
 import '../widgets/contextual_chat.dart';
@@ -161,6 +161,8 @@ class _CodeScreenState extends State<CodeScreen> {
                       onContentChanged: (content) {
                         editorProvider.updateContent(content);
                       },
+                      onCursorChanged: editorProvider.updateCursor,
+                      onSelectionChanged: editorProvider.updateSelection,
                       onSave: hasChanges
                           ? () => editorProvider.saveCurrentFile()
                           : null,
@@ -169,19 +171,13 @@ class _CodeScreenState extends State<CodeScreen> {
                       content: file.currentContent,
                       fileName: file.name,
                       diagnostics: editorProvider.diagnostics,
-                      onAskAi: (selectedText) {
-                        editorProvider.setSelectedText(selectedText);
-                        // Set code context on ChatProvider so contextual chat
-                        // includes the selected code snippet.
-                        final lines = selectedText.split('\n');
-                        context.read<ChatProvider>().setCodeContext(
-                          CodeContext(
-                            filePath: file.path,
-                            startLine: 1,
-                            endLine: lines.length,
-                            selectedText: selectedText,
-                          ),
+                      onSelectionChanged: (selection) {
+                        editorProvider.updateSelection(
+                          selection,
+                          cursor: selection?.end ?? editorProvider.cursor,
                         );
+                      },
+                      onAskAi: () {
                         setState(() => _showChat = true);
                       },
                       onEditRequested: () {
@@ -192,6 +188,9 @@ class _CodeScreenState extends State<CodeScreen> {
                 ContextualChat(
                   onExpandToFullChat: () {
                     setState(() => _showChat = false);
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const ChatScreen()),
+                    );
                   },
                 ),
             ],

--- a/app/lib/screens/code_screen.dart
+++ b/app/lib/screens/code_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../providers/chat_provider.dart';
 import '../providers/editor_provider.dart';
 import 'chat_screen.dart';
 import '../widgets/code_viewer.dart';

--- a/app/lib/services/chat_api_client.dart
+++ b/app/lib/services/chat_api_client.dart
@@ -39,11 +39,13 @@ class ChatApiClient {
   /// Fetch all sessions. Supports optional search query and project filter.
   Future<List<SessionMeta>> getSessions({
     String? query,
-    String? project,
+    String? workspaceRoot,
   }) async {
     final params = <String, String>{};
     if (query != null && query.isNotEmpty) params['q'] = query;
-    if (project != null && project.isNotEmpty) params['project'] = project;
+    if (workspaceRoot != null && workspaceRoot.isNotEmpty) {
+      params['workspaceRoot'] = workspaceRoot;
+    }
 
     final uri = _buildUri(
       '/api/sessions',

--- a/app/lib/widgets/code_editor.dart
+++ b/app/lib/widgets/code_editor.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
 
+import '../models/editor_context.dart';
+
 class CodeEditor extends StatefulWidget {
   final String content;
   final String fileName;
   final void Function(String content) onContentChanged;
+  final void Function(EditorCursor cursor)? onCursorChanged;
+  final void Function(EditorSelection? selection, EditorCursor cursor)?
+  onSelectionChanged;
   final VoidCallback? onSave;
 
   const CodeEditor({
@@ -11,6 +16,8 @@ class CodeEditor extends StatefulWidget {
     required this.content,
     required this.fileName,
     required this.onContentChanged,
+    this.onCursorChanged,
+    this.onSelectionChanged,
     this.onSave,
   });
 
@@ -35,6 +42,7 @@ class _CodeEditorState extends State<CodeEditor> {
     _editorScrollController = ScrollController();
     _focusNode = FocusNode();
     _controller.addListener(_onTextChanged);
+    _controller.addListener(_onSelectionChanged);
     _editorScrollController.addListener(_syncLineNumbersFromEditor);
     _lineNumberScrollController.addListener(_syncEditorFromLineNumbers);
   }
@@ -45,8 +53,10 @@ class _CodeEditorState extends State<CodeEditor> {
     if (oldWidget.content != widget.content &&
         widget.content != _controller.text) {
       _controller.removeListener(_onTextChanged);
+      _controller.removeListener(_onSelectionChanged);
       _controller.text = widget.content;
       _controller.addListener(_onTextChanged);
+      _controller.addListener(_onSelectionChanged);
     }
   }
 
@@ -72,11 +82,57 @@ class _CodeEditorState extends State<CodeEditor> {
     widget.onContentChanged(_controller.text);
   }
 
+  void _onSelectionChanged() {
+    final selection = _controller.selection;
+    if (!selection.isValid) return;
+
+    final cursor = _offsetToCursor(selection.extentOffset);
+    widget.onCursorChanged?.call(cursor);
+
+    if (selection.isCollapsed) {
+      widget.onSelectionChanged?.call(null, cursor);
+      return;
+    }
+
+    final startOffset = selection.start < selection.end
+        ? selection.start
+        : selection.end;
+    final endOffset = selection.start < selection.end
+        ? selection.end
+        : selection.start;
+    widget.onSelectionChanged?.call(
+      EditorSelection(
+        start: _offsetToCursor(startOffset),
+        end: _offsetToCursor(endOffset),
+      ),
+      cursor,
+    );
+  }
+
+  EditorCursor _offsetToCursor(int rawOffset) {
+    final text = _controller.text;
+    final clampedOffset = rawOffset.clamp(0, text.length);
+    var line = 1;
+    var column = 1;
+
+    for (var i = 0; i < clampedOffset; i++) {
+      if (text.codeUnitAt(i) == 10) {
+        line++;
+        column = 1;
+      } else {
+        column++;
+      }
+    }
+
+    return EditorCursor(line: line, column: column);
+  }
+
   @override
   void dispose() {
     _editorScrollController.removeListener(_syncLineNumbersFromEditor);
     _lineNumberScrollController.removeListener(_syncEditorFromLineNumbers);
     _controller.removeListener(_onTextChanged);
+    _controller.removeListener(_onSelectionChanged);
     _controller.dispose();
     _lineNumberScrollController.dispose();
     _editorScrollController.dispose();

--- a/app/lib/widgets/code_viewer.dart
+++ b/app/lib/widgets/code_viewer.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:highlight/highlight.dart' show highlight, Node;
 import '../models/diagnostic.dart';
+import '../models/editor_context.dart';
 
 /// Maps highlight.js CSS class names to TextStyle.
 class _SyntaxTheme {
@@ -81,7 +82,8 @@ class _SyntaxTheme {
 class CodeViewer extends StatefulWidget {
   final String content;
   final String fileName;
-  final void Function(String selectedText)? onAskAi;
+  final VoidCallback? onAskAi;
+  final void Function(EditorSelection? selection)? onSelectionChanged;
   final VoidCallback? onEditRequested;
   final List<Diagnostic> diagnostics;
 
@@ -90,6 +92,7 @@ class CodeViewer extends StatefulWidget {
     required this.content,
     required this.fileName,
     this.onAskAi,
+    this.onSelectionChanged,
     this.onEditRequested,
     this.diagnostics = const [],
   });
@@ -269,6 +272,34 @@ class _CodeViewerState extends State<CodeViewer> {
     return spans;
   }
 
+  EditorSelection? _selectionFromText(String? text) {
+    if (text == null || text.isEmpty) return null;
+    final startOffset = widget.content.indexOf(text);
+    if (startOffset < 0) return null;
+    final endOffset = startOffset + text.length;
+    return EditorSelection(
+      start: _offsetToCursor(startOffset),
+      end: _offsetToCursor(endOffset),
+    );
+  }
+
+  EditorCursor _offsetToCursor(int rawOffset) {
+    final clampedOffset = rawOffset.clamp(0, widget.content.length);
+    var line = 1;
+    var column = 1;
+
+    for (var i = 0; i < clampedOffset; i++) {
+      if (widget.content.codeUnitAt(i) == 10) {
+        line++;
+        column = 1;
+      } else {
+        column++;
+      }
+    }
+
+    return EditorCursor(line: line, column: column);
+  }
+
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
@@ -300,11 +331,13 @@ class _CodeViewerState extends State<CodeViewer> {
                   if (text != null &&
                       text.isNotEmpty &&
                       text != _selectedText) {
+                    widget.onSelectionChanged?.call(_selectionFromText(text));
                     setState(() {
                       _selectedText = text;
                       _showToolbar = true;
                     });
                   } else if ((text == null || text.isEmpty) && _showToolbar) {
+                    widget.onSelectionChanged?.call(null);
                     final expectedGeneration = _selectionGeneration;
                     Future.delayed(const Duration(milliseconds: 300), () {
                       if (mounted &&
@@ -411,7 +444,7 @@ class _CodeViewerState extends State<CodeViewer> {
           _SelectionToolbar(
             onAskAi: widget.onAskAi != null
                 ? () {
-                    widget.onAskAi!(_selectedText!);
+                    widget.onAskAi!();
                     setState(() => _showToolbar = false);
                   }
                 : null,

--- a/app/lib/widgets/contextual_chat.dart
+++ b/app/lib/widgets/contextual_chat.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../providers/chat_provider.dart';
+import '../providers/editor_provider.dart';
 import 'chat_bubble.dart';
 
 /// Draggable bottom sheet chat panel for contextual AI chat (REQ-009).
@@ -85,7 +86,7 @@ class _ContextualChatState extends State<ContextualChat> {
                 children: [
                   _buildHandle(context),
                   _buildHeader(context, provider),
-                  if (provider.codeContext != null)
+                  if (provider.editorContext?.hasContext ?? false)
                     _buildContextBadge(context, provider),
                   Expanded(
                     child: _buildMessageList(provider, sheetScrollController),
@@ -144,7 +145,7 @@ class _ContextualChatState extends State<ContextualChat> {
   Widget _buildContextBadge(BuildContext context, ChatProvider provider) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final ctx = provider.codeContext!;
+    final ctx = provider.editorContext!;
 
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -168,15 +169,17 @@ class _ContextualChatState extends State<ContextualChat> {
               overflow: TextOverflow.ellipsis,
             ),
           ),
-          const SizedBox(width: 6),
-          InkWell(
-            onTap: () => provider.setCodeContext(null),
-            child: Icon(
-              Icons.close,
-              size: 16,
-              color: colorScheme.onSecondaryContainer,
+          if (ctx.selection != null) ...[
+            const SizedBox(width: 6),
+            InkWell(
+              onTap: () => context.read<EditorProvider>().clearSelection(),
+              child: Icon(
+                Icons.close,
+                size: 16,
+                color: colorScheme.onSecondaryContainer,
+              ),
             ),
-          ),
+          ],
         ],
       ),
     );
@@ -194,7 +197,9 @@ class _ContextualChatState extends State<ContextualChat> {
         child: Padding(
           padding: const EdgeInsets.all(24),
           child: Text(
-            'Ask a question about the selected code',
+            provider.editorContext?.selection != null
+                ? 'Ask a question about the selected code'
+                : 'Ask a question about the current file',
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               color: Theme.of(context).colorScheme.onSurfaceVariant,
             ),

--- a/app/lib/widgets/contextual_chat.dart
+++ b/app/lib/widgets/contextual_chat.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../providers/chat_provider.dart';
 import '../providers/editor_provider.dart';
+import '../providers/workspace_provider.dart';
 import 'chat_bubble.dart';
 
 /// Draggable bottom sheet chat panel for contextual AI chat (REQ-009).
@@ -87,7 +88,7 @@ class _ContextualChatState extends State<ContextualChat> {
                   _buildHandle(context),
                   _buildHeader(context, provider),
                   if (provider.editorContext?.hasContext ?? false)
-                    _buildContextBadge(context, provider),
+                    _buildContextSummary(context, provider),
                   Expanded(
                     child: _buildMessageList(provider, sheetScrollController),
                   ),
@@ -142,35 +143,45 @@ class _ContextualChatState extends State<ContextualChat> {
     );
   }
 
-  Widget _buildContextBadge(BuildContext context, ChatProvider provider) {
+  Widget _buildContextSummary(BuildContext context, ChatProvider provider) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final ctx = provider.editorContext!;
+    final workspace = context.read<WorkspaceProvider>();
+    final fileName = (ctx.activeFile ?? '').split('/').last;
+    final selectionLabel = ctx.selection?.lineLabel ?? 'No selection';
 
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       decoration: BoxDecoration(
         color: colorScheme.secondaryContainer,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(
-        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Icon(Icons.code, size: 16, color: colorScheme.onSecondaryContainer),
-          const SizedBox(width: 6),
-          Flexible(
-            child: Text(
-              ctx.label,
-              style: theme.textTheme.labelMedium?.copyWith(
+          const SizedBox(width: 8),
+          Expanded(
+            child: DefaultTextStyle(
+              style: theme.textTheme.labelMedium!.copyWith(
                 color: colorScheme.onSecondaryContainer,
-                fontFamily: 'monospace',
               ),
-              overflow: TextOverflow.ellipsis,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Workspace: ${workspace.displayName}'),
+                  Text(
+                    'File: $fileName',
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text('Selection: $selectionLabel'),
+                ],
+              ),
             ),
           ),
-          if (ctx.selection != null) ...[
-            const SizedBox(width: 6),
+          if (ctx.selection != null)
             InkWell(
               onTap: () => context.read<EditorProvider>().clearSelection(),
               child: Icon(
@@ -179,7 +190,6 @@ class _ContextualChatState extends State<ContextualChat> {
                 color: colorScheme.onSecondaryContainer,
               ),
             ),
-          ],
         ],
       ),
     );

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -358,7 +358,7 @@ packages:
     source: hosted
     version: "1.12.1"
   stream_channel:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: stream_channel
       sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  stream_channel: ^2.1.4
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/app/test/providers/chat_provider_test.dart
+++ b/app/test/providers/chat_provider_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vscode_mobile/models/editor_context.dart';
+import 'package:vscode_mobile/providers/chat_provider.dart';
+
+import '../test_support/chat_test_helpers.dart';
+
+void main() {
+  group('ChatProvider minimal IDE context', () {
+    late RecordingWebSocketChannel channel;
+    late ChatProvider provider;
+
+    setUp(() {
+      channel = RecordingWebSocketChannel();
+      provider = ChatProvider(apiClient: FakeChatApiClient(channel: channel));
+    });
+
+    tearDown(() async {
+      provider.dispose();
+      await channel.dispose();
+    });
+
+    test('binds new conversations to the exact workspace root', () {
+      provider.setWorkspace('/workspaces/alpha');
+
+      provider.startConversation();
+
+      final startPayload = decodeSentJson(channel, 0);
+      expect(startPayload, <String, dynamic>{
+        'type': 'start',
+        'workspaceRoot': '/workspaces/alpha',
+      });
+    });
+
+    test(
+      'serializes only workspace, file, cursor, and selection for each turn',
+      () async {
+        provider.setWorkspace('/workspaces/alpha');
+        provider.setEditorContext(
+          const EditorChatContext(
+            activeFile: '/workspaces/alpha/lib/main.dart',
+            cursor: EditorCursor(line: 12, column: 4),
+            selection: EditorSelection(
+              start: EditorCursor(line: 10, column: 2),
+              end: EditorCursor(line: 14, column: 8),
+            ),
+          ),
+        );
+
+        provider.resumeConversation('sess-1');
+        final resumePayload = decodeSentJson(channel, 0);
+        expect(resumePayload, <String, dynamic>{
+          'type': 'resume',
+          'sessionId': 'sess-1',
+          'workspaceRoot': '/workspaces/alpha',
+        });
+
+        channel.serverSend(<String, dynamic>{
+          'type': 'resumed',
+          'conversationId': 'sess-1',
+        });
+        await Future<void>.delayed(Duration.zero);
+        provider.sendMessage('Explain this code');
+
+        final sendPayload = decodeSentJson(channel, 1);
+        expect(sortedKeys(sendPayload), <String>[
+          'activeFile',
+          'cursor',
+          'message',
+          'selection',
+          'sessionId',
+          'type',
+          'workspaceRoot',
+        ]);
+        expect(sendPayload['type'], 'send');
+        expect(sendPayload['sessionId'], 'sess-1');
+        expect(sendPayload['message'], 'Explain this code');
+        expect(sendPayload['workspaceRoot'], '/workspaces/alpha');
+        expect(sendPayload['activeFile'], '/workspaces/alpha/lib/main.dart');
+        expect(sendPayload['cursor'], <String, dynamic>{
+          'line': 12,
+          'column': 4,
+        });
+        expect(sendPayload['selection'], <String, dynamic>{
+          'start': <String, dynamic>{'line': 10, 'column': 2},
+          'end': <String, dynamic>{'line': 14, 'column': 8},
+        });
+        expect(sendPayload.containsKey('git'), isFalse);
+        expect(sendPayload.containsKey('diagnostics'), isFalse);
+        expect(sendPayload.containsKey('terminal'), isFalse);
+        expect(sendPayload.containsKey('tabs'), isFalse);
+        expect(sendPayload.containsKey('search'), isFalse);
+      },
+    );
+
+    test(
+      'updates file and cursor and clears selection to null for the next turn',
+      () async {
+        provider.setWorkspace('/workspaces/alpha');
+        provider.resumeConversation('sess-2');
+        channel.serverSend(<String, dynamic>{
+          'type': 'resumed',
+          'conversationId': 'sess-2',
+        });
+        await Future<void>.delayed(Duration.zero);
+
+        provider.setEditorContext(
+          const EditorChatContext(
+            activeFile: '/workspaces/alpha/lib/first.dart',
+            cursor: EditorCursor(line: 3, column: 1),
+            selection: EditorSelection(
+              start: EditorCursor(line: 3, column: 1),
+              end: EditorCursor(line: 5, column: 12),
+            ),
+          ),
+        );
+        provider.sendMessage('first turn');
+
+        provider.setEditorContext(
+          const EditorChatContext(
+            activeFile: '/workspaces/alpha/lib/second.dart',
+            cursor: EditorCursor(line: 9, column: 7),
+            selection: null,
+          ),
+        );
+        provider.sendMessage('second turn');
+
+        final secondSendPayload = decodeSentJson(channel, 2);
+        expect(secondSendPayload['workspaceRoot'], '/workspaces/alpha');
+        expect(
+          secondSendPayload['activeFile'],
+          '/workspaces/alpha/lib/second.dart',
+        );
+        expect(secondSendPayload['cursor'], <String, dynamic>{
+          'line': 9,
+          'column': 7,
+        });
+        expect(secondSendPayload.containsKey('selection'), isTrue);
+        expect(secondSendPayload['selection'], isNull);
+      },
+    );
+  });
+}

--- a/app/test/test_support/chat_test_helpers.dart
+++ b/app/test/test_support/chat_test_helpers.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 
 import 'package:vscode_mobile/models/chat_message.dart';
 import 'package:vscode_mobile/models/session.dart';
-import 'package:vscode_mobile/providers/chat_provider.dart';
 import 'package:vscode_mobile/services/chat_api_client.dart';
 import 'package:vscode_mobile/services/settings_service.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -87,7 +86,7 @@ class FakeChatApiClient extends ChatApiClient {
   @override
   Future<List<SessionMeta>> getSessions({
     String? query,
-    String? project,
+    String? workspaceRoot,
   }) async {
     return sessions;
   }

--- a/app/test/test_support/chat_test_helpers.dart
+++ b/app/test/test_support/chat_test_helpers.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:vscode_mobile/models/chat_message.dart';
+import 'package:vscode_mobile/models/session.dart';
+import 'package:vscode_mobile/providers/chat_provider.dart';
+import 'package:vscode_mobile/services/chat_api_client.dart';
+import 'package:vscode_mobile/services/settings_service.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+class RecordingWebSocketSink implements WebSocketSink {
+  final List<dynamic> sentMessages = <dynamic>[];
+  bool isClosed = false;
+
+  @override
+  void add(dynamic event) {
+    sentMessages.add(event);
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> addStream(Stream<dynamic> stream) async {
+    await for (final event in stream) {
+      add(event);
+    }
+  }
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) async {
+    isClosed = true;
+  }
+
+  @override
+  Future<void> get done async {}
+}
+
+class RecordingWebSocketChannel extends StreamChannelMixin<dynamic>
+    implements WebSocketChannel {
+  RecordingWebSocketChannel()
+    : _controller = StreamController<dynamic>.broadcast(),
+      _sink = RecordingWebSocketSink();
+
+  final StreamController<dynamic> _controller;
+  final RecordingWebSocketSink _sink;
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  String? get closeReason => null;
+
+  @override
+  String? get protocol => null;
+
+  @override
+  Future<void> get ready async {}
+
+  @override
+  Stream<dynamic> get stream => _controller.stream;
+
+  @override
+  RecordingWebSocketSink get sink => _sink;
+
+  void serverSend(Map<String, dynamic> payload) {
+    _controller.add(jsonEncode(payload));
+  }
+
+  Future<void> dispose() async {
+    await _controller.close();
+  }
+}
+
+class FakeChatApiClient extends ChatApiClient {
+  FakeChatApiClient({RecordingWebSocketChannel? channel})
+    : channel = channel ?? RecordingWebSocketChannel(),
+      super(settings: SettingsService());
+
+  final RecordingWebSocketChannel channel;
+  List<SessionMeta> sessions = const <SessionMeta>[];
+
+  @override
+  WebSocketChannel connectWebSocket() => channel;
+
+  @override
+  Future<List<SessionMeta>> getSessions({
+    String? query,
+    String? project,
+  }) async {
+    return sessions;
+  }
+
+  @override
+  Future<List<ChatMessage>> getSessionMessages(String sessionId) async {
+    return const <ChatMessage>[];
+  }
+
+  @override
+  Future<List<ChatMessage>> getSubagentMessages(
+    String sessionId,
+    String agentId,
+  ) async {
+    return const <ChatMessage>[];
+  }
+
+  @override
+  Future<Map<String, dynamic>> getSubagentMeta(
+    String sessionId,
+    String agentId,
+  ) async {
+    return const <String, dynamic>{};
+  }
+}
+
+Map<String, dynamic> decodeSentJson(
+  RecordingWebSocketChannel channel,
+  int index,
+) {
+  final raw = channel.sink.sentMessages[index] as String;
+  return jsonDecode(raw) as Map<String, dynamic>;
+}
+
+List<String> sortedKeys(Map<String, dynamic> payload) {
+  final keys = payload.keys.toList()..sort();
+  return keys;
+}

--- a/app/test/widgets/contextual_chat_test.dart
+++ b/app/test/widgets/contextual_chat_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:vscode_mobile/models/editor_context.dart';
+import 'package:vscode_mobile/providers/chat_provider.dart';
+import 'package:vscode_mobile/providers/workspace_provider.dart';
+import 'package:vscode_mobile/screens/chat_screen.dart';
+import 'package:vscode_mobile/widgets/contextual_chat.dart';
+
+import '../test_support/chat_test_helpers.dart';
+
+Widget _wrapWithProviders({
+  required ChatProvider chatProvider,
+  required WorkspaceProvider workspaceProvider,
+  required Widget child,
+}) {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<WorkspaceProvider>.value(value: workspaceProvider),
+      ChangeNotifierProvider<ChatProvider>.value(value: chatProvider),
+    ],
+    child: MaterialApp(home: Scaffold(body: child)),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Context summaries', () {
+    late RecordingWebSocketChannel channel;
+    late ChatProvider chatProvider;
+    late WorkspaceProvider workspaceProvider;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      channel = RecordingWebSocketChannel();
+      chatProvider = ChatProvider(
+        apiClient: FakeChatApiClient(channel: channel),
+      );
+      workspaceProvider = WorkspaceProvider();
+    });
+
+    tearDown(() async {
+      chatProvider.dispose();
+      await channel.dispose();
+    });
+
+    testWidgets('contextual chat shows Workspace, File, and No selection', (
+      WidgetTester tester,
+    ) async {
+      await workspaceProvider.setWorkspace('/workspaces/alpha');
+      chatProvider.setWorkspace('/workspaces/alpha');
+      chatProvider.setEditorContext(
+        const EditorChatContext(
+          activeFile: '/workspaces/alpha/lib/main.dart',
+          cursor: EditorCursor(line: 18, column: 2),
+          selection: null,
+        ),
+      );
+
+      await tester.pumpWidget(
+        _wrapWithProviders(
+          chatProvider: chatProvider,
+          workspaceProvider: workspaceProvider,
+          child: const ContextualChat(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Workspace'), findsOneWidget);
+      expect(find.textContaining('alpha'), findsWidgets);
+      expect(find.textContaining('File'), findsOneWidget);
+      expect(find.textContaining('main.dart'), findsWidgets);
+      expect(find.textContaining('No selection'), findsOneWidget);
+    });
+
+    testWidgets(
+      'summary updates when selection is cleared and survives expand to full chat',
+      (WidgetTester tester) async {
+        await workspaceProvider.setWorkspace('/workspaces/alpha');
+        chatProvider.setWorkspace('/workspaces/alpha');
+        chatProvider.setEditorContext(
+          const EditorChatContext(
+            activeFile: '/workspaces/alpha/lib/main.dart',
+            cursor: EditorCursor(line: 8, column: 3),
+            selection: EditorSelection(
+              start: EditorCursor(line: 8, column: 1),
+              end: EditorCursor(line: 11, column: 5),
+            ),
+          ),
+        );
+
+        var expanded = false;
+        await tester.pumpWidget(
+          _wrapWithProviders(
+            chatProvider: chatProvider,
+            workspaceProvider: workspaceProvider,
+            child: ContextualChat(onExpandToFullChat: () => expanded = true),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('Selection'), findsOneWidget);
+        expect(find.textContaining('No selection'), findsNothing);
+
+        chatProvider.setEditorContext(
+          const EditorChatContext(
+            activeFile: '/workspaces/alpha/lib/main.dart',
+            cursor: EditorCursor(line: 12, column: 6),
+            selection: null,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('No selection'), findsOneWidget);
+
+        await tester.tap(find.byTooltip('Open full chat'));
+        await tester.pumpAndSettle();
+        expect(expanded, isTrue);
+
+        await tester.pumpWidget(
+          _wrapWithProviders(
+            chatProvider: chatProvider,
+            workspaceProvider: workspaceProvider,
+            child: const ChatScreen(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('Workspace'), findsOneWidget);
+        expect(find.textContaining('main.dart'), findsWidgets);
+        expect(find.textContaining('No selection'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/server/internal/api/handler_test.go
+++ b/server/internal/api/handler_test.go
@@ -438,6 +438,48 @@ func TestSessionsSearch_ByQuery(t *testing.T) {
 	}
 }
 
+func TestSessionsSearch_ProjectUsesExactWorkspaceRoot(t *testing.T) {
+	claudeDir := t.TempDir()
+	sessionsDir := filepath.Join(claudeDir, "sessions")
+	os.MkdirAll(sessionsDir, 0o755)
+
+	writeSessionFile(t, claudeDir, 1, "s1", "/tmp/workspaces/app", "cli")
+	writeSessionFile(t, claudeDir, 2, "s2", "/var/tmp/app", "cli")
+	writeSessionFile(t, claudeDir, 3, "s3", "/tmp/workspaces/app-nested", "cli")
+
+	sessIndex := claude.NewSessionIndex(claudeDir)
+	if err := sessIndex.ScanSessions(); err != nil {
+		t.Fatal(err)
+	}
+
+	pm := claude.NewProcessManager("/nonexistent", ".")
+	diagRunner := diagnostics.NewRunner(10 * time.Second)
+	srv := NewServer(nil, sessIndex, pm, "", git.NewGit("."), terminal.NewManager(), diagRunner)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/sessions?project=/tmp/workspaces/app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var sessions []claude.SessionMeta
+	if err := json.NewDecoder(resp.Body).Decode(&sessions); err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 exact-root session, got %d", len(sessions))
+	}
+	if sessions[0].SessionID != "s1" {
+		t.Fatalf("expected session s1, got %#v", sessions)
+	}
+}
+
 func TestSessionMessages_E2E(t *testing.T) {
 	claudeDir := t.TempDir()
 	sessionsDir := filepath.Join(claudeDir, "sessions")

--- a/server/internal/api/sessions.go
+++ b/server/internal/api/sessions.go
@@ -10,18 +10,21 @@ import (
 )
 
 // handleSessionsList handles GET /api/sessions.
-// Supports query params: ?q=keyword&project=name for filtering.
+// Supports query params: ?q=keyword&workspaceRoot=/abs/path for filtering.
 func (s *Server) handleSessionsList(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query().Get("q")
-	project := r.URL.Query().Get("project")
+	workspaceRoot := r.URL.Query().Get("workspaceRoot")
+	if workspaceRoot == "" {
+		workspaceRoot = r.URL.Query().Get("project")
+	}
 
 	var sessions []claude.SessionMeta
-	if query != "" || project != "" {
-		sessions = s.sessionIndex.SearchSessions(query, project)
+	if query != "" || workspaceRoot != "" {
+		sessions = s.sessionIndex.SearchSessions(query, workspaceRoot)
 	} else {
 		sessions = s.sessionIndex.ListSessions()
 	}
-	log.Printf("[Sessions] listed sessions (query=%q, project=%q, count=%d)", query, project, len(sessions))
+	log.Printf("[Sessions] listed sessions (query=%q, workspaceRoot=%q, count=%d)", query, workspaceRoot, len(sessions))
 	writeJSON(w, http.StatusOK, sessions)
 }
 

--- a/server/internal/api/websocket.go
+++ b/server/internal/api/websocket.go
@@ -20,10 +20,15 @@ var upgrader = websocket.Upgrader{
 
 // ChatMessage is the message format for the /ws/chat WebSocket.
 type ChatMessage struct {
-	Type      string `json:"type"`                // "send", "resume", "start"
-	Message   string `json:"message,omitempty"`   // For "send" type.
-	SessionID string `json:"sessionId,omitempty"` // For "resume" type.
-	WorkDir   string `json:"workDir,omitempty"`   // For "start" type.
+	Type          string                  `json:"type"`                    // "send", "resume", "start"
+	Message       string                  `json:"message,omitempty"`       // For "send" type.
+	SessionID     string                  `json:"sessionId,omitempty"`     // For "resume" type.
+	WorkspaceRoot string                  `json:"workspaceRoot,omitempty"` // For workspace-bound chat.
+	WorkDir       string                  `json:"workDir,omitempty"`       // Legacy alias for workspaceRoot.
+	ActiveFile    string                  `json:"activeFile,omitempty"`
+	Cursor        *claude.CursorPosition  `json:"cursor,omitempty"`
+	Selection     *claude.SelectionRange  `json:"selection,omitempty"`
+	Context       *claude.ConversationContext `json:"context,omitempty"`
 }
 
 // handleWSChat handles the /ws/chat WebSocket endpoint for AI conversation streaming.
@@ -85,13 +90,14 @@ func (s *Server) handleWSChat(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleChatStart(conn *websocket.Conn, msg ChatMessage, setActiveConv func(*claude.Conversation)) {
-	conv, err := s.processManager.StartConversation(msg.WorkDir)
+	workspaceRoot := msg.workspaceRoot()
+	conv, err := s.processManager.StartConversation(workspaceRoot)
 	if err != nil {
 		log.Printf("[WS/Chat] failed to start conversation: %v", err)
 		writeWSError(conn, "failed to start conversation: "+err.Error())
 		return
 	}
-	log.Printf("[WS/Chat] started conversation %s (workDir=%s)", conv.ID, msg.WorkDir)
+	log.Printf("[WS/Chat] started conversation %s (workspaceRoot=%s)", conv.ID, workspaceRoot)
 	setActiveConv(conv)
 
 	// Send the conversation ID back.
@@ -105,7 +111,7 @@ func (s *Server) handleChatStart(conn *websocket.Conn, msg ChatMessage, setActiv
 }
 
 func (s *Server) handleChatResume(conn *websocket.Conn, msg ChatMessage, setActiveConv func(*claude.Conversation)) {
-	conv, err := s.processManager.ResumeConversation(msg.SessionID)
+	conv, err := s.processManager.ResumeConversationInDir(msg.SessionID, msg.workspaceRoot())
 	if err != nil {
 		log.Printf("[WS/Chat] failed to resume conversation %s: %v", msg.SessionID, err)
 		writeWSError(conn, "failed to resume conversation: "+err.Error())
@@ -134,12 +140,49 @@ func (s *Server) handleChatSend(conn *websocket.Conn, msg ChatMessage) {
 		return
 	}
 
-	if err := conv.Send(msg.Message); err != nil {
+	chatContext := msg.contextEnvelope()
+	if err := conv.SendWithContext(msg.Message, chatContext); err != nil {
 		log.Printf("[WS/Chat] failed to send message to %s: %v", conv.ID, err)
 		writeWSError(conn, "failed to send message: "+err.Error())
 		return
 	}
 	log.Printf("[WS/Chat] sent message to conversation %s", conv.ID)
+}
+
+func (m ChatMessage) workspaceRoot() string {
+	if m.WorkspaceRoot != "" {
+		return m.WorkspaceRoot
+	}
+	if m.Context != nil && m.Context.WorkspaceRoot != "" {
+		return m.Context.WorkspaceRoot
+	}
+	return m.WorkDir
+}
+
+func (m ChatMessage) contextEnvelope() *claude.ConversationContext {
+	if m.Context != nil {
+		ctxCopy := *m.Context
+		if ctxCopy.WorkspaceRoot == "" {
+			ctxCopy.WorkspaceRoot = m.workspaceRoot()
+		}
+		if ctxCopy.ActiveFile == "" {
+			ctxCopy.ActiveFile = m.ActiveFile
+		}
+		if ctxCopy.Cursor == nil {
+			ctxCopy.Cursor = m.Cursor
+		}
+		if ctxCopy.Selection == nil {
+			ctxCopy.Selection = m.Selection
+		}
+		return &ctxCopy
+	}
+
+	return &claude.ConversationContext{
+		WorkspaceRoot: m.workspaceRoot(),
+		ActiveFile:    m.ActiveFile,
+		Cursor:        m.Cursor,
+		Selection:     m.Selection,
+	}
 }
 
 func (s *Server) streamOutput(conn *websocket.Conn, conv *claude.Conversation) {

--- a/server/internal/api/websocket_test.go
+++ b/server/internal/api/websocket_test.go
@@ -1,0 +1,180 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/Lincyaw/vscode-mobile/server/internal/claude"
+	"github.com/Lincyaw/vscode-mobile/server/internal/diagnostics"
+	"github.com/Lincyaw/vscode-mobile/server/internal/git"
+	"github.com/Lincyaw/vscode-mobile/server/internal/terminal"
+)
+
+func writeFakeClaudeCaptureScript(t *testing.T) (scriptPath, cwdLog, stdinLog string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	cwdLog = filepath.Join(dir, "cwd.log")
+	stdinLog = filepath.Join(dir, "stdin.log")
+	scriptPath = filepath.Join(dir, "fake-claude.sh")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"printf '%s\\n' \"$PWD\" >> '" + cwdLog + "'",
+		"while IFS= read -r line; do",
+		"  printf '%s\\n' \"$line\" >> '" + stdinLog + "'",
+		"done",
+	}, "\n")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake claude script: %v", err)
+	}
+	return scriptPath, cwdLog, stdinLog
+}
+
+func newWebsocketTestServer(t *testing.T, claudeBin, defaultDir string) *httptest.Server {
+	t.Helper()
+	sessionIndex := claude.NewSessionIndex(t.TempDir())
+	pm := claude.NewProcessManager(claudeBin, defaultDir)
+	diagRunner := diagnostics.NewRunner(10 * time.Second)
+	srv := NewServer(newMockFS(), sessionIndex, pm, "", git.NewGit(t.TempDir()), terminal.NewManager(), diagRunner)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func waitForFileLine(t *testing.T, path string) string {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil && strings.TrimSpace(string(data)) != "" {
+			lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+			return lines[len(lines)-1]
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for file %s", path)
+	return ""
+}
+
+func dialChatSocket(t *testing.T, serverURL string) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(serverURL, "http") + "/ws/chat"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	return conn
+}
+
+func TestWSChatStartBindsConversationToRequestedWorkspace(t *testing.T) {
+	claudeBin, cwdLog, _ := writeFakeClaudeCaptureScript(t)
+	ts := newWebsocketTestServer(t, claudeBin, "/server/default")
+
+	workspaceRoot := filepath.Join(t.TempDir(), "workspace-a")
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+
+	conn := dialChatSocket(t, ts.URL)
+	defer conn.Close()
+
+	if err := conn.WriteJSON(map[string]any{
+		"type":          "start",
+		"workspaceRoot": workspaceRoot,
+	}); err != nil {
+		t.Fatalf("write start message: %v", err)
+	}
+
+	var started map[string]any
+	if err := conn.ReadJSON(&started); err != nil {
+		t.Fatalf("read started message: %v", err)
+	}
+	if started["type"] != "started" {
+		t.Fatalf("expected started response, got %#v", started)
+	}
+
+	if got := waitForFileLine(t, cwdLog); got != workspaceRoot {
+		t.Fatalf("expected claude process cwd %q, got %q", workspaceRoot, got)
+	}
+}
+
+func TestWSChatSendStripsUnknownFieldsAndPreservesNullSelection(t *testing.T) {
+	claudeBin, _, stdinLog := writeFakeClaudeCaptureScript(t)
+	ts := newWebsocketTestServer(t, claudeBin, "/server/default")
+
+	workspaceRoot := filepath.Join(t.TempDir(), "workspace-b")
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+
+	conn := dialChatSocket(t, ts.URL)
+	defer conn.Close()
+
+	if err := conn.WriteJSON(map[string]any{
+		"type":          "start",
+		"workspaceRoot": workspaceRoot,
+	}); err != nil {
+		t.Fatalf("write start message: %v", err)
+	}
+
+	var started map[string]any
+	if err := conn.ReadJSON(&started); err != nil {
+		t.Fatalf("read started message: %v", err)
+	}
+	sessionID, _ := started["conversationId"].(string)
+	if sessionID == "" {
+		t.Fatalf("expected conversation id in %#v", started)
+	}
+
+	if err := conn.WriteJSON(map[string]any{
+		"type":          "send",
+		"sessionId":     sessionID,
+		"message":       "Explain this function",
+		"workspaceRoot": workspaceRoot,
+		"activeFile":    filepath.Join(workspaceRoot, "lib", "main.dart"),
+		"cursor": map[string]any{
+			"line":   21,
+			"column": 6,
+		},
+		"selection":   nil,
+		"diagnostics": []string{"forbidden"},
+		"terminal":    map[string]any{"cwd": "/tmp"},
+		"git":         map[string]any{"branch": "forbidden"},
+	}); err != nil {
+		t.Fatalf("write send message: %v", err)
+	}
+
+	logged := waitForFileLine(t, stdinLog)
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(logged), &payload); err != nil {
+		t.Fatalf("unmarshal claude stdin payload: %v\nraw: %s", err, logged)
+	}
+
+	message, ok := payload["message"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected stream-json message object, got %#v", payload)
+	}
+	content, _ := message["content"].(string)
+	if !strings.Contains(content, "workspaceRoot") {
+		t.Fatalf("expected content to include workspaceRoot, got %q", content)
+	}
+	if !strings.Contains(content, "activeFile") {
+		t.Fatalf("expected content to include activeFile, got %q", content)
+	}
+	if !strings.Contains(content, "cursor") {
+		t.Fatalf("expected content to include cursor, got %q", content)
+	}
+	if !strings.Contains(content, "\"selection\":null") {
+		t.Fatalf("expected content to preserve null selection, got %q", content)
+	}
+	if strings.Contains(content, "diagnostics") || strings.Contains(content, "terminal") || strings.Contains(content, "git") {
+		t.Fatalf("expected forbidden fields to be stripped from %q", content)
+	}
+}

--- a/server/internal/claude/process.go
+++ b/server/internal/claude/process.go
@@ -105,11 +105,19 @@ func (pm *ProcessManager) StartConversation(workingDir string) (*Conversation, e
 
 // ResumeConversation resumes an existing Claude session.
 func (pm *ProcessManager) ResumeConversation(sessionID string) (*Conversation, error) {
+	return pm.ResumeConversationInDir(sessionID, "")
+}
+
+// ResumeConversationInDir resumes an existing Claude session in a specific workspace.
+func (pm *ProcessManager) ResumeConversationInDir(sessionID, workingDir string) (*Conversation, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	args := []string{"-p", "--verbose", "-r", sessionID, "--output-format", "stream-json", "--input-format", "stream-json"}
 
 	cmd := exec.CommandContext(ctx, pm.claudeBin, args...)
-	cmd.Dir = pm.workingDir
+	if workingDir == "" {
+		workingDir = pm.workingDir
+	}
+	cmd.Dir = workingDir
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -144,12 +152,17 @@ func (pm *ProcessManager) ResumeConversation(sessionID string) (*Conversation, e
 	pm.active[conv.ID] = conv
 	pm.mu.Unlock()
 
-	log.Printf("[Claude] resumed conversation %s", conv.ID)
+	log.Printf("[Claude] resumed conversation %s in %s", conv.ID, workingDir)
 	return conv, nil
 }
 
 // Send sends a user message to the Claude CLI process.
 func (c *Conversation) Send(message string) error {
+	return c.SendWithContext(message, nil)
+}
+
+// SendWithContext sends a user message plus lightweight editor context.
+func (c *Conversation) SendWithContext(message string, chatContext *ConversationContext) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -161,7 +174,7 @@ func (c *Conversation) Send(message string) error {
 		Type: "user",
 		Message: StreamInputMessage{
 			Role:    "user",
-			Content: message,
+			Content: formatMessageWithContext(message, chatContext),
 		},
 	}
 	data, err := json.Marshal(input)
@@ -174,6 +187,23 @@ func (c *Conversation) Send(message string) error {
 		return fmt.Errorf("writing to stdin: %w", err)
 	}
 	return nil
+}
+
+func formatMessageWithContext(message string, chatContext *ConversationContext) string {
+	if chatContext == nil {
+		return message
+	}
+
+	contextJSON, err := json.Marshal(chatContext)
+	if err != nil {
+		return message
+	}
+
+	return fmt.Sprintf(
+		"[mobile_editor_context]\n%s\n[/mobile_editor_context]\n\n%s",
+		contextJSON,
+		message,
+	)
 }
 
 // Close gracefully shuts down the conversation.

--- a/server/internal/claude/process_test.go
+++ b/server/internal/claude/process_test.go
@@ -1,7 +1,11 @@
 package claude
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewProcessManager(t *testing.T) {
@@ -48,6 +52,106 @@ func TestConversationLifecycle(t *testing.T) {
 	pm.RemoveConversation(conv.ID)
 	if _, ok := pm.GetConversation(conv.ID); ok {
 		t.Fatal("conversation should be removed")
+	}
+}
+
+func writeFakeClaudeCaptureScript(t *testing.T) (scriptPath, cwdLog string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	cwdLog = filepath.Join(dir, "cwd.log")
+	scriptPath = filepath.Join(dir, "fake-claude.sh")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"printf '%s\\n' \"$PWD\" >> '" + cwdLog + "'",
+		"while IFS= read -r _line; do :; done",
+	}, "\n")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake claude script: %v", err)
+	}
+	return scriptPath, cwdLog
+}
+
+func waitForFileLine(t *testing.T, path string) string {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil && strings.TrimSpace(string(data)) != "" {
+			lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+			return lines[len(lines)-1]
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for file %s", path)
+	return ""
+}
+
+func TestStartConversationUsesRequestedWorkingDir(t *testing.T) {
+	claudeBin, cwdLog := writeFakeClaudeCaptureScript(t)
+	pm := NewProcessManager(claudeBin, "/server/default")
+
+	workspaceRoot := filepath.Join(t.TempDir(), "workspace")
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+
+	conv, err := pm.StartConversation(workspaceRoot)
+	if err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	if err := conv.Close(); err != nil {
+		t.Fatalf("failed to close: %v", err)
+	}
+
+	if got := waitForFileLine(t, cwdLog); got != workspaceRoot {
+		t.Fatalf("expected process cwd %q, got %q", workspaceRoot, got)
+	}
+}
+
+func TestFormatMessageWithContextIncludesOnlyMinimalEnvelope(t *testing.T) {
+	message := formatMessageWithContext("Explain this code", &ConversationContext{
+		WorkspaceRoot: "/workspaces/alpha",
+		ActiveFile:    "/workspaces/alpha/lib/main.dart",
+		Cursor:        &CursorPosition{Line: 12, Column: 4},
+		Selection: &SelectionRange{
+			Start: CursorPosition{Line: 10, Column: 2},
+			End:   CursorPosition{Line: 14, Column: 8},
+		},
+	})
+
+	if !strings.Contains(message, "[mobile_editor_context]") {
+		t.Fatalf("expected context envelope, got %q", message)
+	}
+	if !strings.Contains(message, `"workspaceRoot":"/workspaces/alpha"`) {
+		t.Fatalf("expected workspace root in %q", message)
+	}
+	if !strings.Contains(message, `"activeFile":"/workspaces/alpha/lib/main.dart"`) {
+		t.Fatalf("expected active file in %q", message)
+	}
+	if !strings.Contains(message, `"cursor":{"line":12,"column":4}`) {
+		t.Fatalf("expected cursor in %q", message)
+	}
+	if !strings.Contains(message, `"selection":{"start":{"line":10,"column":2},"end":{"line":14,"column":8}}`) {
+		t.Fatalf("expected selection in %q", message)
+	}
+	if strings.Contains(message, "diagnostics") || strings.Contains(message, "terminal") || strings.Contains(message, "git") {
+		t.Fatalf("expected forbidden fields to be absent from %q", message)
+	}
+}
+
+func TestFormatMessageWithContextPreservesNullSelection(t *testing.T) {
+	message := formatMessageWithContext("Explain this code", &ConversationContext{
+		WorkspaceRoot: "/workspaces/alpha",
+		ActiveFile:    "/workspaces/alpha/lib/main.dart",
+		Cursor:        &CursorPosition{Line: 9, Column: 7},
+		Selection:     nil,
+	})
+
+	if !strings.Contains(message, `"selection":null`) {
+		t.Fatalf("expected null selection in %q", message)
 	}
 }
 

--- a/server/internal/claude/session.go
+++ b/server/internal/claude/session.go
@@ -75,31 +75,23 @@ func (idx *SessionIndex) ListSessions() []SessionMeta {
 
 // SearchSessions returns sessions matching the query string.
 // Matches against cwd (project path) and entrypoint, case-insensitive.
-// If project is non-empty, only sessions whose cwd ends with that project name are returned.
-func (idx *SessionIndex) SearchSessions(query, project string) []SessionMeta {
+// If workspaceRoot is non-empty, absolute/path-like values are matched against
+// the exact cleaned workspace root. Bare names fall back to the legacy
+// project-name filter for compatibility with older callers and tests.
+func (idx *SessionIndex) SearchSessions(query, workspaceRoot string) []SessionMeta {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 
 	query = strings.ToLower(query)
-	project = strings.ToLower(project)
+	normalizedRoot := normalizeWorkspaceRoot(workspaceRoot)
 
 	var result []SessionMeta
 	for _, s := range idx.sessions {
 		cwdLower := strings.ToLower(s.Cwd)
 		entryLower := strings.ToLower(s.Entrypoint)
 
-		if project != "" {
-			parts := strings.Split(cwdLower, "/")
-			projectName := ""
-			if len(parts) > 0 {
-				projectName = parts[len(parts)-1]
-				if projectName == "" && len(parts) > 1 {
-					projectName = parts[len(parts)-2]
-				}
-			}
-			if projectName != project {
-				continue
-			}
+		if !matchesWorkspaceRoot(s.Cwd, normalizedRoot) {
+			continue
 		}
 
 		if query != "" {
@@ -111,6 +103,37 @@ func (idx *SessionIndex) SearchSessions(query, project string) []SessionMeta {
 		result = append(result, s)
 	}
 	return result
+}
+
+func normalizeWorkspaceRoot(path string) string {
+	if path == "" {
+		return ""
+	}
+	cleaned := filepath.Clean(strings.TrimSpace(path))
+	if cleaned == "." {
+		return ""
+	}
+	return cleaned
+}
+
+func matchesWorkspaceRoot(cwd, workspaceRoot string) bool {
+	if workspaceRoot == "" {
+		return true
+	}
+
+	if strings.Contains(workspaceRoot, "/") {
+		return normalizeWorkspaceRoot(cwd) == workspaceRoot
+	}
+
+	parts := strings.Split(normalizeWorkspaceRoot(cwd), "/")
+	if len(parts) == 0 {
+		return false
+	}
+	last := parts[len(parts)-1]
+	if last == "" && len(parts) > 1 {
+		last = parts[len(parts)-2]
+	}
+	return strings.EqualFold(last, workspaceRoot)
 }
 
 // GetMessages parses the JSONL file for the given session and returns structured messages.

--- a/server/internal/claude/types.go
+++ b/server/internal/claude/types.go
@@ -112,6 +112,26 @@ type StreamInputMessage struct {
 	Content string `json:"content"`
 }
 
+// ConversationContext is the editor/workspace context attached to a chat send.
+type ConversationContext struct {
+	WorkspaceRoot string          `json:"workspaceRoot,omitempty"`
+	ActiveFile    string          `json:"activeFile,omitempty"`
+	Cursor        *CursorPosition `json:"cursor,omitempty"`
+	Selection     *SelectionRange `json:"selection,omitempty"`
+}
+
+// CursorPosition describes a single cursor location in 1-based coordinates.
+type CursorPosition struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+// SelectionRange describes a selection in 1-based coordinates.
+type SelectionRange struct {
+	Start CursorPosition `json:"start"`
+	End   CursorPosition `json:"end"`
+}
+
 // StreamOutput is the JSON received from claude CLI stdout.
 type StreamOutput struct {
 	Type       string          `json:"type"`

--- a/server/internal/claude/types.go
+++ b/server/internal/claude/types.go
@@ -117,7 +117,7 @@ type ConversationContext struct {
 	WorkspaceRoot string          `json:"workspaceRoot,omitempty"`
 	ActiveFile    string          `json:"activeFile,omitempty"`
 	Cursor        *CursorPosition `json:"cursor,omitempty"`
-	Selection     *SelectionRange `json:"selection,omitempty"`
+	Selection     *SelectionRange `json:"selection"`
 }
 
 // CursorPosition describes a single cursor location in 1-based coordinates.


### PR DESCRIPTION
## Summary
- bind AI chat sessions to the active workspace root on both the Flutter client and server transport
- inject active editor context (`activeFile`, `cursor`, nullable `selection`) into chat sends and reflect it in the chat UI
- add focused app/server tests for workspace filtering, editor context propagation, and context summary rendering

## Why
This delivers the minimal IDE-side context contract for AI in issue #10 without expanding into git, diagnostics, terminal, tabs, or search context injection.

## Issue
- Closes #10

## Validation
- `cd server && go test ./internal/claude ./internal/api`
- `cd app && flutter test test/providers/chat_provider_test.dart test/widgets/contextual_chat_test.dart` *(not run in this environment: `flutter` is unavailable)*
- `cd app && flutter analyze` *(not run in this environment: `flutter` is unavailable)*
