### PR TITLE
ASE-41: runtime bridge foundation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 # Makefile for OpenVSMobile
-# Builds Go server + Flutter Android client
+# Builds the Go server, Flutter client, and focused bridge validation flows.
 
-# Use the project-specific Flutter SDK if available; fall back to PATH.
-FLUTTER := /home/faydev/flutter-sdk/flutter/bin/flutter
-ifeq ($(wildcard $(FLUTTER)),)
-  FLUTTER := flutter
-endif
+FLUTTER ?=
+FLUTTER_BIN := $(strip $(or \
+	$(FLUTTER), \
+	$(shell command -v flutter 2>/dev/null), \
+	$(wildcard $(HOME)/flutter/bin/flutter), \
+	$(wildcard $(HOME)/flutter-sdk/flutter/bin/flutter), \
+	$(wildcard /home/faydev/flutter-sdk/flutter/bin/flutter)))
 
-.PHONY: all build build-server build-android test lint clean deps run-server install-android help
+.PHONY: all build build-server build-android test lint clean deps run-server install-android \
+	help flutter-prereq verify-bridge-extension verify-bridge-foundation
 
 # Default target: build everything
 all: build
@@ -23,9 +26,9 @@ build-server:
 	cd server && go build -o ../server_bin ./cmd/server
 	@echo "==> Server binary: ./server_bin"
 
-build-android:
-	@echo "==> Building Flutter APK with $(FLUTTER)..."
-	cd app && $(FLUTTER) build apk
+build-android: flutter-prereq
+	@echo "==> Building Flutter APK with $(FLUTTER_BIN)..."
+	cd app && $(FLUTTER_BIN) build apk
 
 # -----------------------------------------------------------------------------
 # Development
@@ -35,31 +38,46 @@ run-server: build-server
 	@echo "==> Running Go server..."
 	./server_bin
 
-deps:
+deps: flutter-prereq
 	@echo "==> Getting Go dependencies..."
 	cd server && go mod tidy
 	@echo "==> Getting Flutter dependencies..."
-	cd app && $(FLUTTER) pub get
+	cd app && $(FLUTTER_BIN) pub get
 
 install-android: build-android
 	@echo "==> Installing APK to connected device..."
-	cd app && $(FLUTTER) install
+	cd app && $(FLUTTER_BIN) install
 
 # -----------------------------------------------------------------------------
 # Test & Quality
 # -----------------------------------------------------------------------------
 
-test:
+test: flutter-prereq
 	@echo "==> Running Go tests..."
 	cd server && go test ./...
 	@echo "==> Running Flutter tests..."
-	cd app && $(FLUTTER) test
+	cd app && $(FLUTTER_BIN) test
 
-lint:
+lint: flutter-prereq
 	@echo "==> Running go vet..."
 	cd server && go vet ./...
 	@echo "==> Running flutter analyze..."
-	cd app && $(FLUTTER) analyze
+	cd app && $(FLUTTER_BIN) analyze
+
+flutter-prereq:
+	@if [ -z "$(FLUTTER_BIN)" ]; then \
+		echo "error: Flutter SDK not found." >&2; \
+		echo "hint: install Flutter and add it to PATH, or run 'make FLUTTER=/absolute/path/to/flutter <target>'" >&2; \
+		echo "hint: expected a runnable 'flutter' binary, for example '$$HOME/flutter/bin/flutter'" >&2; \
+		exit 1; \
+	fi
+	@echo "==> Using Flutter SDK: $(FLUTTER_BIN)"
+
+verify-bridge-extension:
+	@./scripts/verify_bridge_foundation.sh --extension-only
+
+verify-bridge-foundation:
+	@./scripts/verify_bridge_foundation.sh
 
 # -----------------------------------------------------------------------------
 # Clean
@@ -68,7 +86,12 @@ lint:
 clean:
 	@echo "==> Cleaning build artifacts..."
 	rm -f server_bin
-	cd app && $(FLUTTER) clean
+	@if [ -n "$(FLUTTER_BIN)" ]; then \
+		echo "==> Cleaning Flutter artifacts with $(FLUTTER_BIN)..."; \
+		cd app && $(FLUTTER_BIN) clean; \
+	else \
+		echo "==> Skipping Flutter clean; no Flutter SDK detected"; \
+	fi
 
 # -----------------------------------------------------------------------------
 # Help
@@ -76,14 +99,17 @@ clean:
 
 help:
 	@echo "Available targets:"
-	@echo "  all            - Build server and Android APK (default)"
-	@echo "  build          - Alias for all"
-	@echo "  build-server   - Build Go server binary -> ./server_bin"
-	@echo "  build-android  - Build Flutter APK"
-	@echo "  run-server     - Build and run Go server"
-	@echo "  deps           - Run go mod tidy + flutter pub get"
-	@echo "  install-android- Build and install APK to connected device"
-	@echo "  test           - Run Go and Flutter tests"
-	@echo "  lint           - Run go vet + flutter analyze"
-	@echo "  clean          - Remove server_bin and flutter build artifacts"
-	@echo "  help           - Show this help message"
+	@echo "  all                     - Build server and Android APK (default)"
+	@echo "  build                   - Alias for all"
+	@echo "  build-server            - Build Go server binary -> ./server_bin"
+	@echo "  build-android           - Build Flutter APK"
+	@echo "  run-server              - Build and run Go server"
+	@echo "  deps                    - Run go mod tidy + flutter pub get"
+	@echo "  install-android         - Build and install APK to a connected device"
+	@echo "  test                    - Run Go and Flutter tests"
+	@echo "  lint                    - Run go vet + flutter analyze"
+	@echo "  flutter-prereq          - Show the resolved Flutter SDK or fail with setup guidance"
+	@echo "  verify-bridge-extension - Compile the built-in mobile bridge extension from openvscode-server/"
+	@echo "  verify-bridge-foundation - Run the bridge extension compile + targeted Go bridge checks"
+	@echo "  clean                   - Remove server_bin and Flutter build artifacts"
+	@echo "  help                    - Show this help message"

--- a/docs/runtime-bridge-validation.md
+++ b/docs/runtime-bridge-validation.md
@@ -1,0 +1,65 @@
+# Runtime bridge validation
+
+ASE-41's bridge foundation work is only useful if other developers can rerun the same checks without guessing tool paths or the OpenVSCode working directory. This document defines the repo-local validation flow and the prerequisite gates behind it.
+
+## Prerequisites
+
+Required for the bridge foundation helper:
+
+- `go` in `PATH`, or `GO_BINARY=/absolute/path/to/go`
+- `node` and `npm` in `PATH`
+- `openvscode-server/` checked out in this repo
+- `openvscode-server` dependencies installed with `cd openvscode-server && npm install` (or `npm ci`)
+
+Optional for the gated restart integration check:
+
+- `VSCODE_INTEGRATION_TEST=1`
+- a compiled OpenVSCode server at `openvscode-server/out/server-main.js`
+
+Optional for repo-wide Flutter targets:
+
+- a runnable Flutter binary in `PATH`, or an explicit override such as `make FLUTTER=/absolute/path/to/flutter test`
+
+## Canonical commands
+
+Compile only the built-in bridge extension from the `openvscode-server/` root:
+
+```bash
+make verify-bridge-extension
+```
+
+Run the full bridge foundation validation helper:
+
+```bash
+make verify-bridge-foundation
+```
+
+The helper lives at `scripts/verify_bridge_foundation.sh` and runs these checks in order:
+
+1. validates required toolchain and `openvscode-server` dependency prerequisites
+2. compiles `mobile-runtime-bridge` from the `openvscode-server/` root
+3. runs targeted Go bridge tests in `server/internal/vscode` and `server/internal/api`
+4. runs `go vet ./...` in `server/`
+5. runs `make test` and `make lint` when Flutter is available through the repo's normal discovery rules
+6. optionally runs `TestIntegration_BridgeLifecycle_EndToEnd` when `VSCODE_INTEGRATION_TEST=1`
+
+## Gated checks
+
+The helper intentionally separates always-on checks from heavier environment-gated validation:
+
+- The bridge extension compile, targeted Go tests, and `go vet` are mandatory.
+- Repo-wide `make test` and `make lint` run automatically when Flutter is available; otherwise the helper logs the missing prerequisite and leaves a deterministic rerun command.
+- The restart end-to-end integration test is gated because it needs a compiled OpenVSCode server and the `VSCODE_INTEGRATION_TEST=1` opt-in used by the existing integration suite.
+- Full repo targets such as `make test` and `make lint` fail fast with a setup hint instead of assuming a machine-specific SDK path.
+
+## Flutter path resolution
+
+The root `Makefile` resolves Flutter in this order:
+
+1. `make FLUTTER=/absolute/path/to/flutter <target>`
+2. `flutter` discovered in `PATH`
+3. `${HOME}/flutter/bin/flutter`
+4. `${HOME}/flutter-sdk/flutter/bin/flutter`
+5. `/home/faydev/flutter-sdk/flutter/bin/flutter`
+
+If none of those locations work, Flutter-backed targets stop immediately with a message that explains how to provide an explicit override.

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -449,6 +449,71 @@ requirements:
       - server/internal/git/git_test.go
     depends_on: [REQ-011]
 
+  - id: REQ-023
+    title: Mobile runtime bridge lifecycle manager
+    description: >
+      Go server tracks a built-in mobile runtime bridge discovery contract,
+      monitors ready/not-ready state, detects generation changes as bridge
+      restarts, and resets state cleanly when the VS Code transport drops or
+      the server shuts down. The bridge manager owns the discovery file poll
+      loop and lifecycle event broadcast foundation without any fallback path.
+    priority: P0
+    status: implemented
+    code:
+      - server/internal/vscode/bridge.go
+      - server/internal/vscode/client.go
+      - server/cmd/server/main.go
+      - openvscode-server/extensions/mobile-runtime-bridge/src/extension.ts
+    tests:
+      - server/internal/vscode/bridge_test.go
+      - server/internal/vscode/bridge_integration_test.go
+    depends_on: [REQ-001]
+
+  - id: REQ-024
+    title: Bridge capabilities discovery API
+    description: >
+      Go server exposes GET /bridge/capabilities with an RFC-shaped capability
+      document once the runtime bridge is ready. Before readiness, the endpoint
+      fails explicitly with structured bridge_not_ready / capability_unavailable
+      errors rather than silently falling back to legacy APIs.
+    priority: P0
+    status: implemented
+    code:
+      - server/internal/api/bridge.go
+      - server/internal/api/router.go
+      - server/internal/vscode/bridge.go
+      - server/cmd/server/main.go
+      - openvscode-server/extensions/mobile-runtime-bridge/src/extension.ts
+    tests:
+      - server/internal/api/bridge_test.go
+      - server/internal/vscode/bridge_test.go
+    depends_on: [REQ-023]
+
+  - id: REQ-025
+    title: Bridge lifecycle event stream
+    description: >
+      Go server exposes WS /bridge/ws/events with a stable {type, payload}
+      envelope and emits bridge/ready plus bridge/restarted lifecycle events.
+      The built-in extension publishes generation-tagged discovery metadata so
+      the server can rebroadcast restart -> ready transitions to clients.
+    priority: P0
+    status: implemented
+    code:
+      - server/internal/api/bridge.go
+      - server/internal/api/router.go
+      - server/internal/vscode/bridge.go
+      - openvscode-server/extensions/mobile-runtime-bridge/package.json
+      - openvscode-server/extensions/mobile-runtime-bridge/tsconfig.json
+      - openvscode-server/extensions/mobile-runtime-bridge/extension.webpack.config.js
+      - openvscode-server/extensions/mobile-runtime-bridge/src/extension.ts
+      - openvscode-server/build/gulpfile.extensions.ts
+      - openvscode-server/build/npm/dirs.ts
+    tests:
+      - server/internal/api/bridge_test.go
+      - server/internal/vscode/bridge_test.go
+      - server/internal/vscode/bridge_integration_test.go
+    depends_on: [REQ-023, REQ-024]
+
   # ============================================================
   # Iteration 5: Bug fixes from code review audit
   # ============================================================

--- a/scripts/verify_bridge_foundation.sh
+++ b/scripts/verify_bridge_foundation.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/verify_bridge_foundation.sh [--extension-only]
+
+Runs the reproducible validation flow for the mobile runtime bridge foundation.
+  --extension-only  Only compile the built-in OpenVSCode bridge extension.
+USAGE
+}
+
+log() {
+  printf '==> %s\n' "$*"
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    die "required command '$1' is not available in PATH"
+  fi
+}
+
+find_go() {
+  local candidate
+  for candidate in \
+    "${GO_BINARY:-}" \
+    "$(command -v go 2>/dev/null || true)" \
+    "${HOME}/go-sdk/go/bin/go" \
+    "${HOME}/.local/go/bin/go" \
+    "/usr/local/go/bin/go"
+  do
+    if [[ -n "${candidate}" && -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+extension_only=0
+case "${1:-}" in
+  "")
+    ;;
+  --extension-only)
+    extension_only=1
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    die "unknown argument: $1"
+    ;;
+esac
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+openvscode_dir="${repo_root}/openvscode-server"
+server_dir="${repo_root}/server"
+openvscode_gulp="${openvscode_dir}/node_modules/gulp/bin/gulp.js"
+openvscode_server_main="${openvscode_dir}/out/server-main.js"
+go_bin=""
+
+[[ -d "${openvscode_dir}" ]] || die "openvscode-server/ is missing; sync the submodule checkout first"
+[[ -f "${openvscode_dir}/package.json" ]] || die "openvscode-server/package.json is missing"
+[[ -d "${server_dir}" ]] || die "server/ is missing"
+
+need_cmd node
+need_cmd npm
+
+if [[ "${extension_only}" != "1" ]]; then
+  go_bin="$(find_go)" || die "required command 'go' is not available; set GO_BINARY or install Go (for example ${HOME}/go-sdk/go/bin/go)"
+fi
+
+if [[ ! -x "${openvscode_gulp}" ]]; then
+  die "openvscode-server dependencies are missing; run 'cd ${openvscode_dir} && npm install' (or 'npm ci') first"
+fi
+
+log "Compiling mobile-runtime-bridge from openvscode-server/"
+(
+  cd "${openvscode_dir}"
+  npm run gulp -- compile-extension:mobile-runtime-bridge
+)
+
+if [[ "${extension_only}" == "1" ]]; then
+  log "Bridge extension compile completed"
+  exit 0
+fi
+
+log "Running targeted Go bridge tests"
+(
+  cd "${server_dir}"
+  "${go_bin}" test ./internal/vscode ./internal/api
+)
+
+log "Running Go vet"
+(
+  cd "${server_dir}"
+  "${go_bin}" vet ./...
+)
+
+if make -s -C "${repo_root}" flutter-prereq >/dev/null 2>&1; then
+  log "Running repo-wide test and lint targets with detected Flutter SDK"
+  make -C "${repo_root}" test
+  make -C "${repo_root}" lint
+else
+  log "Skipping repo-wide Flutter validation (run 'make FLUTTER=/absolute/path/to/flutter test lint' once a Flutter SDK is available)"
+fi
+
+if [[ "${VSCODE_INTEGRATION_TEST:-}" == "1" ]]; then
+  if [[ ! -f "${openvscode_server_main}" ]]; then
+    die "VSCODE_INTEGRATION_TEST=1 requires '${openvscode_server_main}'; build openvscode-server first"
+  fi
+
+  log "Running gated bridge restart integration test"
+  (
+    cd "${server_dir}"
+    GO_BINARY="${go_bin}" OPENVSCODE_SERVER_DIR="${openvscode_dir}" "${go_bin}" test ./internal/vscode -run TestIntegration_BridgeLifecycle_EndToEnd -count=1
+  )
+else
+  log "Skipping gated bridge restart integration test (set VSCODE_INTEGRATION_TEST=1 after building openvscode-server)"
+fi
+
+log "Bridge foundation validation completed"

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -59,6 +59,9 @@ func main() {
 	// Initialize filesystem via VS Code remote proxy.
 	var fs api.FileSystem
 	var vsClient *vscode.Client
+	var bridgeManager *vscode.BridgeManager
+	bridgeCtx, cancelBridge := context.WithCancel(context.Background())
+	defer cancelBridge()
 	if vsCodeURL != "" {
 		vsClient = vscode.NewClient()
 		if err := vsClient.Connect(context.Background(), vsCodeURL, vsCodeTok); err != nil {
@@ -66,6 +69,9 @@ func main() {
 		}
 		fsp := vscode.NewFileSystemProxy(vsClient.IPC(), "vscode-remote")
 		fs = api.NewVSCodeFSAdapter(fsp)
+		bridgeManager = vscode.NewBridgeManager(vscode.BridgeManagerOptions{Client: vsClient})
+		bridgeManager.Start(bridgeCtx)
+		log.Printf("mobile runtime bridge discovery watching %s", bridgeManager.MetadataPath())
 	}
 
 	// Initialize git client.
@@ -96,6 +102,7 @@ func main() {
 
 	// Initialize API server.
 	srv := api.NewServer(fs, sessionIndex, pm, token, gitClient, termMgr, diagRunner)
+	srv.SetBridgeManager(bridgeManager)
 
 	httpServer := &http.Server{
 		Addr:    fmt.Sprintf(":%d", port),
@@ -134,6 +141,10 @@ func main() {
 	pm.Shutdown()
 
 	// Close VS Code connection.
+	cancelBridge()
+	if bridgeManager != nil {
+		bridgeManager.Close()
+	}
 	if vsClient != nil {
 		if err := vsClient.Close(); err != nil {
 			log.Printf("vscode client close error: %v", err)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -69,7 +69,11 @@ func main() {
 		}
 		fsp := vscode.NewFileSystemProxy(vsClient.IPC(), "vscode-remote")
 		fs = api.NewVSCodeFSAdapter(fsp)
-		bridgeManager = vscode.NewBridgeManager(vscode.BridgeManagerOptions{Client: vsClient})
+		bridgeManager = vscode.NewBridgeManager(vscode.BridgeManagerOptions{
+			Client:          vsClient,
+			ServerURL:       vsCodeURL,
+			ConnectionToken: vsCodeTok,
+		})
 		bridgeManager.Start(bridgeCtx)
 		log.Printf("mobile runtime bridge discovery watching %s", bridgeManager.MetadataPath())
 	}

--- a/server/internal/api/bridge.go
+++ b/server/internal/api/bridge.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/Lincyaw/vscode-mobile/server/internal/vscode"
+)
+
+type bridgeErrorDetail struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (s *Server) handleBridgeCapabilities(w http.ResponseWriter, r *http.Request) {
+	if s.bridgeManager == nil {
+		writeBridgeError(w, http.StatusServiceUnavailable, "bridge_not_ready", "mobile runtime bridge is not ready")
+		return
+	}
+
+	capabilities, err := s.bridgeManager.Capabilities()
+	if err != nil {
+		var bridgeErr *vscode.BridgeError
+		if errors.As(err, &bridgeErr) {
+			status := http.StatusServiceUnavailable
+			if bridgeErr.Code == "capability_unavailable" {
+				status = http.StatusNotFound
+			}
+			writeBridgeError(w, status, bridgeErr.Code, bridgeErr.Message)
+			return
+		}
+		writeBridgeError(w, http.StatusInternalServerError, "capability_unavailable", "failed to load mobile runtime bridge capabilities")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, capabilities)
+}
+
+func (s *Server) handleWSBridgeEvents(w http.ResponseWriter, r *http.Request) {
+	if s.bridgeManager == nil {
+		http.Error(w, "mobile runtime bridge is not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("bridge websocket upgrade error: %v", err)
+		return
+	}
+	defer conn.Close()
+	log.Printf("[WS/Bridge] connection established")
+
+	events, unsubscribe := s.bridgeManager.Subscribe(true)
+	defer unsubscribe()
+
+	var writeMu sync.Mutex
+
+	go func() {
+		for event := range events {
+			writeMu.Lock()
+			err := conn.WriteJSON(event)
+			writeMu.Unlock()
+			if err != nil {
+				log.Printf("[WS/Bridge] write error: %v", err)
+				return
+			}
+		}
+	}()
+
+	for {
+		if _, _, err := conn.ReadMessage(); err != nil {
+			log.Printf("[WS/Bridge] connection closed")
+			return
+		}
+	}
+}
+
+func writeBridgeError(w http.ResponseWriter, status int, code, message string) {
+	writeJSON(w, status, bridgeErrorDetail{Code: code, Message: message})
+}

--- a/server/internal/api/bridge_test.go
+++ b/server/internal/api/bridge_test.go
@@ -124,6 +124,39 @@ func readBridgeEvent(t *testing.T, conn *websocket.Conn) vscode.BridgeEvent {
 	return event
 }
 
+func requirePayloadValue(t *testing.T, payload map[string]any, key string) any {
+	t.Helper()
+	value, ok := payload[key]
+	if !ok {
+		t.Fatalf("payload missing %q: %#v", key, payload)
+	}
+	return value
+}
+
+func requireBoolCapability(t *testing.T, payload map[string]any, capability string, want bool) {
+	t.Helper()
+	capabilities, ok := requirePayloadValue(t, payload, "capabilities").(map[string]any)
+	if !ok {
+		t.Fatalf("payload capabilities = %#v, want map[string]any", payload["capabilities"])
+	}
+	entry, ok := capabilities[capability].(map[string]any)
+	if !ok {
+		t.Fatalf("capability %q = %#v, want map[string]any", capability, capabilities[capability])
+	}
+	if entry["enabled"] != want {
+		t.Fatalf("capability %q enabled = %#v, want %v", capability, entry["enabled"], want)
+	}
+}
+
+func requireEventPayload(t *testing.T, event vscode.BridgeEvent) map[string]any {
+	t.Helper()
+	payload, ok := event.Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("event payload = %#v, want map[string]any", event.Payload)
+	}
+	return payload
+}
+
 func TestBridgeCapabilities_NotReadyReturnsStructuredError(t *testing.T) {
 	ts, _, _ := newTestServer(t, "")
 
@@ -260,6 +293,78 @@ func TestBridgeEventsWebSocket_ReplaysReadyThenBroadcastsRestartSequence(t *test
 	if ready.Type != "bridge/ready" {
 		t.Fatalf("third event type = %q, want bridge/ready", ready.Type)
 	}
+}
+
+func TestBridgeEventsWebSocket_StableEnvelopeCarriesLifecyclePayloads(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{MetadataPath: metadataPath, PollInterval: 20 * time.Millisecond})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager.Start(ctx)
+	defer manager.Close()
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:      "gen-1",
+		State:           "ready",
+		ProtocolVersion: "2026-04-20",
+		BridgeVersion:   "0.1.0",
+		Capabilities: map[string]any{
+			"workspace": map[string]any{"enabled": false},
+		},
+	})
+
+	ts := newBridgeEnabledServer(t, manager)
+	conn := dialBridgeEvents(t, ts.URL)
+
+	ready := readBridgeEvent(t, conn)
+	if ready.Type != "bridge/ready" {
+		t.Fatalf("first event type = %q, want bridge/ready", ready.Type)
+	}
+	readyPayload := requireEventPayload(t, ready)
+	if got := requirePayloadValue(t, readyPayload, "generation"); got != "gen-1" {
+		t.Fatalf("ready generation = %#v, want %q", got, "gen-1")
+	}
+	if capabilities, ok := readyPayload["capabilities"]; ok {
+		if got := requirePayloadValue(t, readyPayload, "bridgeVersion"); got != "0.1.0" {
+			t.Fatalf("initial ready bridgeVersion = %#v, want %q", got, "0.1.0")
+		}
+		requireBoolCapability(t, map[string]any{"capabilities": capabilities}, "workspace", false)
+	}
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:      "gen-2",
+		State:           "ready",
+		ProtocolVersion: "2026-04-20",
+		BridgeVersion:   "0.2.0",
+		Capabilities: map[string]any{
+			"workspace": map[string]any{"enabled": true},
+		},
+	})
+
+	restarted := readBridgeEvent(t, conn)
+	if restarted.Type != "bridge/restarted" {
+		t.Fatalf("second event type = %q, want bridge/restarted", restarted.Type)
+	}
+	restartedPayload := requireEventPayload(t, restarted)
+	if got := requirePayloadValue(t, restartedPayload, "generation"); got != "gen-2" {
+		t.Fatalf("restarted generation = %#v, want %q", got, "gen-2")
+	}
+	if got := requirePayloadValue(t, restartedPayload, "previousGeneration"); got != "gen-1" {
+		t.Fatalf("restarted previousGeneration = %#v, want %q", got, "gen-1")
+	}
+
+	ready = readBridgeEvent(t, conn)
+	if ready.Type != "bridge/ready" {
+		t.Fatalf("third event type = %q, want bridge/ready", ready.Type)
+	}
+	readyPayload = requireEventPayload(t, ready)
+	if got := requirePayloadValue(t, readyPayload, "generation"); got != "gen-2" {
+		t.Fatalf("recovered ready generation = %#v, want %q", got, "gen-2")
+	}
+	if got := requirePayloadValue(t, readyPayload, "bridgeVersion"); got != "0.2.0" {
+		t.Fatalf("recovered ready bridgeVersion = %#v, want %q", got, "0.2.0")
+	}
+	requireBoolCapability(t, readyPayload, "workspace", true)
 }
 
 func TestBridgeEventsWebSocket_DropsDisconnectedClientsWithoutBlockingLiveOnes(t *testing.T) {

--- a/server/internal/api/bridge_test.go
+++ b/server/internal/api/bridge_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -73,6 +74,33 @@ func waitForReadyCapabilities(t *testing.T, baseURL string) vscode.BridgeCapabil
 	}
 	t.Fatal("timed out waiting for bridge capabilities")
 	return vscode.BridgeCapabilitiesDocument{}
+}
+
+func waitForNotReadyBridgeError(t *testing.T, baseURL string) bridgeErrorDetail {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/bridge/capabilities")
+		if err != nil {
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		if resp.StatusCode == http.StatusServiceUnavailable {
+			defer resp.Body.Close()
+			var body bridgeErrorDetail
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode bridge error: %v", err)
+			}
+			if body.Code == "bridge_not_ready" {
+				return body
+			}
+		} else {
+			_ = resp.Body.Close()
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for bridge_not_ready error")
+	return bridgeErrorDetail{}
 }
 
 func dialBridgeEvents(t *testing.T, baseURL string) *websocket.Conn {
@@ -149,6 +177,53 @@ func TestBridgeCapabilities_ReadyReturnsRFCDocument(t *testing.T) {
 	}
 }
 
+func TestBridgeCapabilities_NotReadyWindowRecoversToUpdatedCapabilities(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{MetadataPath: metadataPath, PollInterval: 20 * time.Millisecond})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager.Start(ctx)
+	defer manager.Close()
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation: "gen-1",
+		State:      "ready",
+		Capabilities: map[string]any{
+			"workspace": map[string]any{"enabled": false},
+		},
+	})
+
+	ts := newBridgeEnabledServer(t, manager)
+	initial := waitForReadyCapabilities(t, ts.URL)
+	workspace, ok := initial.Capabilities["workspace"].(map[string]any)
+	if !ok || workspace["enabled"] != false {
+		t.Fatalf("initial workspace capability = %#v, want enabled=false", initial.Capabilities["workspace"])
+	}
+
+	if err := os.Remove(metadataPath); err != nil {
+		t.Fatalf("remove metadata: %v", err)
+	}
+
+	notReady := waitForNotReadyBridgeError(t, ts.URL)
+	if notReady.Message == "" {
+		t.Fatal("expected bridge_not_ready message during reconnect window")
+	}
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation: "gen-2",
+		State:      "ready",
+		Capabilities: map[string]any{
+			"workspace": map[string]any{"enabled": true},
+		},
+	})
+
+	recovered := waitForReadyCapabilities(t, ts.URL)
+	workspace, ok = recovered.Capabilities["workspace"].(map[string]any)
+	if !ok || workspace["enabled"] != true {
+		t.Fatalf("recovered workspace capability = %#v, want enabled=true", recovered.Capabilities["workspace"])
+	}
+}
+
 func TestBridgeEventsWebSocket_ReplaysReadyThenBroadcastsRestartSequence(t *testing.T) {
 	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
 	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{MetadataPath: metadataPath, PollInterval: 20 * time.Millisecond})
@@ -221,5 +296,116 @@ func TestBridgeEventsWebSocket_DropsDisconnectedClientsWithoutBlockingLiveOnes(t
 	ready := readBridgeEvent(t, liveConn)
 	if ready.Type != "bridge/ready" {
 		t.Fatalf("live event type = %q, want bridge/ready", ready.Type)
+	}
+}
+
+func TestBridgeEventsWebSocket_BroadcastsRestartedThenReadyAfterNotReadyWindow(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{MetadataPath: metadataPath, PollInterval: 20 * time.Millisecond})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager.Start(ctx)
+	defer manager.Close()
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:   "gen-1",
+		State:        "ready",
+		Capabilities: map[string]any{},
+	})
+
+	ts := newBridgeEnabledServer(t, manager)
+	conn := dialBridgeEvents(t, ts.URL)
+
+	ready := readBridgeEvent(t, conn)
+	if ready.Type != "bridge/ready" {
+		t.Fatalf("first event type = %q, want bridge/ready", ready.Type)
+	}
+
+	if err := os.Remove(metadataPath); err != nil {
+		t.Fatalf("remove metadata: %v", err)
+	}
+	_ = waitForNotReadyBridgeError(t, ts.URL)
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:   "gen-2",
+		State:        "ready",
+		Capabilities: map[string]any{},
+	})
+
+	restarted := readBridgeEvent(t, conn)
+	if restarted.Type != "bridge/restarted" {
+		t.Fatalf("second event type = %q, want bridge/restarted", restarted.Type)
+	}
+	ready = readBridgeEvent(t, conn)
+	if ready.Type != "bridge/ready" {
+		t.Fatalf("third event type = %q, want bridge/ready", ready.Type)
+	}
+}
+
+func TestBridgeCapabilities_ReconnectWindowReturnsNotReadyUntilRecoveryCompletes(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:   "gen-1",
+		State:        "ready",
+		Capabilities: map[string]any{},
+	})
+
+	client := vscode.NewClient()
+	reconnectStarted := make(chan struct{})
+	reconnectRelease := make(chan struct{})
+	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{
+		MetadataPath: metadataPath,
+		Client:       client,
+		ReconnectFn: func(ctx context.Context) error {
+			close(reconnectStarted)
+			select {
+			case <-reconnectRelease:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	})
+	manager.Start(context.Background())
+	defer manager.Close()
+
+	ts := newBridgeEnabledServer(t, manager)
+	_ = waitForReadyCapabilities(t, ts.URL)
+
+	manager.NotifyTransportLost(errors.New("transport closed"))
+
+	select {
+	case <-reconnectStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for reconnect to start")
+	}
+
+	resp, err := http.Get(ts.URL + "/bridge/capabilities")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+	var errBody bridgeErrorDetail
+	if err := json.NewDecoder(resp.Body).Decode(&errBody); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errBody.Code != "bridge_not_ready" {
+		t.Fatalf("error code = %q, want bridge_not_ready", errBody.Code)
+	}
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:   "gen-2",
+		State:        "ready",
+		UpdatedAt:    time.Now().UTC(),
+		Capabilities: map[string]any{},
+	})
+	close(reconnectRelease)
+
+	doc := waitForReadyCapabilities(t, ts.URL)
+	if doc.ProtocolVersion == "" {
+		t.Fatal("expected ready capabilities after reconnect")
 	}
 }

--- a/server/internal/api/bridge_test.go
+++ b/server/internal/api/bridge_test.go
@@ -1,0 +1,225 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/Lincyaw/vscode-mobile/server/internal/claude"
+	"github.com/Lincyaw/vscode-mobile/server/internal/diagnostics"
+	"github.com/Lincyaw/vscode-mobile/server/internal/git"
+	"github.com/Lincyaw/vscode-mobile/server/internal/terminal"
+	"github.com/Lincyaw/vscode-mobile/server/internal/vscode"
+)
+
+func writeBridgeMetadata(t *testing.T, path string, metadata vscode.BridgeMetadata) {
+	t.Helper()
+	if metadata.ProtocolVersion == "" {
+		metadata.ProtocolVersion = "2026-04-20"
+	}
+	if metadata.Capabilities == nil {
+		metadata.Capabilities = map[string]any{}
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir metadata dir: %v", err)
+	}
+	data, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+}
+
+func newBridgeEnabledServer(t *testing.T, manager *vscode.BridgeManager) *httptest.Server {
+	t.Helper()
+	sessionIndex := claude.NewSessionIndex(t.TempDir())
+	pm := claude.NewProcessManager("/nonexistent/claude", ".")
+	srv := NewServer(newMockFS(), sessionIndex, pm, "", git.NewGit(t.TempDir()), terminal.NewManager(), diagnostics.NewRunner(10*time.Second))
+	srv.SetBridgeManager(manager)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func waitForReadyCapabilities(t *testing.T, baseURL string) vscode.BridgeCapabilitiesDocument {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/bridge/capabilities")
+		if err != nil {
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		if resp.StatusCode == http.StatusOK {
+			defer resp.Body.Close()
+			var doc vscode.BridgeCapabilitiesDocument
+			if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+				t.Fatalf("decode capabilities: %v", err)
+			}
+			return doc
+		}
+		_ = resp.Body.Close()
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for bridge capabilities")
+	return vscode.BridgeCapabilitiesDocument{}
+}
+
+func dialBridgeEvents(t *testing.T, baseURL string) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(baseURL, "http") + "/bridge/ws/events"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial bridge events websocket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func readBridgeEvent(t *testing.T, conn *websocket.Conn) vscode.BridgeEvent {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var event vscode.BridgeEvent
+	if err := conn.ReadJSON(&event); err != nil {
+		t.Fatalf("read bridge event: %v", err)
+	}
+	return event
+}
+
+func TestBridgeCapabilities_NotReadyReturnsStructuredError(t *testing.T) {
+	ts, _, _ := newTestServer(t, "")
+
+	resp, err := http.Get(ts.URL + "/bridge/capabilities")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+
+	var body bridgeErrorDetail
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if body.Code != "bridge_not_ready" {
+		t.Fatalf("error code = %q, want %q", body.Code, "bridge_not_ready")
+	}
+	if body.Message == "" {
+		t.Fatal("expected bridge_not_ready message to be non-empty")
+	}
+}
+
+func TestBridgeCapabilities_ReadyReturnsRFCDocument(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{MetadataPath: metadataPath, PollInterval: 20 * time.Millisecond})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager.Start(ctx)
+	defer manager.Close()
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:    "gen-1",
+		State:         "ready",
+		BridgeVersion: "0.1.0",
+		Capabilities:  map[string]any{},
+	})
+
+	ts := newBridgeEnabledServer(t, manager)
+	doc := waitForReadyCapabilities(t, ts.URL)
+	if doc.ProtocolVersion == "" {
+		t.Fatal("expected protocolVersion in capabilities response")
+	}
+	if doc.BridgeVersion != "0.1.0" {
+		t.Fatalf("bridgeVersion = %q, want %q", doc.BridgeVersion, "0.1.0")
+	}
+	if len(doc.Capabilities) != 0 {
+		t.Fatalf("capabilities len = %d, want 0", len(doc.Capabilities))
+	}
+}
+
+func TestBridgeEventsWebSocket_ReplaysReadyThenBroadcastsRestartSequence(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{MetadataPath: metadataPath, PollInterval: 20 * time.Millisecond})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager.Start(ctx)
+	defer manager.Close()
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:   "gen-1",
+		State:        "ready",
+		Capabilities: map[string]any{},
+	})
+
+	ts := newBridgeEnabledServer(t, manager)
+	conn := dialBridgeEvents(t, ts.URL)
+
+	ready := readBridgeEvent(t, conn)
+	if ready.Type != "bridge/ready" {
+		t.Fatalf("first event type = %q, want bridge/ready", ready.Type)
+	}
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:   "gen-2",
+		State:        "ready",
+		Capabilities: map[string]any{},
+	})
+
+	restarted := readBridgeEvent(t, conn)
+	if restarted.Type != "bridge/restarted" {
+		t.Fatalf("second event type = %q, want bridge/restarted", restarted.Type)
+	}
+	ready = readBridgeEvent(t, conn)
+	if ready.Type != "bridge/ready" {
+		t.Fatalf("third event type = %q, want bridge/ready", ready.Type)
+	}
+}
+
+func TestBridgeEventsWebSocket_DropsDisconnectedClientsWithoutBlockingLiveOnes(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{MetadataPath: metadataPath, PollInterval: 20 * time.Millisecond})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager.Start(ctx)
+	defer manager.Close()
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:   "gen-1",
+		State:        "ready",
+		Capabilities: map[string]any{},
+	})
+
+	ts := newBridgeEnabledServer(t, manager)
+	deadConn := dialBridgeEvents(t, ts.URL)
+	liveConn := dialBridgeEvents(t, ts.URL)
+	_ = readBridgeEvent(t, deadConn)
+	_ = readBridgeEvent(t, liveConn)
+	_ = deadConn.Close()
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:   "gen-2",
+		State:        "ready",
+		Capabilities: map[string]any{},
+	})
+
+	restarted := readBridgeEvent(t, liveConn)
+	if restarted.Type != "bridge/restarted" {
+		t.Fatalf("live event type = %q, want bridge/restarted", restarted.Type)
+	}
+	ready := readBridgeEvent(t, liveConn)
+	if ready.Type != "bridge/ready" {
+		t.Fatalf("live event type = %q, want bridge/ready", ready.Type)
+	}
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Lincyaw/vscode-mobile/server/internal/diagnostics"
 	"github.com/Lincyaw/vscode-mobile/server/internal/git"
 	"github.com/Lincyaw/vscode-mobile/server/internal/terminal"
+	"github.com/Lincyaw/vscode-mobile/server/internal/vscode"
 )
 
 // FileSystem defines the interface for file operations.
@@ -35,6 +36,7 @@ type Server struct {
 	termManager      *terminal.Manager
 	diagnosticRunner *diagnostics.Runner
 	fileWatchHub     *FileWatchHub
+	bridgeManager    *vscode.BridgeManager
 }
 
 // NewServer creates a new API server.
@@ -49,6 +51,11 @@ func NewServer(fs FileSystem, sessionIndex *claude.SessionIndex, pm *claude.Proc
 		diagnosticRunner: diagRunner,
 		fileWatchHub:     NewFileWatchHub(),
 	}
+}
+
+// SetBridgeManager injects the bridge lifecycle manager after server construction.
+func (s *Server) SetBridgeManager(manager *vscode.BridgeManager) {
+	s.bridgeManager = manager
 }
 
 // Handler returns the top-level HTTP handler with all routes.
@@ -80,11 +87,13 @@ func (s *Server) Handler() http.Handler {
 
 	// Diagnostics endpoint.
 	mux.HandleFunc("GET /api/diagnostics", s.handleDiagnostics)
+	mux.HandleFunc("GET /bridge/capabilities", s.handleBridgeCapabilities)
 
 	// WebSocket endpoints.
 	mux.HandleFunc("/ws/chat", s.handleWSChat)
 	mux.HandleFunc("/ws/files", s.handleWSFiles)
 	mux.HandleFunc("/ws/terminal", s.handleWSTerminal)
+	mux.HandleFunc("/bridge/ws/events", s.handleWSBridgeEvents)
 
 	// Health-check endpoint (unauthenticated for connectivity tests).
 	mux.HandleFunc("GET /api/health", func(w http.ResponseWriter, r *http.Request) {
@@ -105,7 +114,7 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 		status := wrapped.statusCode
 		// If the connection was hijacked for WebSocket, the status stays at the
 		// default 200 because WriteHeader was never called through the wrapper.
-		if status == http.StatusOK && strings.HasPrefix(r.URL.Path, "/ws/") {
+		if status == http.StatusOK && (strings.HasPrefix(r.URL.Path, "/ws/") || strings.HasPrefix(r.URL.Path, "/bridge/ws/")) {
 			status = http.StatusSwitchingProtocols
 		}
 		log.Printf("[HTTP] %s %s -> %d in %s", r.Method, r.URL.Path, status, time.Since(start))

--- a/server/internal/vscode/bridge.go
+++ b/server/internal/vscode/bridge.go
@@ -71,22 +71,33 @@ func newBridgeError(code, message string, cause error) *BridgeError {
 
 // BridgeManagerOptions controls bridge lifecycle discovery.
 type BridgeManagerOptions struct {
-	MetadataPath string
-	PollInterval time.Duration
-	Client       *Client
+	MetadataPath        string
+	PollInterval        time.Duration
+	Client              *Client
+	ServerURL           string
+	ConnectionToken     string
+	ReconnectMaxRetries int
+	ReconnectTimeout    time.Duration
+	ReconnectFn         func(context.Context) error
 }
 
 // BridgeManager discovers the runtime bridge, tracks readiness, and broadcasts lifecycle events.
 type BridgeManager struct {
 	metadataPath string
 	pollInterval time.Duration
+	client       *Client
+	reconnectFn  func(context.Context) error
+	reconnectTTL time.Duration
 
-	mu           sync.RWMutex
-	ready        bool
-	generation   string
-	capabilities BridgeCapabilitiesDocument
-	lastErr      error
-	subscribers  map[chan BridgeEvent]struct{}
+	mu                    sync.RWMutex
+	ready                 bool
+	generation            string
+	awaitingNewGeneration string
+	disconnectedAt        time.Time
+	capabilities          BridgeCapabilitiesDocument
+	lastErr               error
+	subscribers           map[chan BridgeEvent]struct{}
+	reconnecting          bool
 
 	closeOnce sync.Once
 	stopCh    chan struct{}
@@ -106,12 +117,29 @@ func NewBridgeManager(opts BridgeManagerOptions) *BridgeManager {
 	m := &BridgeManager{
 		metadataPath: metadataPath,
 		pollInterval: pollInterval,
+		client:       opts.Client,
+		reconnectTTL: opts.ReconnectTimeout,
 		stopCh:       make(chan struct{}),
 		subscribers:  make(map[chan BridgeEvent]struct{}),
 	}
+	if m.reconnectTTL <= 0 {
+		m.reconnectTTL = 30 * time.Second
+	}
+	switch {
+	case opts.ReconnectFn != nil:
+		m.reconnectFn = opts.ReconnectFn
+	case opts.Client != nil && opts.ServerURL != "":
+		maxRetries := opts.ReconnectMaxRetries
+		if maxRetries <= 0 {
+			maxRetries = 5
+		}
+		m.reconnectFn = func(ctx context.Context) error {
+			return opts.Client.ReconnectWithRetry(ctx, opts.ServerURL, opts.ConnectionToken, maxRetries)
+		}
+	}
 	if opts.Client != nil {
 		opts.Client.SetDisconnectHandler(func(err error) {
-			m.markNotReady(err)
+			m.NotifyTransportLost(err)
 		})
 	}
 	return m
@@ -152,6 +180,12 @@ func (m *BridgeManager) Close() {
 	m.closeOnce.Do(func() {
 		close(m.stopCh)
 	})
+}
+
+// NotifyTransportLost marks the bridge transport unhealthy and starts recovery
+// when reconnect support is configured.
+func (m *BridgeManager) NotifyTransportLost(err error) {
+	m.handleDisconnect(err)
 }
 
 // MetadataPath returns the discovery file path.
@@ -217,6 +251,10 @@ func (m *BridgeManager) poll() {
 		m.markNotReady(fmt.Errorf("bridge state=%s", metadata.State))
 		return
 	}
+	if err := m.validateMetadata(metadata); err != nil {
+		m.markNotReady(err)
+		return
+	}
 	m.applyMetadata(metadata)
 }
 
@@ -254,6 +292,7 @@ func (m *BridgeManager) applyMetadata(metadata BridgeMetadata) {
 	generationChanged := previousGeneration != "" && previousGeneration != metadata.Generation
 	m.ready = true
 	m.generation = metadata.Generation
+	m.awaitingNewGeneration = ""
 	m.capabilities = caps
 	m.lastErr = nil
 	m.mu.Unlock()
@@ -286,6 +325,81 @@ func (m *BridgeManager) markNotReady(err error) {
 	m.capabilities = BridgeCapabilitiesDocument{}
 	m.lastErr = err
 	m.mu.Unlock()
+}
+
+func (m *BridgeManager) validateMetadata(metadata BridgeMetadata) error {
+	m.mu.RLock()
+	reconnecting := m.reconnecting
+	awaiting := m.awaitingNewGeneration
+	disconnectedAt := m.disconnectedAt
+	m.mu.RUnlock()
+
+	if reconnecting {
+		return fmt.Errorf("waiting for vscode transport reconnection")
+	}
+	if awaiting != "" && metadata.Generation == awaiting {
+		if !metadata.UpdatedAt.IsZero() && metadata.UpdatedAt.After(disconnectedAt) {
+			return nil
+		}
+		return fmt.Errorf("waiting for new bridge generation after reconnect")
+	}
+	return nil
+}
+
+func (m *BridgeManager) handleDisconnect(err error) {
+	select {
+	case <-m.stopCh:
+		return
+	default:
+	}
+
+	m.mu.Lock()
+	if m.reconnecting {
+		m.mu.Unlock()
+		return
+	}
+	m.reconnecting = true
+	if m.generation != "" {
+		m.awaitingNewGeneration = m.generation
+	}
+	m.disconnectedAt = time.Now().UTC()
+	m.mu.Unlock()
+
+	m.markNotReady(err)
+	if m.reconnectFn == nil {
+		m.mu.Lock()
+		m.reconnecting = false
+		m.mu.Unlock()
+		return
+	}
+
+	go m.reconnectTransport()
+}
+
+func (m *BridgeManager) reconnectTransport() {
+	ctx, cancel := context.WithTimeout(context.Background(), m.reconnectTTL)
+	defer cancel()
+	go func() {
+		select {
+		case <-m.stopCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	err := m.reconnectFn(ctx)
+	m.mu.Lock()
+	m.reconnecting = false
+	m.mu.Unlock()
+
+	if err != nil {
+		m.markNotReady(fmt.Errorf("reconnect vscode transport: %w", err))
+		return
+	}
+
+	// Re-evaluate bridge metadata immediately after transport recovery so the
+	// next lifecycle transition does not wait for the periodic poll tick.
+	m.poll()
 }
 
 func (m *BridgeManager) broadcast(event BridgeEvent) {

--- a/server/internal/vscode/bridge.go
+++ b/server/internal/vscode/bridge.go
@@ -1,0 +1,330 @@
+package vscode
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	defaultBridgeProtocolVersion = "2026-04-20"
+	defaultBridgePollInterval    = 1 * time.Second
+	bridgeStateReady             = "ready"
+)
+
+// BridgeCapabilitiesDocument is the RFC-shaped capabilities document exposed to clients.
+type BridgeCapabilitiesDocument struct {
+	ProtocolVersion string                 `json:"protocolVersion"`
+	BridgeVersion   string                 `json:"bridgeVersion,omitempty"`
+	Capabilities    map[string]interface{} `json:"capabilities"`
+}
+
+// BridgeMetadata is the on-disk discovery contract written by the VS Code bridge extension.
+type BridgeMetadata struct {
+	ProtocolVersion string                 `json:"protocolVersion"`
+	Generation      string                 `json:"generation"`
+	State           string                 `json:"state"`
+	Capabilities    map[string]interface{} `json:"capabilities"`
+	BridgeVersion   string                 `json:"bridgeVersion,omitempty"`
+	UpdatedAt       time.Time              `json:"updatedAt,omitempty"`
+}
+
+// BridgeEvent is the stable event envelope broadcast to API/WebSocket consumers.
+type BridgeEvent struct {
+	Type    string      `json:"type"`
+	Payload interface{} `json:"payload"`
+}
+
+// BridgeError provides structured bridge-specific API errors.
+type BridgeError struct {
+	Code    string
+	Message string
+	Cause   error
+}
+
+func (e *BridgeError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Cause == nil {
+		return e.Message
+	}
+	return fmt.Sprintf("%s: %v", e.Message, e.Cause)
+}
+
+func (e *BridgeError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+func newBridgeError(code, message string, cause error) *BridgeError {
+	return &BridgeError{Code: code, Message: message, Cause: cause}
+}
+
+// BridgeManagerOptions controls bridge lifecycle discovery.
+type BridgeManagerOptions struct {
+	MetadataPath string
+	PollInterval time.Duration
+	Client       *Client
+}
+
+// BridgeManager discovers the runtime bridge, tracks readiness, and broadcasts lifecycle events.
+type BridgeManager struct {
+	metadataPath string
+	pollInterval time.Duration
+
+	mu           sync.RWMutex
+	ready        bool
+	generation   string
+	capabilities BridgeCapabilitiesDocument
+	lastErr      error
+	subscribers  map[chan BridgeEvent]struct{}
+
+	closeOnce sync.Once
+	stopCh    chan struct{}
+}
+
+// NewBridgeManager creates a bridge lifecycle manager.
+func NewBridgeManager(opts BridgeManagerOptions) *BridgeManager {
+	metadataPath := opts.MetadataPath
+	if metadataPath == "" {
+		metadataPath = DefaultBridgeMetadataPath()
+	}
+	pollInterval := opts.PollInterval
+	if pollInterval <= 0 {
+		pollInterval = defaultBridgePollInterval
+	}
+
+	m := &BridgeManager{
+		metadataPath: metadataPath,
+		pollInterval: pollInterval,
+		stopCh:       make(chan struct{}),
+		subscribers:  make(map[chan BridgeEvent]struct{}),
+	}
+	if opts.Client != nil {
+		opts.Client.SetDisconnectHandler(func(err error) {
+			m.markNotReady(err)
+		})
+	}
+	return m
+}
+
+// DefaultBridgeMetadataPath returns the well-known discovery file path shared with the built-in extension.
+func DefaultBridgeMetadataPath() string {
+	if override := os.Getenv("OPENVSCODE_MOBILE_BRIDGE_METADATA_PATH"); override != "" {
+		return override
+	}
+	return filepath.Join(os.TempDir(), "openvscode-mobile", "bridge-metadata.json")
+}
+
+// Start begins the discovery loop and returns immediately.
+func (m *BridgeManager) Start(ctx context.Context) {
+	go m.run(ctx)
+}
+
+func (m *BridgeManager) run(ctx context.Context) {
+	m.poll()
+	ticker := time.NewTicker(m.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-m.stopCh:
+			return
+		case <-ticker.C:
+			m.poll()
+		}
+	}
+}
+
+// Close stops background discovery.
+func (m *BridgeManager) Close() {
+	m.closeOnce.Do(func() {
+		close(m.stopCh)
+	})
+}
+
+// MetadataPath returns the discovery file path.
+func (m *BridgeManager) MetadataPath() string {
+	return m.metadataPath
+}
+
+// Capabilities returns the current capabilities document when the bridge is ready.
+func (m *BridgeManager) Capabilities() (BridgeCapabilitiesDocument, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if !m.ready {
+		if m.lastErr != nil {
+			return BridgeCapabilitiesDocument{}, newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", m.lastErr)
+		}
+		return BridgeCapabilitiesDocument{}, newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", nil)
+	}
+	return cloneCapabilities(m.capabilities), nil
+}
+
+// Subscribe registers for lifecycle events. If replayCurrent is true, the current ready state is replayed immediately.
+func (m *BridgeManager) Subscribe(replayCurrent bool) (<-chan BridgeEvent, func()) {
+	ch := make(chan BridgeEvent, 8)
+
+	m.mu.Lock()
+	m.subscribers[ch] = struct{}{}
+	ready := m.ready
+	generation := m.generation
+	m.mu.Unlock()
+
+	if replayCurrent && ready {
+		ch <- BridgeEvent{
+			Type: "bridge/ready",
+			Payload: map[string]interface{}{
+				"generation": generation,
+			},
+		}
+	}
+
+	unsubscribe := func() {
+		m.mu.Lock()
+		if _, ok := m.subscribers[ch]; ok {
+			delete(m.subscribers, ch)
+			close(ch)
+		}
+		m.mu.Unlock()
+	}
+	return ch, unsubscribe
+}
+
+func (m *BridgeManager) poll() {
+	metadata, err := readBridgeMetadata(m.metadataPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			m.markNotReady(err)
+			return
+		}
+		log.Printf("[Bridge] discovery poll failed: %v", err)
+		m.markNotReady(err)
+		return
+	}
+	if metadata.State != bridgeStateReady {
+		m.markNotReady(fmt.Errorf("bridge state=%s", metadata.State))
+		return
+	}
+	m.applyMetadata(metadata)
+}
+
+func readBridgeMetadata(path string) (BridgeMetadata, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return BridgeMetadata{}, err
+	}
+	var metadata BridgeMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return BridgeMetadata{}, fmt.Errorf("decode bridge metadata: %w", err)
+	}
+	if metadata.ProtocolVersion == "" {
+		metadata.ProtocolVersion = defaultBridgeProtocolVersion
+	}
+	if metadata.Generation == "" {
+		return BridgeMetadata{}, fmt.Errorf("bridge generation missing")
+	}
+	if metadata.Capabilities == nil {
+		metadata.Capabilities = map[string]interface{}{}
+	}
+	return metadata, nil
+}
+
+func (m *BridgeManager) applyMetadata(metadata BridgeMetadata) {
+	caps := BridgeCapabilitiesDocument{
+		ProtocolVersion: metadata.ProtocolVersion,
+		BridgeVersion:   metadata.BridgeVersion,
+		Capabilities:    cloneMap(metadata.Capabilities),
+	}
+
+	m.mu.Lock()
+	wasReady := m.ready
+	previousGeneration := m.generation
+	generationChanged := previousGeneration != "" && previousGeneration != metadata.Generation
+	m.ready = true
+	m.generation = metadata.Generation
+	m.capabilities = caps
+	m.lastErr = nil
+	m.mu.Unlock()
+
+	if generationChanged {
+		m.broadcast(BridgeEvent{
+			Type: "bridge/restarted",
+			Payload: map[string]interface{}{
+				"generation":         metadata.Generation,
+				"previousGeneration": previousGeneration,
+			},
+		})
+	}
+	if !wasReady || generationChanged {
+		m.broadcast(BridgeEvent{
+			Type: "bridge/ready",
+			Payload: map[string]interface{}{
+				"generation":      metadata.Generation,
+				"protocolVersion": metadata.ProtocolVersion,
+				"bridgeVersion":   metadata.BridgeVersion,
+				"capabilities":    cloneMap(metadata.Capabilities),
+			},
+		})
+	}
+}
+
+func (m *BridgeManager) markNotReady(err error) {
+	m.mu.Lock()
+	m.ready = false
+	m.capabilities = BridgeCapabilitiesDocument{}
+	m.lastErr = err
+	m.mu.Unlock()
+}
+
+func (m *BridgeManager) broadcast(event BridgeEvent) {
+	m.mu.RLock()
+	deferred := make([]chan BridgeEvent, 0)
+	for ch := range m.subscribers {
+		select {
+		case ch <- event:
+		default:
+			deferred = append(deferred, ch)
+		}
+	}
+	m.mu.RUnlock()
+
+	for _, ch := range deferred {
+		m.mu.Lock()
+		if _, ok := m.subscribers[ch]; ok {
+			delete(m.subscribers, ch)
+			close(ch)
+		}
+		m.mu.Unlock()
+	}
+}
+
+func cloneCapabilities(doc BridgeCapabilitiesDocument) BridgeCapabilitiesDocument {
+	return BridgeCapabilitiesDocument{
+		ProtocolVersion: doc.ProtocolVersion,
+		BridgeVersion:   doc.BridgeVersion,
+		Capabilities:    cloneMap(doc.Capabilities),
+	}
+}
+
+func cloneMap(src map[string]interface{}) map[string]interface{} {
+	if src == nil {
+		return map[string]interface{}{}
+	}
+	dst := make(map[string]interface{}, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}

--- a/server/internal/vscode/bridge_integration_test.go
+++ b/server/internal/vscode/bridge_integration_test.go
@@ -1,0 +1,227 @@
+package vscode
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type bridgeLifecycleEvent struct {
+	Type    string                 `json:"type"`
+	Payload map[string]interface{} `json:"payload"`
+}
+
+func findGoBinary(t *testing.T) string {
+	t.Helper()
+	candidates := []string{
+		os.Getenv("GO_BINARY"),
+		filepath.Join(os.Getenv("HOME"), "go-sdk", "go", "bin", "go"),
+		filepath.Join(os.Getenv("HOME"), ".local", "go", "bin", "go"),
+	}
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	if path, err := exec.LookPath("go"); err == nil {
+		return path
+	}
+	t.Skip("go binary not found; set GO_BINARY or add go to PATH")
+	return ""
+}
+
+func findServerModuleDir(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("server module root not found")
+	return ""
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for free port: %v", err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func startBridgeAPIServer(t *testing.T, vscodeURL string) (*exec.Cmd, string) {
+	t.Helper()
+	goBin := findGoBinary(t)
+	serverDir := findServerModuleDir(t)
+	port := freeTCPPort(t)
+
+	cmd := exec.Command(goBin,
+		"run", "./cmd/server",
+		"--port", strconv.Itoa(port),
+		"--vscode-url", vscodeURL,
+		"--work-dir", t.TempDir(),
+	)
+	cmd.Dir = serverDir
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start bridge API server: %v", err)
+	}
+	t.Cleanup(func() { stopProcess(cmd) })
+
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	waitForHTTPStatus(t, baseURL+"/api/health", http.StatusOK, 20*time.Second)
+	return cmd, baseURL
+}
+
+func stopProcess(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
+}
+
+func waitForHTTPStatus(t *testing.T, url string, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == want {
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s to return %d", url, want)
+}
+
+func waitForBridgeCapabilities(t *testing.T, baseURL string, timeout time.Duration) (bool, BridgeCapabilitiesDocument) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	sawNotReady := false
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/bridge/capabilities")
+		if err == nil {
+			if resp.StatusCode == http.StatusOK {
+				defer resp.Body.Close()
+				var body BridgeCapabilitiesDocument
+				if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+					t.Fatalf("decode capabilities: %v", err)
+				}
+				return sawNotReady, body
+			}
+			var errBody struct {
+				Code string `json:"code"`
+			}
+			_ = json.NewDecoder(resp.Body).Decode(&errBody)
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusServiceUnavailable && errBody.Code == "bridge_not_ready" {
+				sawNotReady = true
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for bridge capabilities at %s", baseURL)
+	return false, BridgeCapabilitiesDocument{}
+}
+
+func dialBridgeEvents(t *testing.T, baseURL string) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(baseURL, "http") + "/bridge/ws/events"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial bridge events websocket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func waitForBridgeEventSequence(t *testing.T, conn *websocket.Conn, timeout time.Duration, sequence ...string) []bridgeLifecycleEvent {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	matched := make([]bridgeLifecycleEvent, 0, len(sequence))
+	index := 0
+	for index < len(sequence) && time.Now().Before(deadline) {
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		var event bridgeLifecycleEvent
+		if err := conn.ReadJSON(&event); err != nil {
+			continue
+		}
+		if event.Type == sequence[index] {
+			matched = append(matched, event)
+			index++
+		}
+	}
+	if index != len(sequence) {
+		t.Fatalf("timed out waiting for bridge event sequence %v, matched %d events", sequence, index)
+	}
+	return matched
+}
+
+func TestIntegration_BridgeLifecycle_EndToEnd(t *testing.T) {
+	skipIfNoServer(t)
+
+	metadataPath := filepath.Join(t.TempDir(), "bridge-metadata.json")
+	t.Setenv("OPENVSCODE_MOBILE_BRIDGE_METADATA_PATH", metadataPath)
+
+	openVSCodeCmd, vscodePort := startTestServer(t)
+	defer stopProcess(openVSCodeCmd)
+
+	_, baseURL := startBridgeAPIServer(t, fmt.Sprintf("http://127.0.0.1:%d", vscodePort))
+	conn := dialBridgeEvents(t, baseURL)
+
+	sawNotReady, capabilities := waitForBridgeCapabilities(t, baseURL, 20*time.Second)
+	if !sawNotReady {
+		t.Fatal("expected to observe bridge_not_ready before the bridge became ready")
+	}
+	if capabilities.ProtocolVersion == "" {
+		t.Fatal("expected protocolVersion in bridge capabilities response")
+	}
+
+	readyEvents := waitForBridgeEventSequence(t, conn, 20*time.Second, "bridge/ready")
+	if readyEvents[0].Payload == nil {
+		t.Fatalf("expected ready event payload, got %+v", readyEvents[0])
+	}
+
+	stopProcess(openVSCodeCmd)
+	openVSCodeCmd, restartedPort := startTestServer(t)
+	defer stopProcess(openVSCodeCmd)
+	if restartedPort != vscodePort {
+		t.Fatalf("restart port = %d, want %d", restartedPort, vscodePort)
+	}
+
+	events := waitForBridgeEventSequence(t, conn, 30*time.Second, "bridge/restarted", "bridge/ready")
+	if events[0].Payload == nil || events[1].Payload == nil {
+		t.Fatalf("expected restarted/ready events to include payloads: %+v", events)
+	}
+}

--- a/server/internal/vscode/bridge_integration_test.go
+++ b/server/internal/vscode/bridge_integration_test.go
@@ -3,6 +3,7 @@ package vscode
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -155,6 +156,43 @@ func waitForBridgeCapabilities(t *testing.T, baseURL string, timeout time.Durati
 	return false, BridgeCapabilitiesDocument{}
 }
 
+func waitForBridgeNotReady(t *testing.T, baseURL string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/bridge/capabilities")
+		if err == nil {
+			var errBody struct {
+				Code string `json:"code"`
+			}
+			_ = json.NewDecoder(resp.Body).Decode(&errBody)
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusServiceUnavailable && errBody.Code == "bridge_not_ready" {
+				return
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s/bridge/capabilities to return bridge_not_ready", baseURL)
+}
+
+func waitForFileRead(t *testing.T, baseURL, path, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/api/files" + path)
+		if err == nil {
+			body, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr == nil && resp.StatusCode == http.StatusOK && string(body) == want {
+				return
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for file read via bridge-backed API: %s", path)
+}
+
 func dialBridgeEvents(t *testing.T, baseURL string) *websocket.Conn {
 	t.Helper()
 	wsURL := "ws" + strings.TrimPrefix(baseURL, "http") + "/bridge/ws/events"
@@ -199,6 +237,11 @@ func TestIntegration_BridgeLifecycle_EndToEnd(t *testing.T) {
 
 	_, baseURL := startBridgeAPIServer(t, fmt.Sprintf("http://127.0.0.1:%d", vscodePort))
 	conn := dialBridgeEvents(t, baseURL)
+	testFile := filepath.Join(t.TempDir(), "bridge-reconnect.txt")
+	testContent := "bridge reconnect transport ok\n"
+	if err := os.WriteFile(testFile, []byte(testContent), 0o644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
 
 	sawNotReady, capabilities := waitForBridgeCapabilities(t, baseURL, 20*time.Second)
 	if !sawNotReady {
@@ -212,8 +255,10 @@ func TestIntegration_BridgeLifecycle_EndToEnd(t *testing.T) {
 	if readyEvents[0].Payload == nil {
 		t.Fatalf("expected ready event payload, got %+v", readyEvents[0])
 	}
+	waitForFileRead(t, baseURL, testFile, testContent, 20*time.Second)
 
 	stopProcess(openVSCodeCmd)
+	waitForBridgeNotReady(t, baseURL, 20*time.Second)
 	openVSCodeCmd, restartedPort := startTestServer(t)
 	defer stopProcess(openVSCodeCmd)
 	if restartedPort != vscodePort {
@@ -224,4 +269,13 @@ func TestIntegration_BridgeLifecycle_EndToEnd(t *testing.T) {
 	if events[0].Payload == nil || events[1].Payload == nil {
 		t.Fatalf("expected restarted/ready events to include payloads: %+v", events)
 	}
+
+	sawNotReady, recoveredCaps := waitForBridgeCapabilities(t, baseURL, 20*time.Second)
+	if !sawNotReady {
+		t.Fatal("expected bridge_not_ready while reconnecting after the OpenVSCode restart")
+	}
+	if recoveredCaps.ProtocolVersion == "" {
+		t.Fatal("expected protocolVersion in recovered bridge capabilities response")
+	}
+	waitForFileRead(t, baseURL, testFile, testContent, 20*time.Second)
 }

--- a/server/internal/vscode/bridge_integration_test.go
+++ b/server/internal/vscode/bridge_integration_test.go
@@ -22,6 +22,13 @@ type bridgeLifecycleEvent struct {
 	Payload map[string]interface{} `json:"payload"`
 }
 
+func skipIfBridgeIntegrationPrereqsMissing(t *testing.T) {
+	t.Helper()
+	if os.Getenv("VSCODE_INTEGRATION_TEST") == "" {
+		t.Skip("skipping bridge integration test: set VSCODE_INTEGRATION_TEST=1, bootstrap openvscode-server from repo root, and start the OpenVSCode test server before rerunning")
+	}
+}
+
 func findGoBinary(t *testing.T) string {
 	t.Helper()
 	candidates := []string{
@@ -227,7 +234,7 @@ func waitForBridgeEventSequence(t *testing.T, conn *websocket.Conn, timeout time
 }
 
 func TestIntegration_BridgeLifecycle_EndToEnd(t *testing.T) {
-	skipIfNoServer(t)
+	skipIfBridgeIntegrationPrereqsMissing(t)
 
 	metadataPath := filepath.Join(t.TempDir(), "bridge-metadata.json")
 	t.Setenv("OPENVSCODE_MOBILE_BRIDGE_METADATA_PATH", metadataPath)

--- a/server/internal/vscode/bridge_test.go
+++ b/server/internal/vscode/bridge_test.go
@@ -1,0 +1,374 @@
+package vscode
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type fakeVSCodeServer struct {
+	failHandshakeAttempts int32
+	attempts              atomic.Int32
+	messages              chan *ProtocolMessage
+}
+
+func newFakeVSCodeServer(t *testing.T, failHandshakeAttempts int) (*httptest.Server, *fakeVSCodeServer) {
+	t.Helper()
+
+	fake := &fakeVSCodeServer{
+		failHandshakeAttempts: int32(failHandshakeAttempts),
+		messages:              make(chan *ProtocolMessage, 32),
+	}
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade failed: %v", err)
+			return
+		}
+
+		attempt := fake.attempts.Add(1)
+		if attempt <= fake.failHandshakeAttempts {
+			_ = conn.Close()
+			return
+		}
+
+		defer conn.Close()
+
+		auth := mustReadProtocolMessage(t, conn)
+		if auth.Type != ProtocolMessageControl {
+			t.Errorf("auth message type = %v, want control", auth.Type)
+			return
+		}
+		var authReq AuthRequest
+		if err := json.Unmarshal(auth.Data, &authReq); err != nil {
+			t.Errorf("unmarshal auth request: %v", err)
+			return
+		}
+		if authReq.Type != "auth" {
+			t.Errorf("auth request type = %q, want auth", authReq.Type)
+			return
+		}
+
+		mustWriteControlJSON(t, conn, map[string]any{
+			"type":       "sign",
+			"data":       "challenge",
+			"signedData": "challenge",
+		})
+
+		connType := mustReadProtocolMessage(t, conn)
+		if connType.Type != ProtocolMessageControl {
+			t.Errorf("connectionType message type = %v, want control", connType.Type)
+			return
+		}
+		var connReq ConnectionTypeRequest
+		if err := json.Unmarshal(connType.Data, &connReq); err != nil {
+			t.Errorf("unmarshal connectionType request: %v", err)
+			return
+		}
+		if connReq.Type != "connectionType" {
+			t.Errorf("connectionType request type = %q, want connectionType", connReq.Type)
+			return
+		}
+
+		mustWriteControlJSON(t, conn, map[string]any{"type": "ok"})
+
+		for {
+			msg, err := readProtocolMessage(conn)
+			if err != nil {
+				return
+			}
+			select {
+			case fake.messages <- msg:
+			default:
+			}
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	return ts, fake
+}
+
+func mustReadProtocolMessage(t *testing.T, conn *websocket.Conn) *ProtocolMessage {
+	t.Helper()
+	msg, err := readProtocolMessage(conn)
+	if err != nil {
+		t.Fatalf("read protocol message: %v", err)
+	}
+	return msg
+}
+
+func readProtocolMessage(conn *websocket.Conn) (*ProtocolMessage, error) {
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		return nil, err
+	}
+	return DecodeProtocolMessage(bytes.NewReader(raw))
+}
+
+func mustWriteControlJSON(t *testing.T, conn *websocket.Conn, payload map[string]any) {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal control payload: %v", err)
+	}
+	encoded := EncodeProtocolMessage(&ProtocolMessage{Type: ProtocolMessageControl, Data: data})
+	if err := conn.WriteMessage(websocket.BinaryMessage, encoded); err != nil {
+		t.Fatalf("write control payload: %v", err)
+	}
+}
+
+func waitForProtocolMessage(t *testing.T, messages <-chan *ProtocolMessage, want ProtocolMessageType, timeout time.Duration) *ProtocolMessage {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case msg := <-messages:
+			if msg.Type == want {
+				return msg
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for protocol message type %v", want)
+		}
+	}
+}
+
+func writeBridgeMetadataFile(t *testing.T, path string, metadata BridgeMetadata) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir metadata dir: %v", err)
+	}
+	data, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+}
+
+func mustReceiveBridgeEvent(t *testing.T, ch <-chan BridgeEvent, timeout time.Duration) BridgeEvent {
+	t.Helper()
+	select {
+	case event := <-ch:
+		return event
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for bridge event")
+		return BridgeEvent{}
+	}
+}
+
+func TestBridgeManager_ColdStartReportsNotReady(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := NewBridgeManager(BridgeManagerOptions{MetadataPath: metadataPath})
+	manager.poll()
+
+	_, err := manager.Capabilities()
+	if err == nil {
+		t.Fatal("expected bridge capabilities to be unavailable on cold start")
+	}
+	var bridgeErr *BridgeError
+	if !errors.As(err, &bridgeErr) {
+		t.Fatalf("error type = %T, want *BridgeError", err)
+	}
+	if bridgeErr.Code != "bridge_not_ready" {
+		t.Fatalf("bridge error code = %q, want bridge_not_ready", bridgeErr.Code)
+	}
+	if !errors.Is(bridgeErr, os.ErrNotExist) {
+		t.Fatalf("expected cold-start error to unwrap os.ErrNotExist, got %v", bridgeErr)
+	}
+}
+
+func TestBridgeManager_ReadyTransitionPublishesCapabilities(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := NewBridgeManager(BridgeManagerOptions{MetadataPath: metadataPath})
+	events, unsubscribe := manager.Subscribe(false)
+	defer unsubscribe()
+
+	writeBridgeMetadataFile(t, metadataPath, BridgeMetadata{
+		ProtocolVersion: defaultBridgeProtocolVersion,
+		Generation:      "gen-1",
+		State:           bridgeStateReady,
+		BridgeVersion:   "0.1.0",
+		Capabilities: map[string]interface{}{
+			"terminal": map[string]interface{}{"enabled": true},
+		},
+	})
+
+	manager.poll()
+	caps, err := manager.Capabilities()
+	if err != nil {
+		t.Fatalf("Capabilities failed after ready transition: %v", err)
+	}
+	if caps.ProtocolVersion != defaultBridgeProtocolVersion {
+		t.Fatalf("protocolVersion = %q, want %q", caps.ProtocolVersion, defaultBridgeProtocolVersion)
+	}
+	if caps.BridgeVersion != "0.1.0" {
+		t.Fatalf("bridgeVersion = %q, want 0.1.0", caps.BridgeVersion)
+	}
+	terminal, ok := caps.Capabilities["terminal"].(map[string]interface{})
+	if !ok || terminal["enabled"] != true {
+		t.Fatalf("terminal capability = %#v, want enabled=true", caps.Capabilities["terminal"])
+	}
+
+	ready := mustReceiveBridgeEvent(t, events, 2*time.Second)
+	if ready.Type != "bridge/ready" {
+		t.Fatalf("event type = %q, want bridge/ready", ready.Type)
+	}
+}
+
+func TestBridgeManager_RestartDetectionBroadcastsRestartedThenReady(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := NewBridgeManager(BridgeManagerOptions{MetadataPath: metadataPath})
+	events, unsubscribe := manager.Subscribe(false)
+	defer unsubscribe()
+
+	writeBridgeMetadataFile(t, metadataPath, BridgeMetadata{
+		ProtocolVersion: defaultBridgeProtocolVersion,
+		Generation:      "gen-1",
+		State:           bridgeStateReady,
+		Capabilities:    map[string]interface{}{"git": map[string]interface{}{"enabled": false}},
+	})
+	manager.poll()
+	ready := mustReceiveBridgeEvent(t, events, 2*time.Second)
+	if ready.Type != "bridge/ready" {
+		t.Fatalf("initial event type = %q, want bridge/ready", ready.Type)
+	}
+
+	writeBridgeMetadataFile(t, metadataPath, BridgeMetadata{
+		ProtocolVersion: defaultBridgeProtocolVersion,
+		Generation:      "gen-2",
+		State:           bridgeStateReady,
+		Capabilities:    map[string]interface{}{"git": map[string]interface{}{"enabled": true}},
+	})
+	manager.poll()
+
+	restarted := mustReceiveBridgeEvent(t, events, 2*time.Second)
+	if restarted.Type != "bridge/restarted" {
+		t.Fatalf("restart event type = %q, want bridge/restarted", restarted.Type)
+	}
+	restartPayload, ok := restarted.Payload.(map[string]interface{})
+	if !ok {
+		t.Fatalf("restart payload type = %T, want map", restarted.Payload)
+	}
+	if restartPayload["previousGeneration"] != "gen-1" || restartPayload["generation"] != "gen-2" {
+		t.Fatalf("restart payload = %#v, want previousGeneration=gen-1 generation=gen-2", restartPayload)
+	}
+
+	ready = mustReceiveBridgeEvent(t, events, 2*time.Second)
+	if ready.Type != "bridge/ready" {
+		t.Fatalf("post-restart event type = %q, want bridge/ready", ready.Type)
+	}
+}
+
+func TestBridgeManager_TransportDisconnectMarksBridgeNotReady(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	client := NewClient()
+	manager := NewBridgeManager(BridgeManagerOptions{MetadataPath: metadataPath, Client: client})
+
+	writeBridgeMetadataFile(t, metadataPath, BridgeMetadata{
+		ProtocolVersion: defaultBridgeProtocolVersion,
+		Generation:      "gen-1",
+		State:           bridgeStateReady,
+		Capabilities:    map[string]interface{}{"workspace": map[string]interface{}{"enabled": true}},
+	})
+	manager.poll()
+	if _, err := manager.Capabilities(); err != nil {
+		t.Fatalf("Capabilities before disconnect failed: %v", err)
+	}
+
+	client.onDisconnect(errors.New("transport closed"))
+
+	_, err := manager.Capabilities()
+	if err == nil {
+		t.Fatal("expected bridge to become not-ready after transport loss")
+	}
+	var bridgeErr *BridgeError
+	if !errors.As(err, &bridgeErr) {
+		t.Fatalf("error type = %T, want *BridgeError", err)
+	}
+	if bridgeErr.Code != "bridge_not_ready" {
+		t.Fatalf("bridge error code = %q, want bridge_not_ready", bridgeErr.Code)
+	}
+	if !strings.Contains(bridgeErr.Error(), "transport closed") {
+		t.Fatalf("bridge error = %q, want transport cause", bridgeErr.Error())
+	}
+}
+
+func TestReconnectWithRetry_RetriesAfterTransientFailure(t *testing.T) {
+	ts, fake := newFakeVSCodeServer(t, 1)
+	client := NewClient()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	if err := client.ReconnectWithRetry(ctx, ts.URL, "", 3); err != nil {
+		t.Fatalf("ReconnectWithRetry failed: %v", err)
+	}
+	defer client.Close()
+
+	if got := fake.attempts.Load(); got != 2 {
+		t.Fatalf("handshake attempts = %d, want 2", got)
+	}
+	if elapsed := time.Since(start); elapsed < time.Second {
+		t.Fatalf("ReconnectWithRetry elapsed = %v, want at least one backoff interval", elapsed)
+	}
+
+	ctxMsg := waitForProtocolMessage(t, fake.messages, ProtocolMessageRegular, 2*time.Second)
+	if len(ctxMsg.Data) == 0 {
+		t.Fatal("expected IPC context bootstrap message after reconnect")
+	}
+}
+
+func TestReconnectWithRetry_StopsWhenContextExpires(t *testing.T) {
+	client := NewClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := client.ReconnectWithRetry(ctx, "http://127.0.0.1:1", "", 5)
+	if err == nil {
+		t.Fatal("expected reconnect failure when context expires")
+	}
+	if err != context.DeadlineExceeded {
+		t.Fatalf("ReconnectWithRetry error = %v, want %v", err, context.DeadlineExceeded)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("ReconnectWithRetry elapsed = %v, want prompt context cancellation", elapsed)
+	}
+}
+
+func TestClientClose_SendsDisconnectFrame(t *testing.T) {
+	ts, fake := newFakeVSCodeServer(t, 0)
+	client := NewClient()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Connect(ctx, ts.URL, ""); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	waitForProtocolMessage(t, fake.messages, ProtocolMessageRegular, 2*time.Second)
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	disconnect := waitForProtocolMessage(t, fake.messages, ProtocolMessageDisconnect, 2*time.Second)
+	if disconnect.Type != ProtocolMessageDisconnect {
+		t.Fatalf("disconnect type = %v, want %v", disconnect.Type, ProtocolMessageDisconnect)
+	}
+}

--- a/server/internal/vscode/bridge_test.go
+++ b/server/internal/vscode/bridge_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -40,7 +42,7 @@ func newFakeVSCodeServer(t *testing.T, failHandshakeAttempts int) (*httptest.Ser
 		}
 
 		attempt := fake.attempts.Add(1)
-		if attempt <= fake.failHandshakeAttempts {
+		if attempt <= atomic.LoadInt32(&fake.failHandshakeAttempts) {
 			_ = conn.Close()
 			return
 		}
@@ -333,6 +335,43 @@ func TestReconnectWithRetry_RetriesAfterTransientFailure(t *testing.T) {
 	}
 }
 
+func TestReconnectWithRetry_RecoversAfterDisconnectAndTransientReconnectFailure(t *testing.T) {
+	ts, fake := newFakeVSCodeServer(t, 0)
+	client := NewClient()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Connect(ctx, ts.URL, ""); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer client.Close()
+
+	waitForProtocolMessage(t, fake.messages, ProtocolMessageRegular, 2*time.Second)
+
+	// Fail the next reconnect handshake once, then allow the retry to succeed.
+	atomic.StoreInt32(&fake.failHandshakeAttempts, fake.attempts.Load()+1)
+
+	reconnectCtx, reconnectCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer reconnectCancel()
+
+	start := time.Now()
+	if err := client.ReconnectWithRetry(reconnectCtx, ts.URL, "", 3); err != nil {
+		t.Fatalf("ReconnectWithRetry failed: %v", err)
+	}
+
+	if got := fake.attempts.Load(); got != 3 {
+		t.Fatalf("handshake attempts = %d, want 3 (initial connect + failed reconnect + successful reconnect)", got)
+	}
+	if elapsed := time.Since(start); elapsed < time.Second {
+		t.Fatalf("ReconnectWithRetry elapsed = %v, want at least one backoff interval", elapsed)
+	}
+
+	ctxMsg := waitForProtocolMessage(t, fake.messages, ProtocolMessageRegular, 2*time.Second)
+	if len(ctxMsg.Data) == 0 {
+		t.Fatal("expected IPC context bootstrap message after reconnect recovery")
+	}
+}
+
 func TestReconnectWithRetry_StopsWhenContextExpires(t *testing.T) {
 	client := NewClient()
 	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
@@ -371,4 +410,192 @@ func TestClientClose_SendsDisconnectFrame(t *testing.T) {
 	if disconnect.Type != ProtocolMessageDisconnect {
 		t.Fatalf("disconnect type = %v, want %v", disconnect.Type, ProtocolMessageDisconnect)
 	}
+}
+
+func TestBridgeManager_DisconnectTriggersReconnectAndBroadcastsRecovery(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	writeBridgeMetadataFile(t, metadataPath, BridgeMetadata{
+		ProtocolVersion: defaultBridgeProtocolVersion,
+		Generation:      "gen-1",
+		State:           bridgeStateReady,
+		Capabilities:    map[string]interface{}{"workspace": map[string]interface{}{"enabled": true}},
+	})
+
+	client := NewClient()
+	reconnectStarted := make(chan struct{})
+	reconnectRelease := make(chan struct{})
+	var reconnectCalls atomic.Int32
+	manager := NewBridgeManager(BridgeManagerOptions{
+		MetadataPath: metadataPath,
+		Client:       client,
+		ReconnectFn: func(ctx context.Context) error {
+			reconnectCalls.Add(1)
+			close(reconnectStarted)
+			select {
+			case <-reconnectRelease:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	})
+	events, unsubscribe := manager.Subscribe(false)
+	defer unsubscribe()
+
+	manager.poll()
+	_ = mustReceiveBridgeEvent(t, events, 2*time.Second) // initial bridge/ready
+
+	client.onDisconnect(errors.New("transport closed"))
+
+	select {
+	case <-reconnectStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for reconnect to start")
+	}
+
+	if reconnectCalls.Load() != 1 {
+		t.Fatalf("reconnect calls = %d, want 1", reconnectCalls.Load())
+	}
+	if _, err := manager.Capabilities(); err == nil {
+		t.Fatal("expected bridge capabilities to be unavailable during reconnect")
+	}
+
+	// The stale pre-restart metadata must not make the bridge ready again.
+	manager.poll()
+	if _, err := manager.Capabilities(); err == nil {
+		t.Fatal("expected stale metadata to remain not-ready during reconnect")
+	}
+
+	writeBridgeMetadataFile(t, metadataPath, BridgeMetadata{
+		ProtocolVersion: defaultBridgeProtocolVersion,
+		Generation:      "gen-2",
+		State:           bridgeStateReady,
+		UpdatedAt:       time.Now().UTC(),
+		Capabilities:    map[string]interface{}{"workspace": map[string]interface{}{"enabled": true}},
+	})
+	close(reconnectRelease)
+
+	restarted := mustReceiveBridgeEvent(t, events, 2*time.Second)
+	if restarted.Type != "bridge/restarted" {
+		t.Fatalf("event type = %q, want bridge/restarted", restarted.Type)
+	}
+	ready := mustReceiveBridgeEvent(t, events, 2*time.Second)
+	if ready.Type != "bridge/ready" {
+		t.Fatalf("event type = %q, want bridge/ready", ready.Type)
+	}
+
+	caps, err := manager.Capabilities()
+	if err != nil {
+		t.Fatalf("Capabilities after reconnect failed: %v", err)
+	}
+	if caps.Capabilities["workspace"] == nil {
+		t.Fatalf("expected workspace capability after reconnect, got %#v", caps.Capabilities)
+	}
+}
+
+func TestBridgeManager_ReconnectFailureLeavesBridgeNotReady(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	writeBridgeMetadataFile(t, metadataPath, BridgeMetadata{
+		ProtocolVersion: defaultBridgeProtocolVersion,
+		Generation:      "gen-1",
+		State:           bridgeStateReady,
+	})
+
+	client := NewClient()
+	manager := NewBridgeManager(BridgeManagerOptions{
+		MetadataPath:     metadataPath,
+		Client:           client,
+		ReconnectTimeout: 100 * time.Millisecond,
+		ReconnectFn: func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+
+	manager.poll()
+	client.onDisconnect(errors.New("transport closed"))
+	time.Sleep(150 * time.Millisecond)
+
+	_, err := manager.Capabilities()
+	if err == nil {
+		t.Fatal("expected bridge capabilities to remain unavailable after reconnect failure")
+	}
+	var bridgeErr *BridgeError
+	if !errors.As(err, &bridgeErr) {
+		t.Fatalf("error type = %T, want *BridgeError", err)
+	}
+	if !strings.Contains(bridgeErr.Error(), "reconnect vscode transport") {
+		t.Fatalf("bridge error = %q, want reconnect failure context", bridgeErr.Error())
+	}
+}
+
+func TestClientReconnect_PreservesIPCClientReferences(t *testing.T) {
+	ts, _ := newFakeVSCodeServer(t, 0)
+	client := NewClient()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Connect(ctx, ts.URL, ""); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer client.Close()
+
+	originalIPC := client.IPC()
+	if originalIPC == nil {
+		t.Fatal("expected IPC client after initial connect")
+	}
+
+	if err := client.Reconnect(ctx, ts.URL, ""); err != nil {
+		t.Fatalf("Reconnect failed: %v", err)
+	}
+	if got := client.IPC(); got != originalIPC {
+		t.Fatal("expected reconnect to preserve IPC client identity")
+	}
+}
+
+func TestBridgeManager_ConcurrentDisconnectOnlyStartsOneReconnect(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	writeBridgeMetadataFile(t, metadataPath, BridgeMetadata{
+		ProtocolVersion: defaultBridgeProtocolVersion,
+		Generation:      "gen-1",
+		State:           bridgeStateReady,
+	})
+
+	client := NewClient()
+	reconnectRelease := make(chan struct{})
+	var reconnectCalls atomic.Int32
+	manager := NewBridgeManager(BridgeManagerOptions{
+		MetadataPath: metadataPath,
+		Client:       client,
+		ReconnectFn: func(ctx context.Context) error {
+			reconnectCalls.Add(1)
+			select {
+			case <-reconnectRelease:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	})
+	manager.poll()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			client.onDisconnect(fmt.Errorf("transport closed %d", i))
+		}(i)
+	}
+	wg.Wait()
+	close(reconnectRelease)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if reconnectCalls.Load() == 1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("reconnect calls = %d, want 1", reconnectCalls.Load())
 }

--- a/server/internal/vscode/client.go
+++ b/server/internal/vscode/client.go
@@ -63,6 +63,13 @@ type Client struct {
 	conn *websocket.Conn
 	mu   sync.Mutex
 
+	// connEpoch identifies the currently active websocket transport so stale
+	// read/keepalive goroutines do not report disconnects for superseded
+	// connections during reconnect.
+	connEpoch atomic.Uint64
+	// disconnectEpoch ensures a transport loss is only reported once per epoch.
+	disconnectEpoch atomic.Uint64
+
 	// reconnectionToken identifies this session for reconnection.
 	reconnectionToken string
 
@@ -123,7 +130,12 @@ func (c *Client) ConnectWithType(ctx context.Context, serverURL string, connecti
 	if err != nil {
 		return fmt.Errorf("websocket dial: %w", err)
 	}
+	c.mu.Lock()
 	c.conn = conn
+	stopKeepAlive := c.stopKeepAlive
+	epoch := c.connEpoch.Add(1)
+	c.disconnectEpoch.Store(0)
+	c.mu.Unlock()
 
 	if err := c.performHandshake(ctx, connectionToken, connType, commit); err != nil {
 		conn.Close()
@@ -141,17 +153,21 @@ func (c *Client) ConnectWithType(ctx context.Context, serverURL string, connecti
 	}
 
 	// Attach the IPC multiplexer.
-	c.ipcClient = NewIPCClient(c)
+	if c.ipcClient == nil {
+		c.ipcClient = NewIPCClient(c)
+	} else {
+		c.ipcClient.reset(c)
+	}
 
 	// Replay any messages buffered during handshake (e.g., Initialize).
 	for _, msg := range c.bufferedMessages {
-		c.handleMessage(msg)
+		c.handleMessage(msg, epoch)
 	}
 	c.bufferedMessages = nil
 
 	// Start the read loop and keep-alive.
-	go c.readLoop()
-	go c.keepAliveLoop()
+	go c.readLoop(conn, epoch)
+	go c.keepAliveLoop(conn, stopKeepAlive, epoch)
 
 	log.Printf("[VSCode] connected to %s (type=%d)", serverURL, connType)
 	return nil
@@ -175,8 +191,8 @@ func (c *Client) SetDisconnectHandler(handler func(error)) {
 func (c *Client) Reconnect(ctx context.Context, serverURL string, connectionToken string) error {
 	// Close existing connection if any.
 	c.mu.Lock()
-	if c.conn != nil {
-		c.conn.Close()
+	if existing := c.conn; existing != nil {
+		_ = existing.Close()
 	}
 	c.mu.Unlock()
 
@@ -184,7 +200,7 @@ func (c *Client) Reconnect(ctx context.Context, serverURL string, connectionToke
 	select {
 	case <-c.stopKeepAlive:
 	default:
-		close(c.stopKeepAlive)
+		closeSignal(c.stopKeepAlive)
 	}
 	c.stopKeepAlive = make(chan struct{})
 
@@ -201,7 +217,12 @@ func (c *Client) Reconnect(ctx context.Context, serverURL string, connectionToke
 	if err != nil {
 		return fmt.Errorf("websocket reconnect dial: %w", err)
 	}
+	c.mu.Lock()
 	c.conn = conn
+	stopKeepAlive := c.stopKeepAlive
+	epoch := c.connEpoch.Add(1)
+	c.disconnectEpoch.Store(0)
+	c.mu.Unlock()
 
 	if err := c.performHandshake(ctx, connectionToken, ConnectionTypeManagement, ""); err != nil {
 		conn.Close()
@@ -216,15 +237,20 @@ func (c *Client) Reconnect(ctx context.Context, serverURL string, connectionToke
 		return fmt.Errorf("reconnect send IPC ctx: %w", err)
 	}
 
-	// Re-attach IPC.
-	c.ipcClient = NewIPCClient(c)
+	// Re-attach IPC without replacing the object so long-lived proxies that hold
+	// the IPCClient continue to use the restored transport.
+	if c.ipcClient == nil {
+		c.ipcClient = NewIPCClient(c)
+	} else {
+		c.ipcClient.reset(c)
+	}
 	for _, msg := range c.bufferedMessages {
-		c.handleMessage(msg)
+		c.handleMessage(msg, epoch)
 	}
 	c.bufferedMessages = nil
 
-	go c.readLoop()
-	go c.keepAliveLoop()
+	go c.readLoop(conn, epoch)
+	go c.keepAliveLoop(conn, stopKeepAlive, epoch)
 
 	log.Printf("[VSCode] reconnected to %s", serverURL)
 	return nil
@@ -259,7 +285,7 @@ func (c *Client) ReconnectWithRetry(ctx context.Context, serverURL, connectionTo
 func (c *Client) Close() error {
 	var closeErr error
 	c.closeOnce.Do(func() {
-		close(c.stopKeepAlive)
+		closeSignal(c.stopKeepAlive)
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		if c.conn == nil {
@@ -429,12 +455,12 @@ func (c *Client) SendRegular(data []byte) error {
 }
 
 // readLoop continuously reads messages from the WebSocket and dispatches them.
-func (c *Client) readLoop() {
+func (c *Client) readLoop(conn *websocket.Conn, epoch uint64) {
 	for {
-		_, rawData, err := c.conn.ReadMessage()
+		_, rawData, err := conn.ReadMessage()
 		if err != nil {
 			// Connection closed or error.
-			c.notifyDisconnect(err)
+			c.notifyDisconnect(epoch, err)
 			return
 		}
 
@@ -448,12 +474,12 @@ func (c *Client) readLoop() {
 				log.Printf("vscode: decode error: %v", err)
 				break
 			}
-			c.handleMessage(msg)
+			c.handleMessage(msg, epoch)
 		}
 	}
 }
 
-func (c *Client) handleMessage(msg *ProtocolMessage) {
+func (c *Client) handleMessage(msg *ProtocolMessage, epoch uint64) {
 	switch msg.Type {
 	case ProtocolMessageRegular:
 		c.incomingMsgID.Store(msg.ID)
@@ -470,17 +496,17 @@ func (c *Client) handleMessage(msg *ProtocolMessage) {
 		// No action needed.
 	case ProtocolMessageDisconnect:
 		log.Println("vscode: received disconnect")
-		c.notifyDisconnect(fmt.Errorf("received disconnect"))
+		c.notifyDisconnect(epoch, fmt.Errorf("received disconnect"))
 	}
 }
 
 // keepAliveLoop sends periodic keep-alive frames.
-func (c *Client) keepAliveLoop() {
+func (c *Client) keepAliveLoop(conn *websocket.Conn, stopCh <-chan struct{}, epoch uint64) {
 	ticker := time.NewTicker(keepAliveSendTime)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-c.stopKeepAlive:
+		case <-stopCh:
 			return
 		case <-ticker.C:
 			msg := &ProtocolMessage{
@@ -489,20 +515,52 @@ func (c *Client) keepAliveLoop() {
 				Ack:  0,
 				Data: []byte{},
 			}
-			if err := c.WriteMessage(msg); err != nil {
-				c.notifyDisconnect(err)
+			if err := c.writeMessageOnConn(conn, msg); err != nil {
+				c.notifyDisconnect(epoch, err)
 				return
 			}
 		}
 	}
 }
 
-func (c *Client) notifyDisconnect(err error) {
+func (c *Client) notifyDisconnect(epoch uint64, err error) {
 	c.mu.Lock()
+	if c.connEpoch.Load() != epoch {
+		c.mu.Unlock()
+		return
+	}
 	handler := c.onDisconnect
 	c.mu.Unlock()
-	if handler != nil {
-		handler(err)
+	if handler == nil {
+		return
+	}
+	if !c.disconnectEpoch.CompareAndSwap(0, epoch) {
+		return
+	}
+	handler(err)
+}
+
+func (c *Client) writeMessageOnConn(conn *websocket.Conn, msg *ProtocolMessage) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if conn == nil {
+		return fmt.Errorf("not connected")
+	}
+	if c.conn != conn {
+		return fmt.Errorf("stale connection")
+	}
+	data := EncodeProtocolMessage(msg)
+	return conn.WriteMessage(websocket.BinaryMessage, data)
+}
+
+func closeSignal(ch chan struct{}) {
+	if ch == nil {
+		return
+	}
+	select {
+	case <-ch:
+	default:
+		close(ch)
 	}
 }
 

--- a/server/internal/vscode/client.go
+++ b/server/internal/vscode/client.go
@@ -86,6 +86,8 @@ type Client struct {
 	onMessage func(data []byte)
 	// onControl is called for each Control message received.
 	onControl func(data []byte)
+	// onDisconnect is called when the websocket transport is lost.
+	onDisconnect func(error)
 }
 
 // NewClient creates a new Client with a fresh reconnection token.
@@ -158,6 +160,13 @@ func (c *Client) ConnectWithType(ctx context.Context, serverURL string, connecti
 // IPC returns the IPC channel multiplexer for this connection.
 func (c *Client) IPC() *IPCClient {
 	return c.ipcClient
+}
+
+// SetDisconnectHandler registers a callback for transport loss notifications.
+func (c *Client) SetDisconnectHandler(handler func(error)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onDisconnect = handler
 }
 
 // Reconnect attempts to re-establish the connection using the same
@@ -425,6 +434,7 @@ func (c *Client) readLoop() {
 		_, rawData, err := c.conn.ReadMessage()
 		if err != nil {
 			// Connection closed or error.
+			c.notifyDisconnect(err)
 			return
 		}
 
@@ -460,6 +470,7 @@ func (c *Client) handleMessage(msg *ProtocolMessage) {
 		// No action needed.
 	case ProtocolMessageDisconnect:
 		log.Println("vscode: received disconnect")
+		c.notifyDisconnect(fmt.Errorf("received disconnect"))
 	}
 }
 
@@ -479,9 +490,19 @@ func (c *Client) keepAliveLoop() {
 				Data: []byte{},
 			}
 			if err := c.WriteMessage(msg); err != nil {
+				c.notifyDisconnect(err)
 				return
 			}
 		}
+	}
+}
+
+func (c *Client) notifyDisconnect(err error) {
+	c.mu.Lock()
+	handler := c.onDisconnect
+	c.mu.Unlock()
+	if handler != nil {
+		handler(err)
 	}
 }
 

--- a/server/internal/vscode/ipc.go
+++ b/server/internal/vscode/ipc.go
@@ -29,8 +29,19 @@ func NewIPCClient(c *Client) *IPCClient {
 		client:      c,
 		initialized: make(chan struct{}),
 	}
-	c.onMessage = ipc.onRawMessage
+	ipc.attachClient(c)
 	return ipc
+}
+
+func (ipc *IPCClient) attachClient(c *Client) {
+	ipc.client = c
+	c.onMessage = ipc.onRawMessage
+}
+
+func (ipc *IPCClient) reset(c *Client) {
+	ipc.handlers = sync.Map{}
+	ipc.initialized = make(chan struct{})
+	ipc.attachClient(c)
 }
 
 // GetChannel returns a handle to the named IPC channel.


### PR DESCRIPTION
## Summary
- add the mobile runtime bridge foundation across the Go server and built-in OpenVSCode extension
- expose `GET /bridge/capabilities` plus `WS /bridge/ws/events` with explicit `bridge_not_ready` / `capability_unavailable` error handling and lifecycle envelopes
- recover bridge transport after runtime restarts and add repo-local validation/docs for the bridge foundation flow

## Why
- closes the ASE-41 foundation slice for bridge lifecycle, capability discovery, and unified event streaming
- uses the existing GitHub issue as the canonical ticket link instead of creating a duplicate issue

## Issue
- https://github.com/Lincyaw/openvsmobile/issues/2

## Validation
- `bash -n scripts/verify_bridge_foundation.sh`
- `./scripts/verify_bridge_foundation.sh --help`
- `cd server && /home/ddq/go-sdk/go/bin/go test ./internal/vscode ./internal/api`
- `cd server && /home/ddq/go-sdk/go/bin/go vet ./...`
- `PATH=/home/ddq/go-sdk/go/bin:$PATH make test`
- `PATH=/home/ddq/go-sdk/go/bin:$PATH make lint`
- `make verify-bridge-extension` *(expected prerequisite stop in this runtime because `openvscode-server/node_modules` is absent)*
- `make verify-bridge-foundation` *(expected prerequisite stop in this runtime because `openvscode-server/node_modules` is absent)*
