### PR TITLE
ASE-42: document sync protocol

### DIFF
--- a/project-index.yaml
+++ b/project-index.yaml
@@ -524,6 +524,30 @@ requirements:
       - server/internal/vscode/bridge_integration_test.go
     depends_on: [REQ-023, REQ-024]
 
+  - id: REQ-026
+    title: Bridge document sync protocol
+    description: >
+      Ticket ASE-42 / GitHub issue #3 adds a VS Code TextDocument-shaped
+      document sync contract for the mobile runtime bridge. The Go server
+      exposes POST /bridge/doc/open, /bridge/doc/change, /bridge/doc/save,
+      and /bridge/doc/close; tracks per-file in-memory buffers with monotonic
+      versions; validates range/position edits with VS Code-compatible
+      character semantics; returns structured document_not_open,
+      version_conflict, and invalid_position errors; and keeps the latest
+      unsaved buffer available to future workspace edit, diagnostics, and
+      completion features without falling back to legacy git/terminal paths.
+    priority: P0
+    status: implemented
+    code:
+      - server/internal/vscode/bridge.go
+      - server/internal/api/bridge.go
+      - server/internal/api/router.go
+      - server/cmd/server/main.go
+    tests:
+      - server/internal/vscode/document_sync_test.go
+      - server/internal/api/bridge_documents_test.go
+    depends_on: [REQ-003, REQ-023]
+
   # ============================================================
   # Iteration 5: Bug fixes from code review audit
   # ============================================================

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -121,6 +121,7 @@ func main() {
 
 	srv := api.NewServer(fs, sessionIndex, pm, token, gitClient, termMgr, diagRunner, githubAuth)
 	srv.SetBridgeManager(bridgeManager)
+	srv.SetDocumentSync(vscode.NewDocumentSyncService(fs))
 
 	httpServer := &http.Server{
 		Addr:    fmt.Sprintf(":%d", port),

--- a/server/internal/api/bridge.go
+++ b/server/internal/api/bridge.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"net/http"
 	"sync"
@@ -12,6 +14,22 @@ import (
 type bridgeErrorDetail struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
+}
+
+type bridgeDocumentOpenRequest struct {
+	Path    string  `json:"path"`
+	Version int     `json:"version"`
+	Content *string `json:"content,omitempty"`
+}
+
+type bridgeDocumentChangeRequest struct {
+	Path    string                  `json:"path"`
+	Version int                     `json:"version"`
+	Changes []vscode.DocumentChange `json:"changes"`
+}
+
+type bridgeDocumentPathRequest struct {
+	Path string `json:"path"`
 }
 
 func (s *Server) handleBridgeCapabilities(w http.ResponseWriter, r *http.Request) {
@@ -94,4 +112,113 @@ func (s *Server) handleWSBridgeEvents(w http.ResponseWriter, r *http.Request) {
 
 func writeBridgeError(w http.ResponseWriter, status int, code, message string) {
 	writeJSON(w, status, bridgeErrorDetail{Code: code, Message: message})
+}
+
+func (s *Server) handleBridgeDocumentOpen(w http.ResponseWriter, r *http.Request) {
+	if s.documentSync == nil {
+		writeBridgeError(w, http.StatusServiceUnavailable, "bridge_not_ready", "document sync is not configured")
+		return
+	}
+
+	var req bridgeDocumentOpenRequest
+	if !decodeBridgeDocumentRequest(w, r, &req) {
+		return
+	}
+
+	snapshot, err := s.documentSync.OpenDocument(req.Path, req.Version, req.Content)
+	if err != nil {
+		writeDocumentSyncError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, snapshot)
+}
+
+func (s *Server) handleBridgeDocumentChange(w http.ResponseWriter, r *http.Request) {
+	if s.documentSync == nil {
+		writeBridgeError(w, http.StatusServiceUnavailable, "bridge_not_ready", "document sync is not configured")
+		return
+	}
+
+	var req bridgeDocumentChangeRequest
+	if !decodeBridgeDocumentRequest(w, r, &req) {
+		return
+	}
+
+	snapshot, err := s.documentSync.ApplyDocumentChanges(req.Path, req.Version, req.Changes)
+	if err != nil {
+		writeDocumentSyncError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, snapshot)
+}
+
+func (s *Server) handleBridgeDocumentSave(w http.ResponseWriter, r *http.Request) {
+	if s.documentSync == nil {
+		writeBridgeError(w, http.StatusServiceUnavailable, "bridge_not_ready", "document sync is not configured")
+		return
+	}
+
+	var req bridgeDocumentPathRequest
+	if !decodeBridgeDocumentRequest(w, r, &req) {
+		return
+	}
+
+	snapshot, err := s.documentSync.SaveDocument(req.Path)
+	if err != nil {
+		writeDocumentSyncError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, snapshot)
+}
+
+func (s *Server) handleBridgeDocumentClose(w http.ResponseWriter, r *http.Request) {
+	if s.documentSync == nil {
+		writeBridgeError(w, http.StatusServiceUnavailable, "bridge_not_ready", "document sync is not configured")
+		return
+	}
+
+	var req bridgeDocumentPathRequest
+	if !decodeBridgeDocumentRequest(w, r, &req) {
+		return
+	}
+
+	if err := s.documentSync.CloseDocument(req.Path); err != nil {
+		writeDocumentSyncError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"path": req.Path, "closed": true})
+}
+
+func decodeBridgeDocumentRequest(w http.ResponseWriter, r *http.Request, dst any) bool {
+	defer r.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		writeBridgeError(w, http.StatusBadRequest, "invalid_request", "failed to read request body")
+		return false
+	}
+	if err := json.Unmarshal(body, dst); err != nil {
+		writeBridgeError(w, http.StatusBadRequest, "invalid_request", "failed to decode JSON request body")
+		return false
+	}
+	return true
+}
+
+func writeDocumentSyncError(w http.ResponseWriter, err error) {
+	var bridgeErr *vscode.BridgeError
+	if errors.As(err, &bridgeErr) {
+		status := http.StatusInternalServerError
+		switch bridgeErr.Code {
+		case "invalid_request", "invalid_position":
+			status = http.StatusBadRequest
+		case "document_not_open":
+			status = http.StatusNotFound
+		case "version_conflict":
+			status = http.StatusConflict
+		case "bridge_not_ready":
+			status = http.StatusServiceUnavailable
+		}
+		writeBridgeError(w, status, bridgeErr.Code, bridgeErr.Message)
+		return
+	}
+	writeBridgeError(w, http.StatusInternalServerError, "bridge_error", "bridge document request failed")
 }

--- a/server/internal/api/bridge_documents_test.go
+++ b/server/internal/api/bridge_documents_test.go
@@ -1,0 +1,367 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+type bridgeDocPosition struct {
+	Line      int `json:"line"`
+	Character int `json:"character"`
+}
+
+type bridgeDocRange struct {
+	Start bridgeDocPosition `json:"start"`
+	End   bridgeDocPosition `json:"end"`
+}
+
+type bridgeDocChange struct {
+	Range *bridgeDocRange `json:"range,omitempty"`
+	Text  string          `json:"text"`
+}
+
+type bridgeDocSnapshot struct {
+	Path    string `json:"path"`
+	Version int    `json:"version"`
+	Content string `json:"content"`
+}
+
+func postBridgeDocumentRequest(t *testing.T, baseURL, path string, payload any) (*http.Response, []byte) {
+	t.Helper()
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal %s payload: %v", path, err)
+	}
+
+	resp, err := http.Post(baseURL+path, "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post %s: %v", path, err)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("read %s response body: %v", path, err)
+	}
+	_ = resp.Body.Close()
+	return resp, respBody
+}
+
+func requireBridgeDocumentSuccess(t *testing.T, baseURL, path string, payload any) []byte {
+	t.Helper()
+
+	resp, body := postBridgeDocumentRequest(t, baseURL, path, payload)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("%s status = %d, want 200 or 204; body=%s", path, resp.StatusCode, string(body))
+	}
+	return body
+}
+
+func requireBridgeDocumentSnapshot(t *testing.T, baseURL, path string, payload any) bridgeDocSnapshot {
+	t.Helper()
+
+	body := requireBridgeDocumentSuccess(t, baseURL, path, payload)
+	var snapshot bridgeDocSnapshot
+	if err := json.Unmarshal(body, &snapshot); err != nil {
+		t.Fatalf("decode %s snapshot response: %v; body=%s", path, err, string(body))
+	}
+	return snapshot
+}
+
+func requireBridgeDocumentError(t *testing.T, baseURL, path string, payload any, wantCode string, wantStatuses ...int) bridgeErrorDetail {
+	t.Helper()
+
+	resp, body := postBridgeDocumentRequest(t, baseURL, path, payload)
+	for _, wantStatus := range wantStatuses {
+		if resp.StatusCode == wantStatus {
+			var detail bridgeErrorDetail
+			if err := json.Unmarshal(body, &detail); err != nil {
+				t.Fatalf("decode %s error response: %v; body=%s", path, err, string(body))
+			}
+			if detail.Code != wantCode {
+				t.Fatalf("%s error code = %q, want %q", path, detail.Code, wantCode)
+			}
+			if detail.Message == "" {
+				t.Fatalf("%s error message should be non-empty", path)
+			}
+			return detail
+		}
+	}
+
+	if len(wantStatuses) == 0 {
+		t.Fatalf("%s returned status %d but no allowed statuses were supplied", path, resp.StatusCode)
+	}
+	t.Fatalf("%s status = %d, want one of %v; body=%s", path, resp.StatusCode, wantStatuses, string(body))
+	return bridgeErrorDetail{}
+}
+
+func TestBridgeDocumentLifecycle_SavePersistsLatestAcceptedBufferAndCloseCleansUp(t *testing.T) {
+	ts, fs, _ := newTestServer(t, "")
+	const filePath = "/workspace/note.txt"
+	fs.files[filePath] = []byte("disk copy\n")
+
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/open", map[string]any{
+		"path":    filePath,
+		"version": 1,
+		"content": "draft\n",
+	})
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/change", map[string]any{
+		"path":    filePath,
+		"version": 2,
+		"changes": []bridgeDocChange{{
+			Range: &bridgeDocRange{
+				Start: bridgeDocPosition{Line: 0, Character: 5},
+				End:   bridgeDocPosition{Line: 0, Character: 5},
+			},
+			Text: " updated",
+		}},
+	})
+
+	if got := string(fs.files[filePath]); got != "disk copy\n" {
+		t.Fatalf("disk content before save = %q, want unchanged", got)
+	}
+
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/save", map[string]any{
+		"path": filePath,
+	})
+	if got := string(fs.files[filePath]); got != "draft updated\n" {
+		t.Fatalf("saved content = %q, want %q", got, "draft updated\\n")
+	}
+
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/close", map[string]any{
+		"path": filePath,
+	})
+	requireBridgeDocumentError(t, ts.URL, "/bridge/doc/save", map[string]any{
+		"path": filePath,
+	}, "document_not_open", http.StatusNotFound, http.StatusBadRequest)
+
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/open", map[string]any{
+		"path":    filePath,
+		"version": 1,
+		"content": "reopened\n",
+	})
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/save", map[string]any{
+		"path": filePath,
+	})
+	if got := string(fs.files[filePath]); got != "reopened\n" {
+		t.Fatalf("saved content after reopen = %q, want %q", got, "reopened\\n")
+	}
+}
+
+func TestBridgeDocumentChange_StaleVersionReturnsVersionConflictWithoutMutatingSavedContent(t *testing.T) {
+	ts, fs, _ := newTestServer(t, "")
+	const filePath = "/workspace/conflict.txt"
+	fs.files[filePath] = []byte("base")
+
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/open", map[string]any{
+		"path":    filePath,
+		"version": 1,
+		"content": "base",
+	})
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/change", map[string]any{
+		"path":    filePath,
+		"version": 2,
+		"changes": []bridgeDocChange{{
+			Range: &bridgeDocRange{
+				Start: bridgeDocPosition{Line: 0, Character: 4},
+				End:   bridgeDocPosition{Line: 0, Character: 4},
+			},
+			Text: " ok",
+		}},
+	})
+
+	requireBridgeDocumentError(t, ts.URL, "/bridge/doc/change", map[string]any{
+		"path":    filePath,
+		"version": 2,
+		"changes": []bridgeDocChange{{
+			Range: &bridgeDocRange{
+				Start: bridgeDocPosition{Line: 0, Character: 0},
+				End:   bridgeDocPosition{Line: 0, Character: 0},
+			},
+			Text: "stale ",
+		}},
+	}, "version_conflict", http.StatusConflict)
+
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/save", map[string]any{
+		"path": filePath,
+	})
+	if got := string(fs.files[filePath]); got != "base ok" {
+		t.Fatalf("saved content after stale change = %q, want %q", got, "base ok")
+	}
+}
+
+func TestBridgeDocumentChange_InvalidPositionReturnsStructuredErrorWithoutMutatingSavedContent(t *testing.T) {
+	ts, fs, _ := newTestServer(t, "")
+	const filePath = "/workspace/invalid.txt"
+	fs.files[filePath] = []byte("hello\nworld\n")
+
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/open", map[string]any{
+		"path":    filePath,
+		"version": 1,
+		"content": "hello\nworld\n",
+	})
+	requireBridgeDocumentError(t, ts.URL, "/bridge/doc/change", map[string]any{
+		"path":    filePath,
+		"version": 2,
+		"changes": []bridgeDocChange{{
+			Range: &bridgeDocRange{
+				Start: bridgeDocPosition{Line: 9, Character: 0},
+				End:   bridgeDocPosition{Line: 9, Character: 0},
+			},
+			Text: "boom",
+		}},
+	}, "invalid_position", http.StatusBadRequest, http.StatusConflict)
+
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/save", map[string]any{
+		"path": filePath,
+	})
+	if got := string(fs.files[filePath]); got != "hello\nworld\n" {
+		t.Fatalf("saved content after invalid change = %q, want original buffer", got)
+	}
+}
+
+func TestBridgeDocumentLifecycle_UnopenedFileOperationsReturnDocumentNotOpen(t *testing.T) {
+	ts, _, _ := newTestServer(t, "")
+	const filePath = "/workspace/missing.txt"
+
+	tests := []struct {
+		name string
+		path string
+		body map[string]any
+	}{
+		{
+			name: "change",
+			path: "/bridge/doc/change",
+			body: map[string]any{
+				"path":    filePath,
+				"version": 2,
+				"changes": []bridgeDocChange{{Text: "ignored"}},
+			},
+		},
+		{
+			name: "save",
+			path: "/bridge/doc/save",
+			body: map[string]any{"path": filePath},
+		},
+		{
+			name: "close",
+			path: "/bridge/doc/close",
+			body: map[string]any{"path": filePath},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			requireBridgeDocumentError(t, ts.URL, tc.path, tc.body, "document_not_open", http.StatusNotFound, http.StatusBadRequest, http.StatusConflict)
+		})
+	}
+}
+
+func TestBridgeDocumentOpen_DuplicateOpenIdempotentAndConflictScenarios(t *testing.T) {
+	ts, fs, _ := newTestServer(t, "")
+	const filePath = "/workspace/reopen.txt"
+	fs.files[filePath] = []byte("disk")
+
+	requireBridgeDocumentSnapshot(t, ts.URL, "/bridge/doc/open", map[string]any{
+		"path":    filePath,
+		"version": 1,
+		"content": "draft",
+	})
+	requireBridgeDocumentSnapshot(t, ts.URL, "/bridge/doc/change", map[string]any{
+		"path":    filePath,
+		"version": 2,
+		"changes": []bridgeDocChange{{
+			Range: &bridgeDocRange{
+				Start: bridgeDocPosition{Line: 0, Character: 5},
+				End:   bridgeDocPosition{Line: 0, Character: 5},
+			},
+			Text: " ok",
+		}},
+	})
+
+	snapshot := requireBridgeDocumentSnapshot(t, ts.URL, "/bridge/doc/open", map[string]any{
+		"path":    filePath,
+		"version": 2,
+		"content": "draft ok",
+	})
+	if snapshot.Version != 2 || snapshot.Content != "draft ok" {
+		t.Fatalf("idempotent reopen snapshot = %+v, want version=2 content=%q", snapshot, "draft ok")
+	}
+
+	for _, tc := range []struct {
+		name    string
+		version int
+		content string
+	}{
+		{name: "stale version", version: 1, content: "draft"},
+		{name: "conflicting same version", version: 2, content: "other"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requireBridgeDocumentError(t, ts.URL, "/bridge/doc/open", map[string]any{
+				"path":    filePath,
+				"version": tc.version,
+				"content": tc.content,
+			}, "version_conflict", http.StatusConflict)
+		})
+	}
+
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/save", map[string]any{
+		"path": filePath,
+	})
+	if got := string(fs.files[filePath]); got != "draft ok" {
+		t.Fatalf("saved content after rejected reopen = %q, want %q", got, "draft ok")
+	}
+}
+
+func TestBridgeDocumentChange_UnicodeRangesPersistLastAcceptedBuffer(t *testing.T) {
+	ts, fs, _ := newTestServer(t, "")
+	const filePath = "/workspace/unicode.txt"
+	fs.files[filePath] = []byte("disk")
+
+	requireBridgeDocumentSnapshot(t, ts.URL, "/bridge/doc/open", map[string]any{
+		"path":    filePath,
+		"version": 1,
+		"content": "你x\n世y\n",
+	})
+
+	snapshot := requireBridgeDocumentSnapshot(t, ts.URL, "/bridge/doc/change", map[string]any{
+		"path":    filePath,
+		"version": 2,
+		"changes": []bridgeDocChange{{
+			Range: &bridgeDocRange{
+				Start: bridgeDocPosition{Line: 0, Character: 1},
+				End:   bridgeDocPosition{Line: 0, Character: 1},
+			},
+			Text: "!",
+		}},
+	})
+	if snapshot.Version != 2 || snapshot.Content != "你!x\n世y\n" {
+		t.Fatalf("same-line unicode snapshot = %+v, want version=2 content=%q", snapshot, "你!x\n世y\n")
+	}
+
+	snapshot = requireBridgeDocumentSnapshot(t, ts.URL, "/bridge/doc/change", map[string]any{
+		"path":    filePath,
+		"version": 3,
+		"changes": []bridgeDocChange{{
+			Range: &bridgeDocRange{
+				Start: bridgeDocPosition{Line: 0, Character: 2},
+				End:   bridgeDocPosition{Line: 1, Character: 1},
+			},
+			Text: "++",
+		}},
+	})
+	if snapshot.Version != 3 || snapshot.Content != "你!++y\n" {
+		t.Fatalf("cross-line unicode snapshot = %+v, want version=3 content=%q", snapshot, "你!++y\n")
+	}
+
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/save", map[string]any{
+		"path": filePath,
+	})
+	if got := string(fs.files[filePath]); got != "你!++y\n" {
+		t.Fatalf("saved unicode content = %q, want %q", got, "你!++y\n")
+	}
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -39,6 +39,7 @@ type Server struct {
 	githubAuth       *gitauth.Service
 	fileWatchHub     *FileWatchHub
 	bridgeManager    *vscode.BridgeManager
+	documentSync     *vscode.DocumentSyncService
 }
 
 // NewServer creates a new API server.
@@ -57,12 +58,18 @@ func NewServer(fs FileSystem, sessionIndex *claude.SessionIndex, pm *claude.Proc
 		diagnosticRunner: diagRunner,
 		githubAuth:       authService,
 		fileWatchHub:     NewFileWatchHub(),
+		documentSync:     newDocumentSyncService(fs),
 	}
 }
 
 // SetBridgeManager injects the bridge lifecycle manager after server construction.
 func (s *Server) SetBridgeManager(manager *vscode.BridgeManager) {
 	s.bridgeManager = manager
+}
+
+// SetDocumentSync injects the bridge-backed document sync service.
+func (s *Server) SetDocumentSync(service *vscode.DocumentSyncService) {
+	s.documentSync = service
 }
 
 // Handler returns the top-level HTTP handler with all routes.
@@ -95,6 +102,10 @@ func (s *Server) Handler() http.Handler {
 	// Diagnostics endpoint.
 	mux.HandleFunc("GET /api/diagnostics", s.handleDiagnostics)
 	mux.HandleFunc("GET /bridge/capabilities", s.handleBridgeCapabilities)
+	mux.HandleFunc("POST /bridge/doc/open", s.handleBridgeDocumentOpen)
+	mux.HandleFunc("POST /bridge/doc/change", s.handleBridgeDocumentChange)
+	mux.HandleFunc("POST /bridge/doc/save", s.handleBridgeDocumentSave)
+	mux.HandleFunc("POST /bridge/doc/close", s.handleBridgeDocumentClose)
 	mux.HandleFunc("GET /bridge/terminal/sessions", s.handleTerminalSessions)
 	mux.HandleFunc("POST /bridge/terminal/create", s.handleTerminalCreate)
 	mux.HandleFunc("POST /bridge/terminal/attach", s.handleTerminalAttach)
@@ -182,4 +193,23 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 
 func (s *Server) githubAuthService() *gitauth.Service {
 	return s.githubAuth
+}
+
+func newDocumentSyncService(fs FileSystem) *vscode.DocumentSyncService {
+	if fs == nil {
+		return vscode.NewDocumentSyncService(nil)
+	}
+	return vscode.NewDocumentSyncService(fileSystemDocumentStore{fs: fs})
+}
+
+type fileSystemDocumentStore struct {
+	fs FileSystem
+}
+
+func (s fileSystemDocumentStore) ReadFile(path string) ([]byte, error) {
+	return s.fs.ReadFile(path)
+}
+
+func (s fileSystemDocumentStore) WriteFile(path string, content []byte) error {
+	return s.fs.WriteFile(path, content)
 }

--- a/server/internal/vscode/bridge.go
+++ b/server/internal/vscode/bridge.go
@@ -8,8 +8,11 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
+	"unicode/utf16"
+	"unicode/utf8"
 )
 
 const (
@@ -441,4 +444,363 @@ func cloneMap(src map[string]interface{}) map[string]interface{} {
 		dst[k] = v
 	}
 	return dst
+}
+
+// DocumentPosition identifies a zero-based line/character location in a text buffer.
+type DocumentPosition struct {
+	Line      int `json:"line"`
+	Character int `json:"character"`
+}
+
+// DocumentRange identifies the half-open span to replace.
+type DocumentRange struct {
+	Start DocumentPosition `json:"start"`
+	End   DocumentPosition `json:"end"`
+}
+
+// DocumentChange describes either a full-buffer replacement or a ranged edit.
+type DocumentChange struct {
+	Range *DocumentRange `json:"range,omitempty"`
+	Text  string         `json:"text"`
+}
+
+// DocumentSnapshot exposes the current in-memory document state.
+type DocumentSnapshot struct {
+	Path    string `json:"path"`
+	Version int    `json:"version"`
+	Content string `json:"content,omitempty"`
+}
+
+// DocumentManagerOptions configures runtime-backed load/save hooks.
+type DocumentManagerOptions struct {
+	Load func(path string) ([]byte, error)
+	Save func(path string, content []byte) error
+}
+
+// DocumentStore is the runtime-backed persistence contract for document sync.
+type DocumentStore interface {
+	ReadFile(path string) ([]byte, error)
+	WriteFile(path string, content []byte) error
+}
+
+type documentSession struct {
+	path    string
+	version int
+	content string
+}
+
+// DocumentManager tracks unsaved document buffers independently from on-disk content.
+type DocumentManager struct {
+	mu     sync.RWMutex
+	loadFn func(path string) ([]byte, error)
+	saveFn func(path string, content []byte) error
+
+	sessions map[string]*documentSession
+}
+
+// DocumentSyncService exposes the bridge document lifecycle used by the API layer.
+type DocumentSyncService struct {
+	manager *DocumentManager
+}
+
+// NewDocumentSyncService creates a document sync service backed by the provided store.
+func NewDocumentSyncService(store DocumentStore) *DocumentSyncService {
+	opts := DocumentManagerOptions{}
+	if store != nil {
+		opts.Load = store.ReadFile
+		opts.Save = store.WriteFile
+	}
+	return &DocumentSyncService{
+		manager: NewDocumentManager(opts),
+	}
+}
+
+// NewDocumentManager creates a document session manager.
+func NewDocumentManager(opts DocumentManagerOptions) *DocumentManager {
+	return &DocumentManager{
+		loadFn:   opts.Load,
+		saveFn:   opts.Save,
+		sessions: make(map[string]*documentSession),
+	}
+}
+
+// OpenDocument starts or replaces the tracked session for path.
+func (s *DocumentSyncService) OpenDocument(path string, version int, content *string) (DocumentSnapshot, error) {
+	if s == nil || s.manager == nil {
+		return DocumentSnapshot{}, newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", nil)
+	}
+	return s.manager.OpenDocument(path, version, content)
+}
+
+// ApplyDocumentChanges applies a versioned batch of incremental edits.
+func (s *DocumentSyncService) ApplyDocumentChanges(path string, version int, changes []DocumentChange) (DocumentSnapshot, error) {
+	if s == nil || s.manager == nil {
+		return DocumentSnapshot{}, newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", nil)
+	}
+	return s.manager.ApplyDocumentChanges(path, version, changes)
+}
+
+// SaveDocument persists the latest accepted in-memory buffer.
+func (s *DocumentSyncService) SaveDocument(path string) (DocumentSnapshot, error) {
+	if s == nil || s.manager == nil {
+		return DocumentSnapshot{}, newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", nil)
+	}
+	return s.manager.SaveDocument(path)
+}
+
+// CloseDocument releases the tracked session for path.
+func (s *DocumentSyncService) CloseDocument(path string) error {
+	if s == nil || s.manager == nil {
+		return newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", nil)
+	}
+	return s.manager.CloseDocument(path)
+}
+
+// DocumentBuffer returns the latest unsaved buffer for an open document.
+func (s *DocumentSyncService) DocumentBuffer(path string) (DocumentSnapshot, error) {
+	if s == nil || s.manager == nil {
+		return DocumentSnapshot{}, newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", nil)
+	}
+	return s.manager.DocumentBuffer(path)
+}
+
+func (m *DocumentManager) OpenDocument(path string, version int, content *string) (DocumentSnapshot, error) {
+	if m == nil {
+		return DocumentSnapshot{}, newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", nil)
+	}
+	if strings.TrimSpace(path) == "" {
+		return DocumentSnapshot{}, newBridgeError("invalid_request", "document path is required", nil)
+	}
+	if version < 0 {
+		return DocumentSnapshot{}, newBridgeError("invalid_request", "document version must be zero or greater", nil)
+	}
+
+	m.mu.Lock()
+	if session, ok := m.sessions[path]; ok {
+		snapshot, err := reconcileOpenDocument(session, version, content)
+		m.mu.Unlock()
+		return snapshot, err
+	}
+	m.mu.Unlock()
+
+	var initial string
+	if content != nil {
+		initial = *content
+	} else if m.loadFn != nil {
+		data, err := m.loadFn(path)
+		if err != nil {
+			return DocumentSnapshot{}, newBridgeError("document_load_failed", "failed to load document content", err)
+		}
+		initial = string(data)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if session, ok := m.sessions[path]; ok {
+		return reconcileOpenDocument(session, version, content)
+	}
+	m.sessions[path] = &documentSession{
+		path:    path,
+		version: version,
+		content: initial,
+	}
+	return DocumentSnapshot{Path: path, Version: version, Content: initial}, nil
+}
+
+// ApplyDocumentChanges applies a versioned batch of incremental edits.
+func (m *DocumentManager) ApplyDocumentChanges(path string, version int, changes []DocumentChange) (DocumentSnapshot, error) {
+	if m == nil {
+		return DocumentSnapshot{}, newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", nil)
+	}
+	if strings.TrimSpace(path) == "" {
+		return DocumentSnapshot{}, newBridgeError("invalid_request", "document path is required", nil)
+	}
+	if len(changes) == 0 {
+		return DocumentSnapshot{}, newBridgeError("invalid_request", "at least one document change is required", nil)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	session, ok := m.sessions[path]
+	if !ok {
+		return DocumentSnapshot{}, newBridgeError("document_not_open", "document is not open", nil)
+	}
+	if version <= session.version {
+		return DocumentSnapshot{}, newBridgeError("version_conflict", "document version is stale", nil)
+	}
+
+	content := session.content
+	for _, change := range changes {
+		next, err := applyDocumentChange(content, change)
+		if err != nil {
+			return DocumentSnapshot{}, err
+		}
+		content = next
+	}
+
+	session.version = version
+	session.content = content
+	return DocumentSnapshot{Path: path, Version: session.version, Content: session.content}, nil
+}
+
+// SaveDocument persists the latest accepted in-memory buffer.
+func (m *DocumentManager) SaveDocument(path string) (DocumentSnapshot, error) {
+	if m == nil {
+		return DocumentSnapshot{}, newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", nil)
+	}
+	if strings.TrimSpace(path) == "" {
+		return DocumentSnapshot{}, newBridgeError("invalid_request", "document path is required", nil)
+	}
+
+	m.mu.RLock()
+	session, ok := m.sessions[path]
+	if !ok {
+		m.mu.RUnlock()
+		return DocumentSnapshot{}, newBridgeError("document_not_open", "document is not open", nil)
+	}
+	snapshot := DocumentSnapshot{Path: session.path, Version: session.version, Content: session.content}
+	saveFn := m.saveFn
+	m.mu.RUnlock()
+
+	if saveFn == nil {
+		return DocumentSnapshot{}, newBridgeError("save_unavailable", "document save is not configured", nil)
+	}
+	if err := saveFn(path, []byte(snapshot.Content)); err != nil {
+		return DocumentSnapshot{}, newBridgeError("document_save_failed", "failed to save document", err)
+	}
+	return snapshot, nil
+}
+
+// CloseDocument releases the tracked session for path.
+func (m *DocumentManager) CloseDocument(path string) error {
+	if m == nil {
+		return newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", nil)
+	}
+	if strings.TrimSpace(path) == "" {
+		return newBridgeError("invalid_request", "document path is required", nil)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.sessions[path]; !ok {
+		return newBridgeError("document_not_open", "document is not open", nil)
+	}
+	delete(m.sessions, path)
+	return nil
+}
+
+// DocumentBuffer returns the latest unsaved buffer for an open document.
+func (m *DocumentManager) DocumentBuffer(path string) (DocumentSnapshot, error) {
+	if m == nil {
+		return DocumentSnapshot{}, newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", nil)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	session, ok := m.sessions[path]
+	if !ok {
+		return DocumentSnapshot{}, newBridgeError("document_not_open", "document is not open", nil)
+	}
+	return DocumentSnapshot{Path: session.path, Version: session.version, Content: session.content}, nil
+}
+
+func applyDocumentChange(content string, change DocumentChange) (string, error) {
+	if change.Range == nil {
+		return change.Text, nil
+	}
+
+	start, end, err := resolveDocumentRange(content, *change.Range)
+	if err != nil {
+		return "", err
+	}
+	return content[:start] + change.Text + content[end:], nil
+}
+
+func resolveDocumentRange(content string, changeRange DocumentRange) (int, int, error) {
+	start, err := documentOffset(content, changeRange.Start)
+	if err != nil {
+		return 0, 0, err
+	}
+	end, err := documentOffset(content, changeRange.End)
+	if err != nil {
+		return 0, 0, err
+	}
+	if end < start {
+		return 0, 0, newBridgeError("invalid_position", "document range end precedes start", nil)
+	}
+	return start, end, nil
+}
+
+func documentOffset(content string, pos DocumentPosition) (int, error) {
+	if pos.Line < 0 || pos.Character < 0 {
+		return 0, newBridgeError("invalid_position", "document position must be zero or greater", nil)
+	}
+
+	offset := 0
+	line := 0
+	for {
+		if line == pos.Line {
+			break
+		}
+		idx := strings.IndexByte(content[offset:], '\n')
+		if idx < 0 {
+			return 0, newBridgeError("invalid_position", "document position line is out of range", nil)
+		}
+		offset += idx + 1
+		line++
+	}
+
+	lineEnd := len(content)
+	if idx := strings.IndexByte(content[offset:], '\n'); idx >= 0 {
+		lineEnd = offset + idx
+	}
+	characterOffset, err := documentCharacterOffset(content[offset:lineEnd], pos.Character)
+	if err != nil {
+		return 0, err
+	}
+	return offset + characterOffset, nil
+}
+
+func reconcileOpenDocument(session *documentSession, version int, content *string) (DocumentSnapshot, error) {
+	snapshot := DocumentSnapshot{Path: session.path, Version: session.version, Content: session.content}
+	switch {
+	case version < session.version:
+		return DocumentSnapshot{}, newBridgeError("version_conflict", "document version is stale", nil)
+	case version == session.version:
+		if content == nil || *content == session.content {
+			return snapshot, nil
+		}
+		return DocumentSnapshot{}, newBridgeError("version_conflict", "document reopen conflicts with tracked buffer", nil)
+	case content == nil:
+		return DocumentSnapshot{}, newBridgeError("version_conflict", "document reopen requires content for a newer version", nil)
+	default:
+		session.version = version
+		session.content = *content
+		return DocumentSnapshot{Path: session.path, Version: session.version, Content: session.content}, nil
+	}
+}
+
+func documentCharacterOffset(line string, character int) (int, error) {
+	offset := 0
+	remaining := character
+	for offset < len(line) {
+		if remaining == 0 {
+			return offset, nil
+		}
+		r, size := utf8.DecodeRuneInString(line[offset:])
+		width := utf16.RuneLen(r)
+		if width < 0 {
+			width = 1
+		}
+		if remaining < width {
+			return 0, newBridgeError("invalid_position", "document position character is out of range", nil)
+		}
+		offset += size
+		remaining -= width
+	}
+	if remaining != 0 {
+		return 0, newBridgeError("invalid_position", "document position character is out of range", nil)
+	}
+	return offset, nil
 }

--- a/server/internal/vscode/document_sync_test.go
+++ b/server/internal/vscode/document_sync_test.go
@@ -1,0 +1,315 @@
+package vscode
+
+import "testing"
+
+type stubDocumentStore struct {
+	files map[string][]byte
+}
+
+func newStubDocumentStore() *stubDocumentStore {
+	return &stubDocumentStore{files: make(map[string][]byte)}
+}
+
+func (s *stubDocumentStore) ReadFile(path string) ([]byte, error) {
+	return s.files[path], nil
+}
+
+func (s *stubDocumentStore) WriteFile(path string, content []byte) error {
+	s.files[path] = append([]byte(nil), content...)
+	return nil
+}
+
+func TestDocumentSyncServiceLifecycle(t *testing.T) {
+	store := newStubDocumentStore()
+	store.files["/workspace/doc.txt"] = []byte("disk")
+	svc := NewDocumentSyncService(store)
+
+	content := "draft\n"
+	snapshot, err := svc.OpenDocument("/workspace/doc.txt", 1, &content)
+	if err != nil {
+		t.Fatalf("open document: %v", err)
+	}
+	if snapshot.Content != "draft\n" || snapshot.Version != 1 {
+		t.Fatalf("unexpected open snapshot: %+v", snapshot)
+	}
+
+	snapshot, err = svc.ApplyDocumentChanges("/workspace/doc.txt", 2, []DocumentChange{{
+		Range: &DocumentRange{
+			Start: DocumentPosition{Line: 0, Character: 5},
+			End:   DocumentPosition{Line: 0, Character: 5},
+		},
+		Text: " updated",
+	}})
+	if err != nil {
+		t.Fatalf("apply changes: %v", err)
+	}
+	if snapshot.Content != "draft updated\n" || snapshot.Version != 2 {
+		t.Fatalf("unexpected change snapshot: %+v", snapshot)
+	}
+
+	latest, err := svc.DocumentBuffer("/workspace/doc.txt")
+	if err != nil {
+		t.Fatalf("get document: %v", err)
+	}
+	if latest.Content != "draft updated\n" {
+		t.Fatalf("latest content = %q, want %q", latest.Content, "draft updated\n")
+	}
+
+	if string(store.files["/workspace/doc.txt"]) != "disk" {
+		t.Fatalf("disk content before save = %q, want unchanged", string(store.files["/workspace/doc.txt"]))
+	}
+
+	snapshot, err = svc.SaveDocument("/workspace/doc.txt")
+	if err != nil {
+		t.Fatalf("save document: %v", err)
+	}
+	if string(store.files["/workspace/doc.txt"]) != "draft updated\n" {
+		t.Fatalf("saved content = %q, want %q", string(store.files["/workspace/doc.txt"]), "draft updated\n")
+	}
+
+	if err := svc.CloseDocument("/workspace/doc.txt"); err != nil {
+		t.Fatalf("close document: %v", err)
+	}
+	if _, err := svc.DocumentBuffer("/workspace/doc.txt"); err == nil {
+		t.Fatal("expected get after close to fail")
+	}
+}
+
+func TestDocumentSyncServiceRejectsStaleVersionWithoutMutatingBuffer(t *testing.T) {
+	svc := NewDocumentSyncService(newStubDocumentStore())
+	content := "hello"
+	if _, err := svc.OpenDocument("/workspace/conflict.txt", 1, &content); err != nil {
+		t.Fatalf("open document: %v", err)
+	}
+	if _, err := svc.ApplyDocumentChanges("/workspace/conflict.txt", 2, []DocumentChange{{Text: "good"}}); err != nil {
+		t.Fatalf("first change: %v", err)
+	}
+
+	_, err := svc.ApplyDocumentChanges("/workspace/conflict.txt", 2, []DocumentChange{{Text: "bad"}})
+	if err == nil {
+		t.Fatal("expected stale version conflict")
+	}
+	bridgeErr, ok := err.(*BridgeError)
+	if !ok || bridgeErr.Code != "version_conflict" {
+		t.Fatalf("stale version error = %#v, want version_conflict", err)
+	}
+
+	snapshot, err := svc.DocumentBuffer("/workspace/conflict.txt")
+	if err != nil {
+		t.Fatalf("get document: %v", err)
+	}
+	if snapshot.Content != "good" {
+		t.Fatalf("content after stale version = %q, want %q", snapshot.Content, "good")
+	}
+}
+
+func TestDocumentSyncServiceRejectsInvalidPositionWithoutMutatingBuffer(t *testing.T) {
+	svc := NewDocumentSyncService(newStubDocumentStore())
+	content := "hello\nworld\n"
+	if _, err := svc.OpenDocument("/workspace/invalid.txt", 1, &content); err != nil {
+		t.Fatalf("open document: %v", err)
+	}
+
+	_, err := svc.ApplyDocumentChanges("/workspace/invalid.txt", 2, []DocumentChange{{
+		Range: &DocumentRange{
+			Start: DocumentPosition{Line: 5, Character: 0},
+			End:   DocumentPosition{Line: 5, Character: 0},
+		},
+		Text: "boom",
+	}})
+	if err == nil {
+		t.Fatal("expected invalid position error")
+	}
+	bridgeErr, ok := err.(*BridgeError)
+	if !ok || bridgeErr.Code != "invalid_position" {
+		t.Fatalf("invalid position error = %#v, want invalid_position", err)
+	}
+
+	snapshot, err := svc.DocumentBuffer("/workspace/invalid.txt")
+	if err != nil {
+		t.Fatalf("get document: %v", err)
+	}
+	if snapshot.Content != "hello\nworld\n" {
+		t.Fatalf("content after invalid change = %q, want original buffer", snapshot.Content)
+	}
+}
+
+func TestDocumentSyncServiceDuplicateOpen_IdempotentSameVersionReusesExistingBuffer(t *testing.T) {
+	svc := NewDocumentSyncService(newStubDocumentStore())
+	content := "draft"
+	if _, err := svc.OpenDocument("/workspace/reopen.txt", 1, &content); err != nil {
+		t.Fatalf("open document: %v", err)
+	}
+	if _, err := svc.ApplyDocumentChanges("/workspace/reopen.txt", 2, []DocumentChange{{
+		Range: &DocumentRange{
+			Start: DocumentPosition{Line: 0, Character: 5},
+			End:   DocumentPosition{Line: 0, Character: 5},
+		},
+		Text: " ok",
+	}}); err != nil {
+		t.Fatalf("apply changes: %v", err)
+	}
+
+	reopenContent := "draft ok"
+	snapshot, err := svc.OpenDocument("/workspace/reopen.txt", 2, &reopenContent)
+	if err != nil {
+		t.Fatalf("idempotent reopen: %v", err)
+	}
+	if snapshot.Version != 2 || snapshot.Content != "draft ok" {
+		t.Fatalf("reopen snapshot = %+v, want version=2 content=%q", snapshot, "draft ok")
+	}
+
+	latest, err := svc.DocumentBuffer("/workspace/reopen.txt")
+	if err != nil {
+		t.Fatalf("get document: %v", err)
+	}
+	if latest.Version != 2 || latest.Content != "draft ok" {
+		t.Fatalf("buffer after reopen = %+v, want version=2 content=%q", latest, "draft ok")
+	}
+}
+
+func TestDocumentSyncServiceDuplicateOpen_RejectsStaleOrConflictingReopenWithoutMutatingBuffer(t *testing.T) {
+	svc := NewDocumentSyncService(newStubDocumentStore())
+	content := "draft"
+	if _, err := svc.OpenDocument("/workspace/reopen-conflict.txt", 1, &content); err != nil {
+		t.Fatalf("open document: %v", err)
+	}
+	if _, err := svc.ApplyDocumentChanges("/workspace/reopen-conflict.txt", 2, []DocumentChange{{
+		Range: &DocumentRange{
+			Start: DocumentPosition{Line: 0, Character: 5},
+			End:   DocumentPosition{Line: 0, Character: 5},
+		},
+		Text: " ok",
+	}}); err != nil {
+		t.Fatalf("apply changes: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		version int
+		content string
+	}{
+		{name: "stale version", version: 1, content: "draft"},
+		{name: "conflicting same version", version: 2, content: "other"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.OpenDocument("/workspace/reopen-conflict.txt", tc.version, &tc.content)
+			if err == nil {
+				t.Fatal("expected reopen to fail")
+			}
+			bridgeErr, ok := err.(*BridgeError)
+			if !ok || bridgeErr.Code != "version_conflict" {
+				t.Fatalf("reopen error = %#v, want version_conflict", err)
+			}
+
+			latest, err := svc.DocumentBuffer("/workspace/reopen-conflict.txt")
+			if err != nil {
+				t.Fatalf("get document: %v", err)
+			}
+			if latest.Version != 2 || latest.Content != "draft ok" {
+				t.Fatalf("buffer after rejected reopen = %+v, want version=2 content=%q", latest, "draft ok")
+			}
+		})
+	}
+}
+
+func TestDocumentSyncServiceApplyDocumentChanges_UnicodeRanges(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		initial     string
+		version     int
+		changes     []DocumentChange
+		wantContent string
+	}{
+		{
+			name:    "same line after multibyte character",
+			initial: "A你B\n",
+			version: 2,
+			changes: []DocumentChange{{
+				Range: &DocumentRange{
+					Start: DocumentPosition{Line: 0, Character: 2},
+					End:   DocumentPosition{Line: 0, Character: 2},
+				},
+				Text: "!",
+			}},
+			wantContent: "A你!B\n",
+		},
+		{
+			name:    "cross line span across multibyte characters",
+			initial: "你!x\n世y\n",
+			version: 3,
+			changes: []DocumentChange{{
+				Range: &DocumentRange{
+					Start: DocumentPosition{Line: 0, Character: 2},
+					End:   DocumentPosition{Line: 1, Character: 1},
+				},
+				Text: "++",
+			}},
+			wantContent: "你!++y\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := NewDocumentSyncService(newStubDocumentStore())
+			if _, err := svc.OpenDocument("/workspace/unicode.txt", 1, &tc.initial); err != nil {
+				t.Fatalf("open document: %v", err)
+			}
+
+			snapshot, err := svc.ApplyDocumentChanges("/workspace/unicode.txt", tc.version, tc.changes)
+			if err != nil {
+				t.Fatalf("apply unicode change: %v", err)
+			}
+			if snapshot.Version != tc.version || snapshot.Content != tc.wantContent {
+				t.Fatalf("snapshot after unicode change = %+v, want version=%d content=%q", snapshot, tc.version, tc.wantContent)
+			}
+
+			latest, err := svc.DocumentBuffer("/workspace/unicode.txt")
+			if err != nil {
+				t.Fatalf("get document: %v", err)
+			}
+			if latest.Content != tc.wantContent {
+				t.Fatalf("buffer after unicode change = %q, want %q", latest.Content, tc.wantContent)
+			}
+		})
+	}
+}
+
+func TestDocumentSyncServiceRequiresOpenDocumentForChangeSaveAndClose(t *testing.T) {
+	svc := NewDocumentSyncService(newStubDocumentStore())
+
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "change",
+			run: func() error {
+				_, err := svc.ApplyDocumentChanges("/workspace/missing.txt", 1, []DocumentChange{{Text: "ignored"}})
+				return err
+			},
+		},
+		{
+			name: "save",
+			run: func() error {
+				_, err := svc.SaveDocument("/workspace/missing.txt")
+				return err
+			},
+		},
+		{
+			name: "close",
+			run: func() error {
+				return svc.CloseDocument("/workspace/missing.txt")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run()
+			if err == nil {
+				t.Fatal("expected document_not_open error")
+			}
+			bridgeErr, ok := err.(*BridgeError)
+			if !ok || bridgeErr.Code != "document_not_open" {
+				t.Fatalf("%s error = %#v, want document_not_open", tc.name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed
- Replays the already-landed ASE-42 document sync patch on a review-only branch so GitHub can host a PR against `main`
- Covers the Go-side document lifecycle endpoints for `open`, `change`, `save`, and `close`
- Includes version tracking, conflict handling, invalid position handling, unsaved buffer reads, and focused API/service tests

## Why
- The ASE-42 implementation was merged directly to `main` as `d48f1ccc628179ebeece73ccc1a26652a2595707` before the PR workflow ran
- This branch preserves the exact code delta for human review without inventing unrelated code changes

## GitHub issue
- Closes #3

## Validation
- `cd server && /home/ddq/go-sdk/go/bin/go test -json ./internal/vscode ./internal/api`
- `cd server && /home/ddq/go-sdk/go/bin/go vet ./...`

## Notes
- The review branch commit is a replay of the landed patch, not a second implementation
- `openvscode-server/` is still uninitialized in the workspace, so extension-side runtime adapter validation remains out of scope here
