### PR TITLE
ASE-51: finalize repo binding backend review gate

### DIFF
--- a/server/internal/api/terminal_bridge_test.go
+++ b/server/internal/api/terminal_bridge_test.go
@@ -19,13 +19,14 @@ import (
 type terminalSessionEnvelope map[string]any
 
 type terminalStreamEnvelope struct {
-	Type  string                 `json:"type"`
-	Data  string                 `json:"data,omitempty"`
-	Error string                 `json:"error,omitempty"`
-	Exit  any                    `json:"exit,omitempty"`
-	Meta  map[string]any         `json:"meta,omitempty"`
-	Ready map[string]any         `json:"ready,omitempty"`
-	Extra map[string]interface{} `json:"-"`
+	Type    string                 `json:"type"`
+	Data    string                 `json:"data,omitempty"`
+	Error   string                 `json:"error,omitempty"`
+	Exit    any                    `json:"exit,omitempty"`
+	Meta    map[string]any         `json:"meta,omitempty"`
+	Ready   map[string]any         `json:"ready,omitempty"`
+	Session map[string]any         `json:"session,omitempty"`
+	Extra   map[string]interface{} `json:"-"`
 }
 
 type terminalLifecycleEvent struct {
@@ -171,6 +172,22 @@ func waitForTerminalEventType(t *testing.T, conn *websocket.Conn, want string) t
 	return terminalLifecycleEvent{}
 }
 
+func waitForTerminalExitEnvelope(t *testing.T, conn *websocket.Conn) terminalStreamEnvelope {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		msg := readTerminalEnvelope(t, conn)
+		switch msg.Type {
+		case "exit":
+			return msg
+		case "error":
+			t.Fatalf("received terminal error before exit: %s", msg.Error)
+		}
+	}
+	t.Fatal("timed out waiting for terminal exit envelope")
+	return terminalStreamEnvelope{}
+}
+
 func TestTerminalBridgeSessionLifecycleRESTContract(t *testing.T) {
 	ts := newReadyTerminalBridgeServer(t)
 
@@ -295,6 +312,93 @@ func TestTerminalBridgeWebSocketReadyInputOutputExitAndReconnect(t *testing.T) {
 		}
 	}
 	t.Fatal("timed out waiting for terminal exit envelope")
+}
+
+func TestTerminalBridgeExitedSessionReattachReplaysBacklogAndExplicitCloseEmitsClosedEvent(t *testing.T) {
+	ts, _, _ := newTestServer(t, "")
+	events := dialBridgeEvents(t, ts.URL)
+
+	createdResp, created := postTerminalJSON(t, ts.URL, "/bridge/terminal/create", map[string]any{
+		"name":    "exit-bridge",
+		"cwd":     t.TempDir(),
+		"profile": "bash",
+		"rows":    24,
+		"cols":    80,
+	})
+	defer createdResp.Body.Close()
+	if createdResp.StatusCode != http.StatusOK {
+		t.Fatalf("create status = %d, want %d body=%#v", createdResp.StatusCode, http.StatusOK, created)
+	}
+	sessionID, _ := created["id"].(string)
+	_ = waitForTerminalEventType(t, events, "terminal/session.created")
+
+	conn := dialTerminalStream(t, ts.URL, sessionID)
+	ready := readTerminalEnvelope(t, conn)
+	if ready.Type != "ready" {
+		t.Fatalf("initial stream envelope type = %q, want ready", ready.Type)
+	}
+
+	encodedExit := base64.StdEncoding.EncodeToString([]byte("echo exited-backlog\nexit 9\n"))
+	if err := conn.WriteJSON(map[string]any{"type": "input", "data": encodedExit}); err != nil {
+		t.Fatalf("write exit frame: %v", err)
+	}
+	waitForTerminalOutput(t, conn, "exited-backlog")
+	_ = waitForTerminalExitEnvelope(t, conn)
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close exited websocket: %v", err)
+	}
+
+	attachResp, attached := postTerminalJSON(t, ts.URL, "/bridge/terminal/attach", map[string]any{"id": sessionID})
+	defer attachResp.Body.Close()
+	if attachResp.StatusCode != http.StatusOK {
+		t.Fatalf("attach exited status = %d, want %d body=%#v", attachResp.StatusCode, http.StatusOK, attached)
+	}
+	if attached["state"] != "exited" {
+		t.Fatalf("attached exited state = %#v, want exited", attached["state"])
+	}
+	if got, ok := attached["exitCode"].(float64); !ok || got != 9 {
+		t.Fatalf("attached exitCode = %#v, want 9", attached["exitCode"])
+	}
+
+	reconnected := dialTerminalStream(t, ts.URL, sessionID)
+	ready = readTerminalEnvelope(t, reconnected)
+	if ready.Type != "ready" {
+		t.Fatalf("reattached stream envelope type = %q, want ready", ready.Type)
+	}
+	if ready.Session["state"] != "exited" {
+		t.Fatalf("ready session state = %#v, want exited", ready.Session["state"])
+	}
+	waitForTerminalOutput(t, reconnected, "exited-backlog")
+	_ = waitForTerminalExitEnvelope(t, reconnected)
+
+	closeResp, closeBody := postTerminalJSON(t, ts.URL, "/bridge/terminal/close", map[string]any{"id": sessionID})
+	defer closeResp.Body.Close()
+	if closeResp.StatusCode != http.StatusOK {
+		t.Fatalf("close exited status = %d, want %d body=%#v", closeResp.StatusCode, http.StatusOK, closeBody)
+	}
+	if closeBody["state"] != "exited" {
+		t.Fatalf("closed session state = %#v, want exited", closeBody["state"])
+	}
+	if got, ok := closeBody["exitCode"].(float64); !ok || got != 9 {
+		t.Fatalf("closed exitCode = %#v, want 9", closeBody["exitCode"])
+	}
+
+	closedEvent := waitForTerminalEventType(t, events, "terminal/session.closed")
+	if closedEvent.Payload["id"] != sessionID {
+		t.Fatalf("closed event id = %#v, want %q", closedEvent.Payload["id"], sessionID)
+	}
+	if closedEvent.Payload["state"] != "exited" {
+		t.Fatalf("closed event state = %#v, want exited", closedEvent.Payload["state"])
+	}
+	if got, ok := closedEvent.Payload["exitCode"].(float64); !ok || got != 9 {
+		t.Fatalf("closed event exitCode = %#v, want 9", closedEvent.Payload["exitCode"])
+	}
+
+	missingResp, missingBody := postTerminalJSON(t, ts.URL, "/bridge/terminal/attach", map[string]any{"id": sessionID})
+	defer missingResp.Body.Close()
+	if missingResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("attach after close status = %d, want %d body=%#v", missingResp.StatusCode, http.StatusNotFound, missingBody)
+	}
 }
 
 func TestTerminalBridgeLifecycleEventsFlowThroughUnifiedEventStreamWithoutBridgeManagerDependency(t *testing.T) {

--- a/server/internal/terminal/terminal.go
+++ b/server/internal/terminal/terminal.go
@@ -245,13 +245,20 @@ func (t *Terminal) attach() *Attachment {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	output := make(chan []byte, 32)
-	t.subscribers[output] = struct{}{}
 	backlog := append([]byte(nil), t.backlog...)
 
 	if t.state == StateExited {
+		output := make(chan []byte)
 		close(output)
+		return &Attachment{
+			backlog: backlog,
+			output:  output,
+			closeFn: func() {},
+		}
 	}
+
+	output := make(chan []byte, 32)
+	t.subscribers[output] = struct{}{}
 
 	return &Attachment{
 		backlog: backlog,

--- a/server/internal/terminal/terminal_test.go
+++ b/server/internal/terminal/terminal_test.go
@@ -161,6 +161,26 @@ func TestExitStatePersistsForReattachUntilClose(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for exited attachment stream to close")
 	}
+
+	// Closing an exited attachment should be safe even after the output channel is drained.
+	replay.Close()
+	replay.Close()
+
+	closeAllDone := make(chan struct{})
+	go func() {
+		m.CloseAll()
+		close(closeAllDone)
+	}()
+
+	select {
+	case <-closeAllDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for CloseAll after exited attachment cleanup")
+	}
+
+	if _, ok := m.Get(term.ID); ok {
+		t.Fatal("expected CloseAll to remove exited session from manager")
+	}
 }
 
 func TestCloseBroadcastsClosedEventAndRemovesSession(t *testing.T) {
@@ -189,6 +209,62 @@ func TestCloseBroadcastsClosedEventAndRemovesSession(t *testing.T) {
 
 	if _, ok := m.Get(term.ID); ok {
 		t.Fatal("expected closed session to be removed from manager")
+	}
+}
+
+func TestCloseExitedSessionBroadcastsClosedEventAndRemovesSession(t *testing.T) {
+	m := NewManager()
+	events, unsubscribe := m.SubscribeEvents()
+	defer unsubscribe()
+
+	term, err := m.CreateSession(CreateOptions{Name: "close-after-exit", Shell: "/bin/bash", WorkDir: "/tmp"})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	_ = waitForManagerEvent(t, events, 3*time.Second, "terminal/session.created")
+
+	if _, err := term.Write([]byte("exit 9\n")); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	select {
+	case <-term.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for terminal to exit")
+	}
+
+	exited := term.Snapshot()
+	if exited.State != StateExited {
+		t.Fatalf("session state after exit = %q, want %q", exited.State, StateExited)
+	}
+	if exited.ExitCode == nil || *exited.ExitCode != 9 {
+		t.Fatalf("stored exit code after exit = %+v, want 9", exited.ExitCode)
+	}
+
+	closed, err := m.CloseSession(term.ID)
+	if err != nil {
+		t.Fatalf("CloseSession failed after exit: %v", err)
+	}
+	if closed.State != StateExited {
+		t.Fatalf("closed session state = %q, want %q", closed.State, StateExited)
+	}
+	if closed.ExitCode == nil || *closed.ExitCode != 9 {
+		t.Fatalf("closed exit code = %+v, want 9", closed.ExitCode)
+	}
+
+	event := waitForManagerEvent(t, events, 3*time.Second, "terminal/session.closed")
+	if event.Session.ID != term.ID {
+		t.Fatalf("closed event id = %q, want %q", event.Session.ID, term.ID)
+	}
+	if event.Session.State != StateExited {
+		t.Fatalf("closed event state = %q, want %q", event.Session.State, StateExited)
+	}
+	if event.Session.ExitCode == nil || *event.Session.ExitCode != 9 {
+		t.Fatalf("closed event exit code = %+v, want 9", event.Session.ExitCode)
+	}
+
+	if _, ok := m.Get(term.ID); ok {
+		t.Fatal("expected explicitly closed exited session to be removed from manager")
 	}
 }
 


### PR DESCRIPTION
## Summary
- carry the already-validated ASE-51 review branch as a PR so the ticket has the required GitHub review artifact
- keep the repo binding backend work green by including the follow-up terminal session cleanup fix that removes the flaky full-suite blocker encountered during ASE-51 verification
- preserve the GitHub repo-context contract already implemented for `/github/repos/current` and `/github/resolve-local-file`

## Why
- GitHub issue: closes the delivery loop for `Lincyaw/openvsmobile#12`
- ASE-51 could not advance cleanly without an open PR and a green validation pass on the review branch

## Validation
- `cd server && /home/ddq/go-sdk/go/bin/go test ./internal/git ./internal/github ./internal/api -run 'Test(GitHubRepoContextCurrentRepoSupportsBothRoutePrefixes|GitHubRepoContextCurrentRepoReportsStructuredErrors|GitHubResolveLocalFileHandlesExistingMissingAndEscapingPaths|GitHubRepoContextCurrentRepoSupportsSSHRemote|GitHubResolveLocalFile_EndToEndFromNestedWorkspace)$' -count=1`
- `cd server && /home/ddq/go-sdk/go/bin/go test ./...`

## Issue
- https://github.com/Lincyaw/openvsmobile/issues/12
