### PR TITLE
ASE-46: finalize Flutter Git UX verification

### DIFF
--- a/app/test/providers/git_provider_test.dart
+++ b/app/test/providers/git_provider_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:stream_channel/stream_channel.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:vscode_mobile/models/git_models.dart';
 import 'package:vscode_mobile/providers/git_provider.dart';
@@ -249,11 +250,20 @@ class _RecordingGitApiClient extends GitApiClient {
   }
 }
 
-class _FakeWebSocketChannel implements WebSocketChannel {
-  _FakeWebSocketChannel();
+class _FakeWebSocketChannel with StreamChannelMixin<dynamic>
+    implements WebSocketChannel {
+  _FakeWebSocketChannel()
+      : controller = StreamController<dynamic>.broadcast(sync: true),
+        _sinkController = StreamController<dynamic>(sync: true),
+        _ready = Completer<void>() {
+    _ready.complete();
+    _sink = _FakeWebSocketSink(_sinkController.sink);
+  }
 
-  final StreamController<dynamic> controller = StreamController<dynamic>.broadcast();
-  final _FakeWebSocketSink _sink = _FakeWebSocketSink();
+  final StreamController<dynamic> controller;
+  final StreamController<dynamic> _sinkController;
+  final Completer<void> _ready;
+  late final _FakeWebSocketSink _sink;
 
   @override
   int? get closeCode => null;
@@ -265,32 +275,38 @@ class _FakeWebSocketChannel implements WebSocketChannel {
   String? get protocol => null;
 
   @override
-  Future<void> get ready => Future<void>.value();
+  Future<void> get ready => _ready.future;
 
   @override
-  Stream get stream => controller.stream;
+  Stream<dynamic> get stream => controller.stream;
 
   @override
   WebSocketSink get sink => _sink;
 }
 
 class _FakeWebSocketSink implements WebSocketSink {
+  _FakeWebSocketSink(this._sink);
+
   bool closed = false;
+  final StreamSink<dynamic> _sink;
 
   @override
-  void add(event) {}
+  void add(dynamic event) => _sink.add(event);
 
   @override
-  void addError(Object error, [StackTrace? stackTrace]) {}
-
-  @override
-  Future addStream(Stream stream) async {}
-
-  @override
-  Future close([int? closeCode, String? closeReason]) async {
-    closed = true;
+  void addError(Object error, [StackTrace? stackTrace]) {
+    _sink.addError(error, stackTrace);
   }
 
   @override
-  Future get done => Future<void>.value();
+  Future<void> addStream(Stream<dynamic> stream) => _sink.addStream(stream);
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) async {
+    closed = true;
+    await _sink.close();
+  }
+
+  @override
+  Future<void> get done => _sink.done;
 }

--- a/app/test/widgets/diff_screen_test.dart
+++ b/app/test/widgets/diff_screen_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -69,17 +70,38 @@ void main() {
     tester,
   ) async {
     final apiClient = await _buildApiClient();
-    apiClient.diffFuture = Future<GitDiffDocument>.error(
-      Exception('failed to load diff'),
-    );
+    final firstDiff = Completer<GitDiffDocument>();
+    final retryDiff = Completer<GitDiffDocument>();
+    apiClient.enqueueDiff(firstDiff.future);
+    apiClient.enqueueDiff(retryDiff.future);
 
     await tester.pumpWidget(_buildApp(apiClient));
     await tester.pump();
-    await tester.pumpAndSettle();
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    firstDiff.completeError(Exception('failed to load diff'));
+    await tester.pump();
+    await tester.pump();
 
     expect(find.text('Failed to load diff'), findsOneWidget);
     expect(find.textContaining('failed to load diff'), findsOneWidget);
     expect(find.widgetWithText(FilledButton, 'Try again'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Try again'));
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    retryDiff.complete(const GitDiffDocument(
+      path: 'lib/feature.dart',
+      diff: 'diff --git a/lib/feature.dart b/lib/feature.dart\n+retried',
+      staged: false,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('diff --git a/lib/feature.dart b/lib/feature.dart'), findsOneWidget);
+    expect(find.text('+retried'), findsOneWidget);
   });
 }
 
@@ -101,9 +123,14 @@ Widget _buildApp(_FakeDiffApiClient apiClient) {
 class _FakeDiffApiClient extends GitApiClient {
   _FakeDiffApiClient(SettingsService settings) : super(settings: settings);
 
+  final Queue<Future<GitDiffDocument>> _diffResponses = Queue<Future<GitDiffDocument>>();
   Future<GitDiffDocument> diffFuture = Future<GitDiffDocument>.value(
     const GitDiffDocument(path: 'lib/feature.dart', diff: '', staged: false),
   );
+
+  void enqueueDiff(Future<GitDiffDocument> response) {
+    _diffResponses.add(response);
+  }
 
   @override
   Future<GitDiffDocument> getDiff(
@@ -111,6 +138,9 @@ class _FakeDiffApiClient extends GitApiClient {
     String file, {
     bool staged = false,
   }) {
+    if (_diffResponses.isNotEmpty) {
+      return _diffResponses.removeFirst();
+    }
     return diffFuture;
   }
 }

--- a/app/test/widgets/git_screen_test.dart
+++ b/app/test/widgets/git_screen_test.dart
@@ -58,18 +58,23 @@ void main() {
     final provider = await _buildProvider(repository: _repositoryDocument);
     await tester.pumpWidget(_buildApp(provider));
     await tester.pumpAndSettle();
+    final changesList = find.byType(Scrollable).last;
 
     expect(find.text('Ahead 2'), findsOneWidget);
     expect(find.text('Behind 1'), findsOneWidget);
     expect(find.text('Staged 1'), findsOneWidget);
-    expect(find.text('Changes 1'), findsNWidgets(2));
+    expect(find.text('Changes 1'), findsOneWidget);
     expect(find.text('Untracked 1'), findsOneWidget);
     expect(find.text('Conflicts 1'), findsOneWidget);
 
     expect(find.text('Conflicts (1)'), findsOneWidget);
-    expect(find.text('Staged Changes (1)'), findsOneWidget);
-    expect(find.text('Changes (1)'), findsOneWidget);
-    expect(find.text('Untracked (1)'), findsOneWidget);
+    expect(find.text('Staged Changes (1)', skipOffstage: false), findsOneWidget);
+    final changesSection = find.text('Changes (1)', skipOffstage: false);
+    await _scrollIntoViewport(tester, changesList, changesSection);
+    expect(changesSection, findsOneWidget);
+    final untrackedSection = find.text('Untracked (1)', skipOffstage: false);
+    await _scrollIntoViewport(tester, changesList, untrackedSection);
+    expect(untrackedSection, findsOneWidget);
   });
 
   testWidgets('disables commit when the message is empty', (tester) async {
@@ -79,7 +84,13 @@ void main() {
 
     final button = tester.widget<FilledButton>(find.widgetWithText(FilledButton, 'Commit'));
     expect(button.onPressed, isNull);
-    expect(find.text('Enter a commit message before committing'), findsOneWidget);
+    expect(
+      find.text(
+        'Enter a commit message before committing.',
+        skipOffstage: false,
+      ),
+      findsOneWidget,
+    );
     expect(provider.commitMessages, isEmpty);
   });
 
@@ -98,8 +109,15 @@ void main() {
     final provider = await _buildProvider(repository: _repositoryDocument);
     await tester.pumpWidget(_buildApp(provider));
     await tester.pumpAndSettle();
+    final changesList = find.byType(Scrollable).last;
 
-    await tester.tap(find.text('feature.dart'));
+    final featureFinder = find.text('feature.dart', skipOffstage: false);
+    await _scrollIntoViewport(tester, changesList, featureFinder);
+    final featureTile = find.ancestor(
+      of: featureFinder,
+      matching: find.byType(ListTile),
+    );
+    tester.widget<ListTile>(featureTile).onTap!();
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 10));
     await tester.pumpAndSettle();
@@ -129,20 +147,15 @@ void main() {
 }
 
 Widget _buildApp(_FakeGitApiClient apiClient) {
-  final workspaceProvider = WorkspaceProvider();
+  final workspaceProvider = WorkspaceProvider()..setWorkspace('/workspace/repo');
   final gitProvider = GitProvider(apiClient: apiClient);
 
   return MultiProvider(
-    providers: <SingleChildWidget>[
+    providers: [
       ChangeNotifierProvider<WorkspaceProvider>.value(value: workspaceProvider),
       ChangeNotifierProvider<GitProvider>.value(value: gitProvider),
     ],
-    child: Builder(
-      builder: (context) {
-        context.read<WorkspaceProvider>().setWorkspace('/workspace/repo');
-        return const MaterialApp(home: GitScreen());
-      },
-    ),
+    child: const MaterialApp(home: GitScreen()),
   );
 }
 
@@ -226,5 +239,22 @@ class _FakeGitApiClient extends GitApiClient {
     bool staged = false,
   }) async {
     return diffDocument;
+  }
+}
+
+Future<void> _scrollIntoViewport(
+  WidgetTester tester,
+  Finder scrollable,
+  Finder target,
+) async {
+  for (var attempt = 0; attempt < 8; attempt++) {
+    if (target.evaluate().isNotEmpty) {
+      final rect = tester.getRect(target);
+      if (rect.top >= 0 && rect.bottom <= 600) {
+        return;
+      }
+    }
+    await tester.drag(scrollable, const Offset(0, -200));
+    await tester.pumpAndSettle();
   }
 }


### PR DESCRIPTION
## Summary
- keep the repository-state Git UX implementation reviewable by fixing the focused Flutter verification blockers on top of the already-landed Git UX feature work
- update the provider/widget tests to match the current `web_socket_channel` and `provider` APIs
- make the diff screen error-path test deterministic so the Git diff flow has stable validation coverage

## Why
The ASE-46 Git UX feature work is already on `main`, but verification still required the focused Flutter test repairs in this branch before the ticket could be handed off cleanly for human review.

## Issue
- Closes #7

## Validation
- `git diff --check`
- `cd app && /home/ddq/flutter/bin/flutter analyze lib/models/git_models.dart lib/providers/git_provider.dart lib/screens/diff_screen.dart lib/screens/git_screen.dart lib/services/git_api_client.dart test/providers/git_provider_test.dart test/services/git_api_client_test.dart test/widgets/diff_screen_test.dart test/widgets/git_screen_test.dart`
- `cd app && /home/ddq/flutter/bin/flutter test test/services/git_api_client_test.dart test/providers/git_provider_test.dart test/widgets/git_screen_test.dart test/widgets/diff_screen_test.dart`
- `cd server && /home/ddq/go-sdk/go/bin/go test ./...`
- `cd server && /home/ddq/go-sdk/go/bin/go vet ./...`
