### PR TITLE
ASE-43: finalize editor intelligence backend review fixes

### DIFF
--- a/docs/runtime-bridge-validation.md
+++ b/docs/runtime-bridge-validation.md
@@ -43,6 +43,15 @@ The helper lives at `scripts/verify_bridge_foundation.sh` and runs these checks 
 5. runs `make test` and `make lint` when Flutter is available through the repo's normal discovery rules
 6. optionally runs `TestIntegration_BridgeLifecycle_EndToEnd` when `VSCODE_INTEGRATION_TEST=1`
 
+For ASE-43's editor-intelligence bridge work, targeted server checks should also cover:
+
+- `cd server && go test ./internal/vscode ./internal/api`
+- versioned document-sync flows (`/bridge/doc/open` -> `/bridge/doc/change`) before requesting bridge editor diagnostics
+- `/bridge/ws/events` rebroadcast of diagnostics updates with the stable `{type, payload}` envelope
+- capability matrices for diagnostics, completion, hover, definition, references, signature help, formatting, code actions, rename, and document symbols
+
+The OpenVSCode-side provider adapter still depends on a populated `openvscode-server/` checkout. In a workspace where the submodule is empty, server-side validation can still exercise the API contracts and bridge metadata handling, but extension compilation and end-to-end language-provider behavior remain blocked until the submodule is restored.
+
 ## Gated checks
 
 The helper intentionally separates always-on checks from heavier environment-gated validation:

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -71,6 +71,8 @@ func main() {
 	var vsClient *vscode.Client
 	var bridgeManager *vscode.BridgeManager
 	var gitService *vscode.GitService
+	var documentSync *vscode.DocumentSyncService
+	var editorService *vscode.EditorService
 	bridgeCtx, cancelBridge := context.WithCancel(context.Background())
 	defer cancelBridge()
 	if vsCodeURL != "" {
@@ -88,7 +90,13 @@ func main() {
 		bridgeManager.Start(bridgeCtx)
 		gitService = vscode.NewGitService(vsClient, bridgeManager)
 		gitService.Start(bridgeCtx)
+		documentSync = vscode.NewDocumentSyncService(fs)
+		editorService = vscode.NewEditorService(vsClient, bridgeManager, documentSync)
+		editorService.Start(bridgeCtx)
 		log.Printf("mobile runtime bridge discovery watching %s", bridgeManager.MetadataPath())
+	}
+	if documentSync == nil {
+		documentSync = vscode.NewDocumentSyncService(fs)
 	}
 
 	termMgr := terminal.NewManager()
@@ -124,7 +132,8 @@ func main() {
 	srv := api.NewServer(fs, sessionIndex, pm, token, git.NewGit(workDir), termMgr, diagRunner, githubAuth)
 	srv.SetBridgeManager(bridgeManager)
 	srv.SetGitService(gitService)
-	srv.SetDocumentSync(vscode.NewDocumentSyncService(fs))
+	srv.SetDocumentSync(documentSync)
+	srv.SetEditorService(editorService)
 
 	httpServer := &http.Server{
 		Addr:    fmt.Sprintf(":%d", port),
@@ -158,6 +167,9 @@ func main() {
 	cancelBridge()
 	if gitService != nil {
 		gitService.Close()
+	}
+	if editorService != nil {
+		editorService.Close()
 	}
 	if bridgeManager != nil {
 		bridgeManager.Close()

--- a/server/internal/api/bridge.go
+++ b/server/internal/api/bridge.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/Lincyaw/vscode-mobile/server/internal/vscode"
@@ -35,6 +36,28 @@ type bridgeDocumentPathRequest struct {
 func (s *Server) handleBridgeCapabilities(w http.ResponseWriter, r *http.Request) {
 	if s.bridgeManager == nil {
 		writeBridgeError(w, http.StatusServiceUnavailable, "bridge_not_ready", "mobile runtime bridge is not ready")
+		return
+	}
+
+	if name := strings.TrimSpace(r.URL.Query().Get("name")); name != "" {
+		capability, err := s.bridgeManager.Capability(name)
+		if err != nil {
+			var bridgeErr *vscode.BridgeError
+			if errors.As(err, &bridgeErr) {
+				status := http.StatusServiceUnavailable
+				if bridgeErr.Code == "capability_unavailable" {
+					status = http.StatusNotFound
+				}
+				writeBridgeError(w, status, bridgeErr.Code, bridgeErr.Message)
+				return
+			}
+			writeBridgeError(w, http.StatusInternalServerError, "capability_unavailable", "failed to load mobile runtime bridge capability")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"name":       name,
+			"capability": capability,
+		})
 		return
 	}
 

--- a/server/internal/api/bridge_documents_test.go
+++ b/server/internal/api/bridge_documents_test.go
@@ -5,7 +5,14 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/Lincyaw/vscode-mobile/server/internal/claude"
+	"github.com/Lincyaw/vscode-mobile/server/internal/diagnostics"
+	"github.com/Lincyaw/vscode-mobile/server/internal/terminal"
+	"github.com/Lincyaw/vscode-mobile/server/internal/vscode"
 )
 
 type bridgeDocPosition struct {
@@ -97,6 +104,19 @@ func requireBridgeDocumentError(t *testing.T, baseURL, path string, payload any,
 	}
 	t.Fatalf("%s status = %d, want one of %v; body=%s", path, resp.StatusCode, wantStatuses, string(body))
 	return bridgeErrorDetail{}
+}
+
+func newBridgeDocumentServer(t *testing.T, fs *mockFS, manager *vscode.BridgeManager) *httptest.Server {
+	t.Helper()
+
+	sessionIndex := claude.NewSessionIndex(t.TempDir())
+	pm := claude.NewProcessManager("/nonexistent/claude", ".")
+	srv := NewServer(fs, sessionIndex, pm, "", nil, terminal.NewManager(), diagnostics.NewRunner(10*time.Second))
+	srv.SetBridgeManager(manager)
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
 }
 
 func TestBridgeDocumentLifecycle_SavePersistsLatestAcceptedBufferAndCloseCleansUp(t *testing.T) {
@@ -363,5 +383,111 @@ func TestBridgeDocumentChange_UnicodeRangesPersistLastAcceptedBuffer(t *testing.
 	})
 	if got := string(fs.files[filePath]); got != "你!++y\n" {
 		t.Fatalf("saved unicode content = %q, want %q", got, "你!++y\n")
+	}
+}
+
+func TestBridgeDocumentLifecycle_VersionedBufferFeedsDiagnosticsEventPayload(t *testing.T) {
+	fs := newMockFS()
+	const filePath = "/workspace/editor.dart"
+	fs.files[filePath] = []byte("print('disk');\n")
+
+	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{})
+	ts := newBridgeDocumentServer(t, fs, manager)
+	conn := dialBridgeEvents(t, ts.URL)
+
+	requireBridgeDocumentSnapshot(t, ts.URL, "/bridge/doc/open", map[string]any{
+		"path":    filePath,
+		"version": 1,
+		"content": "print('draft');\n",
+	})
+	snapshot := requireBridgeDocumentSnapshot(t, ts.URL, "/bridge/doc/change", map[string]any{
+		"path":    filePath,
+		"version": 2,
+		"changes": []bridgeDocChange{{
+			Range: &bridgeDocRange{
+				Start: bridgeDocPosition{Line: 0, Character: 14},
+				End:   bridgeDocPosition{Line: 0, Character: 14},
+			},
+			Text: " // unsaved",
+		}},
+	})
+	if snapshot.Version != 2 || snapshot.Content != "print('draft') // unsaved;\n" {
+		t.Fatalf("buffer snapshot = %+v, want version=2 content=%q", snapshot, "print('draft') // unsaved;\n")
+	}
+
+	manager.Publish(vscode.BridgeEvent{
+		Type: "bridge/diagnosticsChanged",
+		Payload: map[string]any{
+			"path":    filePath,
+			"version": snapshot.Version,
+			"diagnostics": []any{
+				map[string]any{
+					"severity": "warning",
+					"message":  "unsaved buffer warning",
+				},
+			},
+		},
+	})
+
+	event := readBridgeEvent(t, conn)
+	if event.Type != "bridge/diagnosticsChanged" {
+		t.Fatalf("event type = %q, want bridge/diagnosticsChanged", event.Type)
+	}
+	payload := requireEventPayload(t, event)
+	if got := requirePayloadValue(t, payload, "path"); got != filePath {
+		t.Fatalf("event path = %#v, want %q", got, filePath)
+	}
+	if got := requirePayloadValue(t, payload, "version"); got != float64(2) {
+		t.Fatalf("event version = %#v, want 2", got)
+	}
+
+	if got := string(fs.files[filePath]); got != "print('disk');\n" {
+		t.Fatalf("disk content = %q, want unsaved buffer to remain in-memory only", got)
+	}
+}
+
+func TestBridgeDocumentLifecycle_EditorDiagnosticsEndpointUsesVersionedBufferWhenAvailable(t *testing.T) {
+	fs := newMockFS()
+	const filePath = "/workspace/editor.dart"
+	fs.files[filePath] = []byte("print('disk');\n")
+
+	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{})
+	ts := newBridgeDocumentServer(t, fs, manager)
+
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/open", map[string]any{
+		"path":    filePath,
+		"version": 1,
+		"content": "print('draft');\n",
+	})
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/change", map[string]any{
+		"path":    filePath,
+		"version": 2,
+		"changes": []bridgeDocChange{{
+			Range: &bridgeDocRange{
+				Start: bridgeDocPosition{Line: 0, Character: 14},
+				End:   bridgeDocPosition{Line: 0, Character: 14},
+			},
+			Text: " // unsaved",
+		}},
+	})
+
+	resp, body := postBridgeDocumentRequest(t, ts.URL, "/bridge/editor/diagnostics", map[string]any{
+		"path":    filePath,
+		"version": 2,
+		"workDir": "/workspace",
+	})
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode /bridge/editor/diagnostics response: %v; body=%s", err, string(body))
+		}
+		if payload["path"] != filePath {
+			t.Fatalf("diagnostics path = %#v, want %q", payload["path"], filePath)
+		}
+	case http.StatusNotFound:
+		t.Skip("editor diagnostics endpoint not implemented yet")
+	default:
+		t.Fatalf("/bridge/editor/diagnostics status = %d, want 200 once implemented or 404 while pending; body=%s", resp.StatusCode, string(body))
 	}
 }

--- a/server/internal/api/bridge_test.go
+++ b/server/internal/api/bridge_test.go
@@ -209,6 +209,48 @@ func TestBridgeCapabilities_ReadyReturnsRFCDocument(t *testing.T) {
 	}
 }
 
+func TestBridgeCapabilities_PreservesEditorFeatureMatrix(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{MetadataPath: metadataPath, PollInterval: 20 * time.Millisecond})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager.Start(ctx)
+	defer manager.Close()
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:      "gen-editor",
+		State:           "ready",
+		ProtocolVersion: "2026-04-20",
+		BridgeVersion:   "0.3.0",
+		Capabilities: map[string]any{
+			"diagnostics": map[string]any{"enabled": true, "push": true},
+			"completion":  map[string]any{"enabled": true, "insertTextFormat": true, "textEdit": true},
+			"hover":       map[string]any{"enabled": true},
+			"definition":  map[string]any{"enabled": true},
+			"references":  map[string]any{"enabled": true},
+			"signatureHelp": map[string]any{
+				"enabled": true,
+			},
+			"formatting":      map[string]any{"enabled": false},
+			"codeActions":     map[string]any{"enabled": true},
+			"rename":          map[string]any{"enabled": false},
+			"documentSymbols": map[string]any{"enabled": true},
+		},
+	})
+
+	ts := newBridgeEnabledServer(t, manager)
+	doc := waitForReadyCapabilities(t, ts.URL)
+
+	if doc.BridgeVersion != "0.3.0" {
+		t.Fatalf("bridgeVersion = %q, want %q", doc.BridgeVersion, "0.3.0")
+	}
+	requireBoolCapability(t, map[string]any{"capabilities": doc.Capabilities}, "diagnostics", true)
+	requireBoolCapability(t, map[string]any{"capabilities": doc.Capabilities}, "completion", true)
+	requireBoolCapability(t, map[string]any{"capabilities": doc.Capabilities}, "formatting", false)
+	requireBoolCapability(t, map[string]any{"capabilities": doc.Capabilities}, "rename", false)
+	requireBoolCapability(t, map[string]any{"capabilities": doc.Capabilities}, "documentSymbols", true)
+}
+
 func TestBridgeCapabilities_NotReadyWindowRecoversToUpdatedCapabilities(t *testing.T) {
 	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
 	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{MetadataPath: metadataPath, PollInterval: 20 * time.Millisecond})
@@ -364,6 +406,69 @@ func TestBridgeEventsWebSocket_StableEnvelopeCarriesLifecyclePayloads(t *testing
 		t.Fatalf("recovered ready bridgeVersion = %#v, want %q", got, "0.2.0")
 	}
 	requireBoolCapability(t, readyPayload, "workspace", true)
+}
+
+func TestBridgeEventsWebSocket_ForwardsDiagnosticsChangedEvents(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{MetadataPath: metadataPath, PollInterval: 20 * time.Millisecond})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	manager.Start(ctx)
+	defer manager.Close()
+
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:      "gen-1",
+		State:           "ready",
+		ProtocolVersion: "2026-04-20",
+		Capabilities: map[string]any{
+			"diagnostics": map[string]any{"enabled": true},
+		},
+	})
+
+	ts := newBridgeEnabledServer(t, manager)
+	conn := dialBridgeEvents(t, ts.URL)
+	ready := readBridgeEvent(t, conn)
+	if ready.Type != "bridge/ready" {
+		t.Fatalf("first event type = %q, want bridge/ready", ready.Type)
+	}
+
+	manager.Publish(vscode.BridgeEvent{
+		Type: "bridge/diagnosticsChanged",
+		Payload: map[string]any{
+			"path":    "/workspace/lib/main.dart",
+			"version": 9,
+			"diagnostics": []any{
+				map[string]any{
+					"severity": "warning",
+					"message":  "Unused import",
+					"source":   "dart-analyzer",
+				},
+			},
+		},
+	})
+
+	event := readBridgeEvent(t, conn)
+	if event.Type != "bridge/diagnosticsChanged" {
+		t.Fatalf("event type = %q, want bridge/diagnosticsChanged", event.Type)
+	}
+	payload := requireEventPayload(t, event)
+	if got := requirePayloadValue(t, payload, "path"); got != "/workspace/lib/main.dart" {
+		t.Fatalf("path = %#v, want %q", got, "/workspace/lib/main.dart")
+	}
+	if got := requirePayloadValue(t, payload, "version"); got != float64(9) {
+		t.Fatalf("version = %#v, want 9", got)
+	}
+	diagnostics, ok := requirePayloadValue(t, payload, "diagnostics").([]any)
+	if !ok || len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %#v, want 1 entry", payload["diagnostics"])
+	}
+	first, ok := diagnostics[0].(map[string]any)
+	if !ok {
+		t.Fatalf("diagnostic[0] = %#v, want map[string]any", diagnostics[0])
+	}
+	if first["message"] != "Unused import" {
+		t.Fatalf("diagnostic message = %#v, want %q", first["message"], "Unused import")
+	}
 }
 
 func TestBridgeEventsWebSocket_DropsDisconnectedClientsWithoutBlockingLiveOnes(t *testing.T) {

--- a/server/internal/api/diagnostics.go
+++ b/server/internal/api/diagnostics.go
@@ -5,12 +5,15 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+
+	"github.com/Lincyaw/vscode-mobile/server/internal/diagnostics"
+	"github.com/Lincyaw/vscode-mobile/server/internal/vscode"
 )
 
 // handleDiagnostics handles GET /api/diagnostics?path=<file>&workDir=<dir>.
 // Returns structured diagnostic findings for the given file or directory.
 func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
-	if s.diagnosticRunner == nil {
+	if s.diagnosticRunner == nil && s.editorService == nil {
 		http.Error(w, "diagnostics not configured", http.StatusServiceUnavailable)
 		return
 	}
@@ -54,6 +57,28 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 		runErr  error
 	)
 
+	if s.editorService != nil && filePath != "" {
+		doc, err := s.editorService.Diagnostics(vscode.EditorRequest{
+			Path:    filePath,
+			WorkDir: workDir,
+		})
+		if err == nil {
+			if strings.EqualFold(r.URL.Query().Get("format"), "lsp") {
+				version := doc.Version
+				writeJSON(w, http.StatusOK, diagnosticsDocumentToReport(doc, &version))
+			} else {
+				writeJSON(w, http.StatusOK, doc.Diagnostics)
+			}
+			return
+		}
+		log.Printf("[Diagnostics] bridge diagnostics unavailable for path=%s workDir=%s: %v", filePath, workDir, err)
+	}
+
+	if s.diagnosticRunner == nil {
+		http.Error(w, "diagnostics not configured", http.StatusServiceUnavailable)
+		return
+	}
+
 	if filePath != "" {
 		results, runErr = s.diagnosticRunner.RunForFile(filePath, workDir)
 	} else {
@@ -68,5 +93,17 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("[Diagnostics] path=%s workDir=%s", filePath, workDir)
+	if strings.EqualFold(r.URL.Query().Get("format"), "lsp") && filePath != "" {
+		var version *int
+		if s.documentSync != nil {
+			if snapshot, err := s.documentSync.DocumentBuffer(filePath); err == nil {
+				version = &snapshot.Version
+			}
+		}
+		if entries, ok := results.([]diagnostics.Diagnostic); ok {
+			writeJSON(w, http.StatusOK, diagnosticsToLSPReport(filePath, version, entries))
+			return
+		}
+	}
 	writeJSON(w, http.StatusOK, results)
 }

--- a/server/internal/api/diagnostics.go
+++ b/server/internal/api/diagnostics.go
@@ -58,20 +58,31 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 	)
 
 	if s.editorService != nil && filePath != "" {
-		doc, err := s.editorService.Diagnostics(vscode.EditorRequest{
-			Path:    filePath,
-			WorkDir: workDir,
-		})
-		if err == nil {
-			if strings.EqualFold(r.URL.Query().Get("format"), "lsp") {
-				version := doc.Version
-				writeJSON(w, http.StatusOK, diagnosticsDocumentToReport(doc, &version))
-			} else {
-				writeJSON(w, http.StatusOK, doc.Diagnostics)
-			}
+		if s.documentSync == nil {
+			writeBridgeError(w, http.StatusServiceUnavailable, "bridge_not_ready", "document sync is not configured")
 			return
 		}
-		log.Printf("[Diagnostics] bridge diagnostics unavailable for path=%s workDir=%s: %v", filePath, workDir, err)
+		snapshot, err := s.documentSync.DocumentBuffer(filePath)
+		if err != nil {
+			writeEditorBridgeError(w, err)
+			return
+		}
+		doc, err := s.editorService.Diagnostics(vscode.EditorRequest{
+			Path:    filePath,
+			Version: snapshot.Version,
+			WorkDir: workDir,
+		})
+		if err != nil {
+			writeEditorBridgeError(w, err)
+			return
+		}
+		if strings.EqualFold(r.URL.Query().Get("format"), "lsp") {
+			version := doc.Version
+			writeJSON(w, http.StatusOK, diagnosticsDocumentToReport(doc, &version))
+		} else {
+			writeJSON(w, http.StatusOK, doc.Diagnostics)
+		}
+		return
 	}
 
 	if s.diagnosticRunner == nil {

--- a/server/internal/api/editor.go
+++ b/server/internal/api/editor.go
@@ -1,0 +1,257 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/Lincyaw/vscode-mobile/server/internal/diagnostics"
+	"github.com/Lincyaw/vscode-mobile/server/internal/vscode"
+)
+
+type bridgeEditorRequest struct {
+	Path     string                   `json:"path"`
+	Version  int                      `json:"version,omitempty"`
+	WorkDir  string                   `json:"workDir,omitempty"`
+	Position *vscode.DocumentPosition `json:"position,omitempty"`
+	Range    *vscode.DocumentRange    `json:"range,omitempty"`
+	Context  map[string]any           `json:"context,omitempty"`
+	Options  map[string]any           `json:"options,omitempty"`
+	NewName  string                   `json:"newName,omitempty"`
+	Query    string                   `json:"query,omitempty"`
+}
+
+func (s *Server) handleBridgeEditorDiagnostics(w http.ResponseWriter, r *http.Request) {
+	if s.editorService == nil {
+		writeBridgeError(w, http.StatusNotFound, "capability_unavailable", "editor intelligence bridge is not configured")
+		return
+	}
+
+	req, ok := decodeBridgeEditorQuery(w, r)
+	if !ok {
+		return
+	}
+	result, err := s.editorService.Diagnostics(req)
+	if err != nil {
+		writeEditorBridgeError(w, err)
+		return
+	}
+	version := result.Version
+	writeJSON(w, http.StatusOK, diagnosticsDocumentToReport(result, &version))
+}
+
+func (s *Server) handleBridgeEditorCompletion(w http.ResponseWriter, r *http.Request) {
+	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+		return s.editorService.Completion(req)
+	})
+}
+
+func (s *Server) handleBridgeEditorHover(w http.ResponseWriter, r *http.Request) {
+	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+		return s.editorService.Hover(req)
+	})
+}
+
+func (s *Server) handleBridgeEditorDefinition(w http.ResponseWriter, r *http.Request) {
+	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+		return s.editorService.Definition(req)
+	})
+}
+
+func (s *Server) handleBridgeEditorReferences(w http.ResponseWriter, r *http.Request) {
+	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+		return s.editorService.References(req)
+	})
+}
+
+func (s *Server) handleBridgeEditorSignatureHelp(w http.ResponseWriter, r *http.Request) {
+	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+		return s.editorService.SignatureHelp(req)
+	})
+}
+
+func (s *Server) handleBridgeEditorFormatting(w http.ResponseWriter, r *http.Request) {
+	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+		return s.editorService.Formatting(req)
+	})
+}
+
+func (s *Server) handleBridgeEditorCodeActions(w http.ResponseWriter, r *http.Request) {
+	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+		return s.editorService.CodeActions(req)
+	})
+}
+
+func (s *Server) handleBridgeEditorRename(w http.ResponseWriter, r *http.Request) {
+	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+		return s.editorService.Rename(req)
+	})
+}
+
+func (s *Server) handleBridgeEditorDocumentSymbols(w http.ResponseWriter, r *http.Request) {
+	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+		return s.editorService.DocumentSymbols(req)
+	})
+}
+
+func (s *Server) handleBridgeEditorRPC(w http.ResponseWriter, r *http.Request, fn func(vscode.EditorRequest) (any, error)) {
+	if s.editorService == nil {
+		writeBridgeError(w, http.StatusNotFound, "capability_unavailable", "editor intelligence bridge is not configured")
+		return
+	}
+	var raw bridgeEditorRequest
+	if !decodeBridgeDocumentRequest(w, r, &raw) {
+		return
+	}
+	req, err := sanitizeBridgeEditorRequest(raw)
+	if err != nil {
+		writeBridgeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	result, err := fn(req)
+	if err != nil {
+		writeEditorBridgeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+func decodeBridgeEditorQuery(w http.ResponseWriter, r *http.Request) (vscode.EditorRequest, bool) {
+	path := r.URL.Query().Get("path")
+	if strings.TrimSpace(path) == "" {
+		writeBridgeError(w, http.StatusBadRequest, "invalid_request", "path is required")
+		return vscode.EditorRequest{}, false
+	}
+	workDir := r.URL.Query().Get("workDir")
+	if workDir == "" {
+		workDir = "/"
+	}
+	req, err := sanitizeBridgeEditorRequest(bridgeEditorRequest{Path: path, WorkDir: workDir})
+	if err != nil {
+		writeBridgeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return vscode.EditorRequest{}, false
+	}
+	return req, true
+}
+
+func sanitizeBridgeEditorRequest(raw bridgeEditorRequest) (vscode.EditorRequest, error) {
+	path, workDir, err := sanitizeEditorPathContext(raw.Path, raw.WorkDir)
+	if err != nil {
+		return vscode.EditorRequest{}, err
+	}
+	return vscode.EditorRequest{
+		Path:     path,
+		Version:  raw.Version,
+		WorkDir:  workDir,
+		Position: raw.Position,
+		Range:    raw.Range,
+		Context:  raw.Context,
+		Options:  raw.Options,
+		NewName:  raw.NewName,
+		Query:    raw.Query,
+	}, nil
+}
+
+func sanitizeEditorPathContext(rawPath, rawWorkDir string) (string, string, error) {
+	path, err := sanitizePath(rawPath, false)
+	if err != nil {
+		return "", "", err
+	}
+	workDir := rawWorkDir
+	if workDir == "" {
+		workDir = filepath.Dir(path)
+	}
+	workDir, err = sanitizePath(workDir, true)
+	if err != nil {
+		return "", "", err
+	}
+	if path != workDir && !strings.HasPrefix(path, workDir+string(filepath.Separator)) {
+		return "", "", errors.New("path must be within workDir")
+	}
+	return path, workDir, nil
+}
+
+func writeEditorBridgeError(w http.ResponseWriter, err error) {
+	var bridgeErr *vscode.BridgeError
+	if errors.As(err, &bridgeErr) {
+		status := http.StatusBadGateway
+		switch bridgeErr.Code {
+		case "invalid_request", "invalid_position":
+			status = http.StatusBadRequest
+		case "bridge_not_ready":
+			status = http.StatusServiceUnavailable
+		case "capability_unavailable":
+			status = http.StatusNotImplemented
+		case "document_not_open":
+			status = http.StatusNotFound
+		}
+		writeBridgeError(w, status, bridgeErr.Code, bridgeErr.Message)
+		return
+	}
+	writeBridgeError(w, http.StatusInternalServerError, "bridge_error", "bridge editor request failed")
+}
+
+func diagnosticsToLSPReport(path string, version *int, entries []diagnostics.Diagnostic) vscode.EditorDiagnosticReport {
+	report := vscode.EditorDiagnosticReport{
+		URI:         pathToDocumentURI(path),
+		Path:        path,
+		Version:     version,
+		Diagnostics: make([]vscode.EditorDiagnostic, 0, len(entries)),
+	}
+	for _, entry := range entries {
+		report.Diagnostics = append(report.Diagnostics, vscode.EditorDiagnostic{
+			Range: vscode.DocumentRange{
+				Start: diagnosticsPosition(entry.Line, entry.Column),
+				End:   diagnosticsPosition(entry.Line, entry.Column+1),
+			},
+			Severity: diagnosticsSeverity(entry.Severity),
+			Source:   entry.Source,
+			Message:  entry.Message,
+		})
+	}
+	return report
+}
+
+func diagnosticsDocumentToReport(doc vscode.EditorDiagnosticsDocument, version *int) vscode.EditorDiagnosticReport {
+	if version == nil {
+		version = &doc.Version
+	}
+	return vscode.EditorDiagnosticReport{
+		URI:         pathToDocumentURI(doc.Path),
+		Path:        doc.Path,
+		Version:     version,
+		Diagnostics: doc.Diagnostics,
+	}
+}
+
+func diagnosticsPosition(line, column int) vscode.DocumentPosition {
+	if line < 1 {
+		line = 1
+	}
+	if column < 1 {
+		column = 1
+	}
+	return vscode.DocumentPosition{Line: line - 1, Character: column - 1}
+}
+
+func diagnosticsSeverity(severity string) int {
+	switch strings.ToLower(severity) {
+	case diagnostics.SeverityError:
+		return vscode.LSPDiagnosticSeverityError
+	case diagnostics.SeverityWarning:
+		return vscode.LSPDiagnosticSeverityWarning
+	case diagnostics.SeverityInfo:
+		return vscode.LSPDiagnosticSeverityInformation
+	default:
+		return vscode.LSPDiagnosticSeverityHint
+	}
+}
+
+func pathToDocumentURI(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	return (&url.URL{Scheme: "file", Path: filepath.ToSlash(path)}).String()
+}

--- a/server/internal/api/editor.go
+++ b/server/internal/api/editor.go
@@ -13,7 +13,7 @@ import (
 
 type bridgeEditorRequest struct {
 	Path     string                   `json:"path"`
-	Version  int                      `json:"version,omitempty"`
+	Version  *int                     `json:"version,omitempty"`
 	WorkDir  string                   `json:"workDir,omitempty"`
 	Position *vscode.DocumentPosition `json:"position,omitempty"`
 	Range    *vscode.DocumentRange    `json:"range,omitempty"`
@@ -23,14 +23,25 @@ type bridgeEditorRequest struct {
 	Query    string                   `json:"query,omitempty"`
 }
 
+type bridgeEditorRequestRequirements struct {
+	Position bool
+	Range    bool
+	NewName  bool
+}
+
 func (s *Server) handleBridgeEditorDiagnostics(w http.ResponseWriter, r *http.Request) {
 	if s.editorService == nil {
 		writeBridgeError(w, http.StatusNotFound, "capability_unavailable", "editor intelligence bridge is not configured")
 		return
 	}
 
-	req, ok := decodeBridgeEditorQuery(w, r)
-	if !ok {
+	var raw bridgeEditorRequest
+	if !decodeBridgeDocumentRequest(w, r, &raw) {
+		return
+	}
+	req, err := sanitizeBridgeEditorRequest(raw, bridgeEditorRequestRequirements{})
+	if err != nil {
+		writeBridgeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
 	result, err := s.editorService.Diagnostics(req)
@@ -43,60 +54,60 @@ func (s *Server) handleBridgeEditorDiagnostics(w http.ResponseWriter, r *http.Re
 }
 
 func (s *Server) handleBridgeEditorCompletion(w http.ResponseWriter, r *http.Request) {
-	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+	s.handleBridgeEditorRPC(w, r, bridgeEditorRequestRequirements{Position: true}, func(req vscode.EditorRequest) (any, error) {
 		return s.editorService.Completion(req)
 	})
 }
 
 func (s *Server) handleBridgeEditorHover(w http.ResponseWriter, r *http.Request) {
-	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+	s.handleBridgeEditorRPC(w, r, bridgeEditorRequestRequirements{Position: true}, func(req vscode.EditorRequest) (any, error) {
 		return s.editorService.Hover(req)
 	})
 }
 
 func (s *Server) handleBridgeEditorDefinition(w http.ResponseWriter, r *http.Request) {
-	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+	s.handleBridgeEditorRPC(w, r, bridgeEditorRequestRequirements{Position: true}, func(req vscode.EditorRequest) (any, error) {
 		return s.editorService.Definition(req)
 	})
 }
 
 func (s *Server) handleBridgeEditorReferences(w http.ResponseWriter, r *http.Request) {
-	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+	s.handleBridgeEditorRPC(w, r, bridgeEditorRequestRequirements{Position: true}, func(req vscode.EditorRequest) (any, error) {
 		return s.editorService.References(req)
 	})
 }
 
 func (s *Server) handleBridgeEditorSignatureHelp(w http.ResponseWriter, r *http.Request) {
-	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+	s.handleBridgeEditorRPC(w, r, bridgeEditorRequestRequirements{Position: true}, func(req vscode.EditorRequest) (any, error) {
 		return s.editorService.SignatureHelp(req)
 	})
 }
 
 func (s *Server) handleBridgeEditorFormatting(w http.ResponseWriter, r *http.Request) {
-	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+	s.handleBridgeEditorRPC(w, r, bridgeEditorRequestRequirements{}, func(req vscode.EditorRequest) (any, error) {
 		return s.editorService.Formatting(req)
 	})
 }
 
 func (s *Server) handleBridgeEditorCodeActions(w http.ResponseWriter, r *http.Request) {
-	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+	s.handleBridgeEditorRPC(w, r, bridgeEditorRequestRequirements{Range: true}, func(req vscode.EditorRequest) (any, error) {
 		return s.editorService.CodeActions(req)
 	})
 }
 
 func (s *Server) handleBridgeEditorRename(w http.ResponseWriter, r *http.Request) {
-	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+	s.handleBridgeEditorRPC(w, r, bridgeEditorRequestRequirements{Position: true, NewName: true}, func(req vscode.EditorRequest) (any, error) {
 		return s.editorService.Rename(req)
 	})
 }
 
 func (s *Server) handleBridgeEditorDocumentSymbols(w http.ResponseWriter, r *http.Request) {
-	s.handleBridgeEditorRPC(w, r, func(req vscode.EditorRequest) (any, error) {
+	s.handleBridgeEditorRPC(w, r, bridgeEditorRequestRequirements{}, func(req vscode.EditorRequest) (any, error) {
 		return s.editorService.DocumentSymbols(req)
 	})
 }
 
-func (s *Server) handleBridgeEditorRPC(w http.ResponseWriter, r *http.Request, fn func(vscode.EditorRequest) (any, error)) {
+func (s *Server) handleBridgeEditorRPC(w http.ResponseWriter, r *http.Request, requirements bridgeEditorRequestRequirements, fn func(vscode.EditorRequest) (any, error)) {
 	if s.editorService == nil {
 		writeBridgeError(w, http.StatusNotFound, "capability_unavailable", "editor intelligence bridge is not configured")
 		return
@@ -105,7 +116,7 @@ func (s *Server) handleBridgeEditorRPC(w http.ResponseWriter, r *http.Request, f
 	if !decodeBridgeDocumentRequest(w, r, &raw) {
 		return
 	}
-	req, err := sanitizeBridgeEditorRequest(raw)
+	req, err := sanitizeBridgeEditorRequest(raw, requirements)
 	if err != nil {
 		writeBridgeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
@@ -118,32 +129,26 @@ func (s *Server) handleBridgeEditorRPC(w http.ResponseWriter, r *http.Request, f
 	writeJSON(w, http.StatusOK, result)
 }
 
-func decodeBridgeEditorQuery(w http.ResponseWriter, r *http.Request) (vscode.EditorRequest, bool) {
-	path := r.URL.Query().Get("path")
-	if strings.TrimSpace(path) == "" {
-		writeBridgeError(w, http.StatusBadRequest, "invalid_request", "path is required")
-		return vscode.EditorRequest{}, false
-	}
-	workDir := r.URL.Query().Get("workDir")
-	if workDir == "" {
-		workDir = "/"
-	}
-	req, err := sanitizeBridgeEditorRequest(bridgeEditorRequest{Path: path, WorkDir: workDir})
-	if err != nil {
-		writeBridgeError(w, http.StatusBadRequest, "invalid_request", err.Error())
-		return vscode.EditorRequest{}, false
-	}
-	return req, true
-}
-
-func sanitizeBridgeEditorRequest(raw bridgeEditorRequest) (vscode.EditorRequest, error) {
+func sanitizeBridgeEditorRequest(raw bridgeEditorRequest, requirements bridgeEditorRequestRequirements) (vscode.EditorRequest, error) {
 	path, workDir, err := sanitizeEditorPathContext(raw.Path, raw.WorkDir)
 	if err != nil {
 		return vscode.EditorRequest{}, err
 	}
+	if raw.Version == nil {
+		return vscode.EditorRequest{}, errors.New("version is required")
+	}
+	if requirements.Position && raw.Position == nil {
+		return vscode.EditorRequest{}, errors.New("position is required")
+	}
+	if requirements.Range && raw.Range == nil {
+		return vscode.EditorRequest{}, errors.New("range is required")
+	}
+	if requirements.NewName && strings.TrimSpace(raw.NewName) == "" {
+		return vscode.EditorRequest{}, errors.New("newName is required")
+	}
 	return vscode.EditorRequest{
 		Path:     path,
-		Version:  raw.Version,
+		Version:  *raw.Version,
 		WorkDir:  workDir,
 		Position: raw.Position,
 		Range:    raw.Range,
@@ -180,6 +185,8 @@ func writeEditorBridgeError(w http.ResponseWriter, err error) {
 		switch bridgeErr.Code {
 		case "invalid_request", "invalid_position":
 			status = http.StatusBadRequest
+		case "version_conflict":
+			status = http.StatusConflict
 		case "bridge_not_ready":
 			status = http.StatusServiceUnavailable
 		case "capability_unavailable":

--- a/server/internal/api/editor_bridge_test.go
+++ b/server/internal/api/editor_bridge_test.go
@@ -1,0 +1,418 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/Lincyaw/vscode-mobile/server/internal/claude"
+	"github.com/Lincyaw/vscode-mobile/server/internal/diagnostics"
+	"github.com/Lincyaw/vscode-mobile/server/internal/terminal"
+	"github.com/Lincyaw/vscode-mobile/server/internal/vscode"
+)
+
+type apiEditorRequestCapture struct {
+	Command string
+	Payload map[string]any
+}
+
+func newAPIEditorRuntimeServer(t *testing.T, responseFor func(command string, payload map[string]any) any) (*httptest.Server, <-chan apiEditorRequestCapture) {
+	t.Helper()
+
+	requests := make(chan apiEditorRequestCapture, 32)
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade failed: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		auth := mustReadAPIEditorProtocolMessage(t, conn)
+		if auth.Type != vscode.ProtocolMessageControl {
+			t.Errorf("auth message type = %v, want control", auth.Type)
+			return
+		}
+		var authReq vscode.AuthRequest
+		if err := json.Unmarshal(auth.Data, &authReq); err != nil {
+			t.Errorf("unmarshal auth request: %v", err)
+			return
+		}
+		if authReq.Type != "auth" {
+			t.Errorf("auth request type = %q, want auth", authReq.Type)
+			return
+		}
+		mustWriteAPIEditorControlJSON(t, conn, map[string]any{
+			"type":       "sign",
+			"data":       "challenge",
+			"signedData": "challenge",
+		})
+
+		connType := mustReadAPIEditorProtocolMessage(t, conn)
+		if connType.Type != vscode.ProtocolMessageControl {
+			t.Errorf("connection type message type = %v, want control", connType.Type)
+			return
+		}
+		var connReq vscode.ConnectionTypeRequest
+		if err := json.Unmarshal(connType.Data, &connReq); err != nil {
+			t.Errorf("unmarshal connection type request: %v", err)
+			return
+		}
+		if connReq.Type != "connectionType" {
+			t.Errorf("connection type request type = %q, want connectionType", connReq.Type)
+			return
+		}
+		mustWriteAPIEditorControlJSON(t, conn, map[string]any{"type": "ok"})
+
+		bootstrap := mustReadAPIEditorProtocolMessage(t, conn)
+		if bootstrap.Type != vscode.ProtocolMessageRegular {
+			t.Errorf("bootstrap message type = %v, want regular", bootstrap.Type)
+			return
+		}
+		mustWriteAPIEditorProtocolMessage(t, conn, &vscode.ProtocolMessage{
+			Type: vscode.ProtocolMessageRegular,
+			Data: vscode.EncodeIPCMessage([]interface{}{int(vscode.ResponseTypeInitialize)}, nil),
+		})
+
+		for {
+			msg, err := readAPIEditorProtocolMessage(conn)
+			if err != nil {
+				return
+			}
+			if msg.Type != vscode.ProtocolMessageRegular {
+				continue
+			}
+			header, body, err := vscode.DecodeIPCMessage(msg.Data)
+			if err != nil {
+				t.Errorf("decode ipc message: %v", err)
+				return
+			}
+			hdr, ok := header.([]interface{})
+			if !ok || len(hdr) < 4 {
+				t.Errorf("header = %#v, want request header", header)
+				return
+			}
+			reqType, ok := hdr[0].(int)
+			if !ok {
+				t.Errorf("request type header = %#v, want int", hdr[0])
+				return
+			}
+			if vscode.RequestType(reqType) != vscode.RequestTypePromise {
+				t.Errorf("request type = %d, want promise", reqType)
+				return
+			}
+			id, ok := hdr[1].(int)
+			if !ok {
+				t.Errorf("request id header = %#v, want int", hdr[1])
+				return
+			}
+			command, _ := hdr[3].(string)
+			payload, _ := body.(map[string]any)
+			if payload == nil {
+				payload = map[string]any{}
+			}
+
+			select {
+			case requests <- apiEditorRequestCapture{Command: command, Payload: payload}:
+			default:
+				t.Errorf("request buffer overflow for command %q", command)
+				return
+			}
+
+			respBody := responseFor(command, payload)
+			mustWriteAPIEditorProtocolMessage(t, conn, &vscode.ProtocolMessage{
+				Type: vscode.ProtocolMessageRegular,
+				Data: vscode.EncodeIPCMessage([]interface{}{int(vscode.ResponseTypePromiseSuccess), id}, respBody),
+			})
+		}
+	}))
+
+	t.Cleanup(ts.Close)
+	return ts, requests
+}
+
+func mustReadAPIEditorProtocolMessage(t *testing.T, conn *websocket.Conn) *vscode.ProtocolMessage {
+	t.Helper()
+	msg, err := readAPIEditorProtocolMessage(conn)
+	if err != nil {
+		t.Fatalf("read protocol message: %v", err)
+	}
+	return msg
+}
+
+func readAPIEditorProtocolMessage(conn *websocket.Conn) (*vscode.ProtocolMessage, error) {
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		return nil, err
+	}
+	return vscode.DecodeProtocolMessage(bytes.NewReader(raw))
+}
+
+func mustWriteAPIEditorControlJSON(t *testing.T, conn *websocket.Conn, payload map[string]any) {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal control payload: %v", err)
+	}
+	mustWriteAPIEditorProtocolMessage(t, conn, &vscode.ProtocolMessage{
+		Type: vscode.ProtocolMessageControl,
+		Data: data,
+	})
+}
+
+func mustWriteAPIEditorProtocolMessage(t *testing.T, conn *websocket.Conn, msg *vscode.ProtocolMessage) {
+	t.Helper()
+	data := vscode.EncodeProtocolMessage(msg)
+	if err := conn.WriteMessage(websocket.BinaryMessage, data); err != nil {
+		t.Fatalf("write protocol message: %v", err)
+	}
+}
+
+func newAPIEditorBridgeServer(t *testing.T, fs *mockFS, responseFor func(command string, payload map[string]any) any) (*httptest.Server, <-chan apiEditorRequestCapture) {
+	t.Helper()
+
+	runtimeTS, requests := newAPIEditorRuntimeServer(t, responseFor)
+	client := vscode.NewClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	if err := client.Connect(ctx, runtimeTS.URL, ""); err != nil {
+		t.Fatalf("connect bridge client: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	sessionIndex := claude.NewSessionIndex(t.TempDir())
+	pm := claude.NewProcessManager("/nonexistent/claude", ".")
+	runner := diagnostics.NewRunner(10 * time.Second)
+	srv := NewServer(fs, sessionIndex, pm, "", nil, terminal.NewManager(), runner)
+
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := vscode.NewBridgeManager(vscode.BridgeManagerOptions{
+		MetadataPath: metadataPath,
+		Client:       client,
+		PollInterval: 20 * time.Millisecond,
+	})
+	writeBridgeMetadata(t, metadataPath, vscode.BridgeMetadata{
+		Generation:      "gen-editor",
+		State:           "ready",
+		ProtocolVersion: "2026-04-20",
+		BridgeVersion:   "0.3.0",
+		Capabilities: map[string]any{
+			"diagnostics":     map[string]any{"enabled": true},
+			"completion":      map[string]any{"enabled": true},
+			"hover":           map[string]any{"enabled": true},
+			"definition":      map[string]any{"enabled": true},
+			"references":      map[string]any{"enabled": true},
+			"signatureHelp":   map[string]any{"enabled": true},
+			"formatting":      map[string]any{"enabled": true},
+			"codeActions":     map[string]any{"enabled": true},
+			"rename":          map[string]any{"enabled": true},
+			"documentSymbols": map[string]any{"enabled": true},
+		},
+	})
+	managerCtx, managerCancel := context.WithCancel(context.Background())
+	t.Cleanup(managerCancel)
+	manager.Start(managerCtx)
+	t.Cleanup(manager.Close)
+	waitForAPIEditorBridgeReady(t, manager)
+
+	documents := vscode.NewDocumentSyncService(fs)
+	srv.SetBridgeManager(manager)
+	srv.SetDocumentSync(documents)
+	srv.SetEditorService(vscode.NewEditorService(client, manager, documents))
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts, requests
+}
+
+func waitForAPIEditorBridgeReady(t *testing.T, manager *vscode.BridgeManager) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := manager.Capabilities(); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for bridge manager readiness")
+}
+
+func TestBridgeEditorCompletionUsesUnsavedBufferAndVersionedContext(t *testing.T) {
+	fs := newMockFS()
+	workDir := t.TempDir()
+	filePath := filepath.Join(workDir, "main.dart")
+	fs.files[filePath] = []byte("print('disk');\n")
+
+	ts, requests := newAPIEditorBridgeServer(t, fs, func(command string, payload map[string]any) any {
+		if command != "completion" {
+			return map[string]any{"items": []any{}}
+		}
+		return map[string]any{"isIncomplete": false, "items": []any{}}
+	})
+
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/open", map[string]any{
+		"path":    filePath,
+		"version": 1,
+		"content": "print('draft');\n",
+	})
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/change", map[string]any{
+		"path":    filePath,
+		"version": 2,
+		"changes": []bridgeDocChange{{
+			Range: &bridgeDocRange{
+				Start: bridgeDocPosition{Line: 0, Character: 14},
+				End:   bridgeDocPosition{Line: 0, Character: 14},
+			},
+			Text: " // unsaved",
+		}},
+	})
+
+	position := map[string]any{"line": 0, "character": 7}
+	resp, body := postBridgeDocumentRequest(t, ts.URL, "/bridge/editor/completion", map[string]any{
+		"path":     filePath,
+		"version":  2,
+		"position": position,
+		"workDir":  workDir,
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("completion status = %d, body=%s", resp.StatusCode, string(body))
+	}
+
+	req := <-requests
+	if req.Command != "completion" {
+		t.Fatalf("bridge command = %q, want completion", req.Command)
+	}
+	if got := req.Payload["path"]; got != filePath {
+		t.Fatalf("bridge path = %#v, want %q", got, filePath)
+	}
+	if got, ok := req.Payload["version"].(float64); !ok || got != 2 {
+		t.Fatalf("bridge version = %#v, want 2", req.Payload["version"])
+	}
+	if got := req.Payload["content"]; got != "print('draft') // unsaved;\n" {
+		t.Fatalf("bridge content = %#v, want unsaved buffer", got)
+	}
+	if _, ok := req.Payload["position"]; !ok {
+		t.Fatalf("bridge payload missing position: %#v", req.Payload)
+	}
+
+	resp, body = postBridgeDocumentRequest(t, ts.URL, "/bridge/editor/completion", map[string]any{
+		"path":     filePath,
+		"version":  1,
+		"position": position,
+		"workDir":  workDir,
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("stale completion status = %d, want %d; body=%s", resp.StatusCode, http.StatusConflict, string(body))
+	}
+	var staleErr bridgeErrorDetail
+	if err := json.Unmarshal(body, &staleErr); err != nil {
+		t.Fatalf("decode stale completion error: %v; body=%s", err, string(body))
+	}
+	if staleErr.Code != "version_conflict" {
+		t.Fatalf("stale completion code = %q, want version_conflict", staleErr.Code)
+	}
+	select {
+	case extra := <-requests:
+		t.Fatalf("unexpected extra bridge request after stale version rejection: %#v", extra)
+	default:
+	}
+}
+
+func TestDiagnosticsBridgeResponseWinsWhenDocumentIsOpen(t *testing.T) {
+	fs := newMockFS()
+	workDir := t.TempDir()
+	filePath := filepath.Join(workDir, "main.dart")
+	fs.files[filePath] = []byte("print('disk');\n")
+
+	ts, requests := newAPIEditorBridgeServer(t, fs, func(command string, payload map[string]any) any {
+		switch command {
+		case "diagnostics":
+			return map[string]any{
+				"path":    payload["path"],
+				"version": payload["version"],
+				"diagnostics": []any{
+					map[string]any{
+						"severity": "warning",
+						"message":  "bridge diagnostics",
+					},
+				},
+			}
+		default:
+			return map[string]any{}
+		}
+	})
+
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/open", map[string]any{
+		"path":    filePath,
+		"version": 1,
+		"content": "print('draft');\n",
+	})
+	requireBridgeDocumentSuccess(t, ts.URL, "/bridge/doc/change", map[string]any{
+		"path":    filePath,
+		"version": 2,
+		"changes": []bridgeDocChange{{
+			Range: &bridgeDocRange{
+				Start: bridgeDocPosition{Line: 0, Character: 14},
+				End:   bridgeDocPosition{Line: 0, Character: 14},
+			},
+			Text: " // unsaved",
+		}},
+	})
+
+	resp, err := http.Get(ts.URL + "/api/diagnostics?path=" + filePath + "&workDir=" + url.QueryEscape(workDir) + "&format=lsp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := make([]byte, 0)
+	defer resp.Body.Close()
+	body, _ = io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("diagnostics status = %d, body=%s", resp.StatusCode, string(body))
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode diagnostics body: %v; body=%s", err, string(body))
+	}
+	if got := payload["path"]; got != filePath {
+		t.Fatalf("diagnostics path = %#v, want %q", got, filePath)
+	}
+	if got := payload["version"]; got != float64(2) {
+		t.Fatalf("diagnostics version = %#v, want 2", got)
+	}
+	diagnosticsList, ok := payload["diagnostics"].([]any)
+	if !ok || len(diagnosticsList) != 1 {
+		t.Fatalf("diagnostics = %#v, want 1 entry", payload["diagnostics"])
+	}
+	first, ok := diagnosticsList[0].(map[string]any)
+	if !ok {
+		t.Fatalf("diagnostic[0] = %#v, want object", diagnosticsList[0])
+	}
+	if got := first["message"]; got != "bridge diagnostics" {
+		t.Fatalf("diagnostic message = %#v, want bridge diagnostics", got)
+	}
+
+	req := <-requests
+	if req.Command != "diagnostics" {
+		t.Fatalf("bridge command = %q, want diagnostics", req.Command)
+	}
+	if got := req.Payload["content"]; got != "print('draft') // unsaved;\n" {
+		t.Fatalf("bridge diagnostics content = %#v, want unsaved buffer", got)
+	}
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -35,6 +35,7 @@ type Server struct {
 	token            string
 	git              *git.Git
 	gitService       *vscode.GitService
+	editorService    *vscode.EditorService
 	termManager      *terminal.Manager
 	diagnosticRunner *diagnostics.Runner
 	githubAuth       *gitauth.Service
@@ -79,6 +80,11 @@ func (s *Server) SetDocumentSync(service *vscode.DocumentSyncService) {
 	s.documentSync = service
 }
 
+// SetEditorService injects the bridge-backed editor intelligence service.
+func (s *Server) SetEditorService(service *vscode.EditorService) {
+	s.editorService = service
+}
+
 // Handler returns the top-level HTTP handler with all routes.
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
@@ -113,6 +119,16 @@ func (s *Server) Handler() http.Handler {
 	// Diagnostics endpoint.
 	mux.HandleFunc("GET /api/diagnostics", s.handleDiagnostics)
 	mux.HandleFunc("GET /bridge/capabilities", s.handleBridgeCapabilities)
+	mux.HandleFunc("POST /bridge/editor/diagnostics", s.handleBridgeEditorDiagnostics)
+	mux.HandleFunc("POST /bridge/editor/completion", s.handleBridgeEditorCompletion)
+	mux.HandleFunc("POST /bridge/editor/hover", s.handleBridgeEditorHover)
+	mux.HandleFunc("POST /bridge/editor/definition", s.handleBridgeEditorDefinition)
+	mux.HandleFunc("POST /bridge/editor/references", s.handleBridgeEditorReferences)
+	mux.HandleFunc("POST /bridge/editor/signature-help", s.handleBridgeEditorSignatureHelp)
+	mux.HandleFunc("POST /bridge/editor/formatting", s.handleBridgeEditorFormatting)
+	mux.HandleFunc("POST /bridge/editor/code-actions", s.handleBridgeEditorCodeActions)
+	mux.HandleFunc("POST /bridge/editor/rename", s.handleBridgeEditorRename)
+	mux.HandleFunc("POST /bridge/editor/document-symbols", s.handleBridgeEditorDocumentSymbols)
 	mux.HandleFunc("POST /bridge/doc/open", s.handleBridgeDocumentOpen)
 	mux.HandleFunc("POST /bridge/doc/change", s.handleBridgeDocumentChange)
 	mux.HandleFunc("POST /bridge/doc/save", s.handleBridgeDocumentSave)

--- a/server/internal/vscode/bridge.go
+++ b/server/internal/vscode/bridge.go
@@ -209,6 +209,29 @@ func (m *BridgeManager) Capabilities() (BridgeCapabilitiesDocument, error) {
 	return cloneCapabilities(m.capabilities), nil
 }
 
+// RequireCapability verifies the bridge is ready and that the named capability is enabled.
+func (m *BridgeManager) RequireCapability(name string) error {
+	_, err := m.Capability(name)
+	return err
+}
+
+// Capability returns the named capability entry when the bridge is ready and the
+// capability is present+enabled in the metadata document.
+func (m *BridgeManager) Capability(name string) (map[string]any, error) {
+	caps, err := m.Capabilities()
+	if err != nil {
+		return nil, err
+	}
+	entry, ok := lookupCapability(caps.Capabilities, name)
+	if !ok {
+		return nil, newBridgeError("capability_unavailable", fmt.Sprintf("bridge capability %q is unavailable", name), nil)
+	}
+	if !capabilityEnabled(entry) {
+		return nil, newBridgeError("capability_unavailable", fmt.Sprintf("bridge capability %q is disabled", name), nil)
+	}
+	return entry, nil
+}
+
 // Publish broadcasts an event on the unified bridge event stream.
 func (m *BridgeManager) Publish(event BridgeEvent) {
 	if m == nil {
@@ -449,9 +472,70 @@ func cloneMap(src map[string]interface{}) map[string]interface{} {
 	}
 	dst := make(map[string]interface{}, len(src))
 	for k, v := range src {
-		dst[k] = v
+		dst[k] = cloneBridgeValue(v)
 	}
 	return dst
+}
+
+func cloneBridgeValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneMap(typed)
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneBridgeValue(item)
+		}
+		return cloned
+	default:
+		return typed
+	}
+}
+
+func lookupCapability(capabilities map[string]interface{}, name string) (map[string]any, bool) {
+	if capabilities == nil {
+		return nil, false
+	}
+	if exact, ok := capabilityEntry(capabilities[name]); ok {
+		return exact, true
+	}
+	current := capabilities
+	parts := strings.Split(name, ".")
+	for _, part := range parts {
+		next, ok := current[part]
+		if !ok {
+			return nil, false
+		}
+		entry, ok := capabilityEntry(next)
+		if !ok {
+			return nil, false
+		}
+		current = entry
+	}
+	return current, true
+}
+
+func capabilityEntry(value any) (map[string]any, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed, true
+	case bool:
+		return map[string]any{"enabled": typed}, true
+	default:
+		return nil, false
+	}
+}
+
+func capabilityEnabled(entry map[string]any) bool {
+	if entry == nil {
+		return false
+	}
+	enabled, ok := entry["enabled"]
+	if !ok {
+		return true
+	}
+	flag, ok := enabled.(bool)
+	return ok && flag
 }
 
 // DocumentPosition identifies a zero-based line/character location in a text buffer.

--- a/server/internal/vscode/bridge_test.go
+++ b/server/internal/vscode/bridge_test.go
@@ -240,6 +240,63 @@ func TestBridgeManager_ReadyTransitionPublishesCapabilities(t *testing.T) {
 	}
 }
 
+func TestBridgeManager_CapabilitiesDeepClonePreservesEditorFeatureFlags(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := NewBridgeManager(BridgeManagerOptions{MetadataPath: metadataPath})
+
+	writeBridgeMetadataFile(t, metadataPath, BridgeMetadata{
+		ProtocolVersion: defaultBridgeProtocolVersion,
+		Generation:      "gen-editor",
+		State:           bridgeStateReady,
+		Capabilities: map[string]interface{}{
+			"diagnostics": map[string]interface{}{
+				"enabled": true,
+				"kinds":   []interface{}{"push"},
+			},
+			"completion": map[string]interface{}{
+				"enabled":            true,
+				"insertTextFormat":   true,
+				"additionalTextEdit": true,
+			},
+			"rename": map[string]interface{}{
+				"enabled": true,
+			},
+			"documentSymbols": map[string]interface{}{
+				"enabled": true,
+			},
+		},
+	})
+
+	manager.poll()
+
+	first, err := manager.Capabilities()
+	if err != nil {
+		t.Fatalf("Capabilities failed: %v", err)
+	}
+	diagnostics, ok := first.Capabilities["diagnostics"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("diagnostics capability = %#v, want map[string]interface{}", first.Capabilities["diagnostics"])
+	}
+	diagnostics["enabled"] = false
+	diagnostics["kinds"] = []interface{}{"mutated"}
+
+	second, err := manager.Capabilities()
+	if err != nil {
+		t.Fatalf("Capabilities second read failed: %v", err)
+	}
+	diagnostics, ok = second.Capabilities["diagnostics"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("diagnostics capability second read = %#v, want map[string]interface{}", second.Capabilities["diagnostics"])
+	}
+	if diagnostics["enabled"] != true {
+		t.Fatalf("diagnostics enabled = %#v, want true after caller mutation", diagnostics["enabled"])
+	}
+	kinds, ok := diagnostics["kinds"].([]interface{})
+	if !ok || len(kinds) != 1 || kinds[0] != "push" {
+		t.Fatalf("diagnostics kinds = %#v, want [push]", diagnostics["kinds"])
+	}
+}
+
 func TestBridgeManager_RestartDetectionBroadcastsRestartedThenReady(t *testing.T) {
 	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
 	manager := NewBridgeManager(BridgeManagerOptions{MetadataPath: metadataPath})
@@ -352,6 +409,57 @@ func TestBridgeManager_BroadcastsGitRepositoryChangedStableEnvelope(t *testing.T
 	}
 	if len(repository["mergeChanges"].([]interface{})) != 1 {
 		t.Fatalf("mergeChanges = %#v, want 1 entry", repository["mergeChanges"])
+	}
+}
+
+func TestBridgeManager_PublishDiagnosticsChangedStableEnvelope(t *testing.T) {
+	manager := NewBridgeManager(BridgeManagerOptions{})
+	events, unsubscribe := manager.Subscribe(false)
+	defer unsubscribe()
+
+	manager.Publish(BridgeEvent{
+		Type: "bridge/diagnosticsChanged",
+		Payload: map[string]interface{}{
+			"path":    "/workspace/lib/main.dart",
+			"version": 7,
+			"diagnostics": []interface{}{
+				map[string]interface{}{
+					"severity": "error",
+					"message":  "Missing semicolon",
+					"range": map[string]interface{}{
+						"start": map[string]interface{}{"line": 3, "character": 12},
+						"end":   map[string]interface{}{"line": 3, "character": 13},
+					},
+				},
+			},
+		},
+	})
+
+	event := mustReceiveBridgeEvent(t, events, 2*time.Second)
+	if event.Type != "bridge/diagnosticsChanged" {
+		t.Fatalf("event type = %q, want bridge/diagnosticsChanged", event.Type)
+	}
+
+	payload, ok := event.Payload.(map[string]interface{})
+	if !ok {
+		t.Fatalf("payload = %#v, want map[string]interface{}", event.Payload)
+	}
+	if payload["path"] != "/workspace/lib/main.dart" {
+		t.Fatalf("payload path = %#v, want %q", payload["path"], "/workspace/lib/main.dart")
+	}
+	if payload["version"] != 7 {
+		t.Fatalf("payload version = %#v, want 7", payload["version"])
+	}
+	diagnostics, ok := payload["diagnostics"].([]interface{})
+	if !ok || len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %#v, want 1 entry", payload["diagnostics"])
+	}
+	first, ok := diagnostics[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("diagnostic[0] = %#v, want map[string]interface{}", diagnostics[0])
+	}
+	if first["message"] != "Missing semicolon" {
+		t.Fatalf("diagnostic message = %#v, want %q", first["message"], "Missing semicolon")
 	}
 }
 

--- a/server/internal/vscode/editor.go
+++ b/server/internal/vscode/editor.go
@@ -1,0 +1,535 @@
+package vscode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const editorChannelName = "openvsmobile/editor"
+
+// EditorRequest contains the versioned live-document context required for editor intelligence calls.
+type EditorRequest struct {
+	Path     string            `json:"path"`
+	Version  int               `json:"version"`
+	Content  string            `json:"content,omitempty"`
+	Position *DocumentPosition `json:"position,omitempty"`
+	Range    *DocumentRange    `json:"range,omitempty"`
+	NewName  string            `json:"newName,omitempty"`
+	WorkDir  string            `json:"workDir,omitempty"`
+	Context  map[string]any    `json:"context,omitempty"`
+	Options  map[string]any    `json:"options,omitempty"`
+	Query    string            `json:"query,omitempty"`
+}
+
+// EditorDiagnostic mirrors VS Code/LSP diagnostic payloads closely enough for clients to apply directly.
+type EditorDiagnostic struct {
+	Range    DocumentRange `json:"range"`
+	Severity any           `json:"severity,omitempty"`
+	Code     any           `json:"code,omitempty"`
+	Source   string        `json:"source,omitempty"`
+	Message  string        `json:"message"`
+	Tags     []int         `json:"tags,omitempty"`
+	Related  any           `json:"relatedInformation,omitempty"`
+	Data     any           `json:"data,omitempty"`
+}
+
+// EditorDiagnosticsDocument is the stable diagnostics response envelope.
+type EditorDiagnosticsDocument struct {
+	Path        string             `json:"path"`
+	Version     int                `json:"version"`
+	Diagnostics []EditorDiagnostic `json:"diagnostics"`
+}
+
+// EditorDiagnosticReport is the LSP-shaped diagnostics document returned to API clients.
+type EditorDiagnosticReport struct {
+	URI         string             `json:"uri,omitempty"`
+	Path        string             `json:"path,omitempty"`
+	Version     *int               `json:"version,omitempty"`
+	Diagnostics []EditorDiagnostic `json:"diagnostics"`
+}
+
+const (
+	LSPDiagnosticSeverityError       = 1
+	LSPDiagnosticSeverityWarning     = 2
+	LSPDiagnosticSeverityInformation = 3
+	LSPDiagnosticSeverityHint        = 4
+)
+
+// CompletionListDocument is the stable completion response envelope.
+type CompletionListDocument struct {
+	IsIncomplete bool             `json:"isIncomplete,omitempty"`
+	Items        []CompletionItem `json:"items"`
+}
+
+// CompletionItem preserves the replacement-related fields that clients need.
+type CompletionItem struct {
+	Label               any        `json:"label"`
+	Kind                any        `json:"kind,omitempty"`
+	Detail              string     `json:"detail,omitempty"`
+	Documentation       any        `json:"documentation,omitempty"`
+	SortText            string     `json:"sortText,omitempty"`
+	FilterText          string     `json:"filterText,omitempty"`
+	InsertText          string     `json:"insertText,omitempty"`
+	InsertTextFormat    any        `json:"insertTextFormat,omitempty"`
+	TextEdit            any        `json:"textEdit,omitempty"`
+	AdditionalTextEdits []TextEdit `json:"additionalTextEdits,omitempty"`
+	Command             any        `json:"command,omitempty"`
+	Data                any        `json:"data,omitempty"`
+}
+
+// HoverDocument is the stable hover response envelope.
+type HoverDocument struct {
+	Contents any            `json:"contents"`
+	Range    *DocumentRange `json:"range,omitempty"`
+}
+
+// LocationDocument mirrors the LSP location shape.
+type LocationDocument struct {
+	URI   string        `json:"uri"`
+	Range DocumentRange `json:"range"`
+}
+
+// TextEdit mirrors the LSP text edit shape.
+type TextEdit struct {
+	Range   DocumentRange `json:"range"`
+	NewText string        `json:"newText"`
+}
+
+// WorkspaceEdit mirrors the LSP workspace edit shape.
+type WorkspaceEdit struct {
+	Changes           map[string][]TextEdit `json:"changes,omitempty"`
+	DocumentChanges   any                   `json:"documentChanges,omitempty"`
+	ChangeAnnotations any                   `json:"changeAnnotations,omitempty"`
+}
+
+// DocumentSymbol mirrors the LSP document symbol tree shape.
+type DocumentSymbol struct {
+	Name           string           `json:"name"`
+	Detail         string           `json:"detail,omitempty"`
+	Kind           int              `json:"kind"`
+	Tags           []int            `json:"tags,omitempty"`
+	Deprecated     bool             `json:"deprecated,omitempty"`
+	Range          DocumentRange    `json:"range"`
+	SelectionRange DocumentRange    `json:"selectionRange"`
+	Children       []DocumentSymbol `json:"children,omitempty"`
+}
+
+// EditorService talks to the runtime bridge's editor adapter and republishes diagnostics updates.
+type EditorService struct {
+	client      *Client
+	bridge      *BridgeManager
+	documents   *DocumentSyncService
+	channelName string
+
+	mu              sync.Mutex
+	diagnosticsStop func()
+	lifecycleStop   func()
+}
+
+// NewEditorService creates a bridge-backed editor intelligence service.
+func NewEditorService(client *Client, bridge *BridgeManager, documents *DocumentSyncService) *EditorService {
+	return &EditorService{client: client, bridge: bridge, documents: documents, channelName: editorChannelName}
+}
+
+// Start binds diagnostics subscriptions to the bridge lifecycle.
+func (s *EditorService) Start(ctx context.Context) {
+	if s == nil || s.bridge == nil {
+		return
+	}
+	events, unsubscribe := s.bridge.Subscribe(false)
+	s.mu.Lock()
+	s.lifecycleStop = unsubscribe
+	s.mu.Unlock()
+	go func() {
+		defer unsubscribe()
+		defer s.disposeDiagnosticsWatcher()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event, ok := <-events:
+				if !ok {
+					return
+				}
+				switch event.Type {
+				case "bridge/ready", "bridge/restarted":
+					_ = s.subscribeDiagnostics(ctx)
+				}
+			}
+		}
+	}()
+}
+
+func (s *EditorService) Close() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	stop := s.lifecycleStop
+	s.lifecycleStop = nil
+	s.mu.Unlock()
+	if stop != nil {
+		stop()
+	}
+	s.disposeDiagnosticsWatcher()
+}
+
+func (s *EditorService) Diagnostics(req EditorRequest) (EditorDiagnosticsDocument, error) {
+	raw, err := s.callWithDocument("diagnostics", "diagnostics", req)
+	if err != nil {
+		return EditorDiagnosticsDocument{}, err
+	}
+	doc, err := decodeDiagnosticsDocument(raw, req.Path, req.Version)
+	if err != nil {
+		return EditorDiagnosticsDocument{}, err
+	}
+	if s.bridge != nil {
+		s.bridge.Publish(BridgeEvent{Type: "bridge/editor/diagnosticsChanged", Payload: doc})
+	}
+	return doc, nil
+}
+
+func (s *EditorService) Completion(req EditorRequest) (CompletionListDocument, error) {
+	raw, err := s.callWithDocument("completion", "completion", req)
+	if err != nil {
+		return CompletionListDocument{}, err
+	}
+	return decodeCompletionList(raw)
+}
+
+func (s *EditorService) Hover(req EditorRequest) (HoverDocument, error) {
+	raw, err := s.callWithDocument("hover", "hover", req)
+	if err != nil {
+		return HoverDocument{}, err
+	}
+	var doc HoverDocument
+	if err := decodeJSON(raw, &doc); err != nil {
+		return HoverDocument{}, newBridgeError("editor_response_invalid", "failed to decode hover response", err)
+	}
+	return doc, nil
+}
+
+func (s *EditorService) Definition(req EditorRequest) ([]LocationDocument, error) {
+	raw, err := s.callWithDocument("definition", "definition", req)
+	if err != nil {
+		return nil, err
+	}
+	return decodeLocationList(raw)
+}
+
+func (s *EditorService) References(req EditorRequest) ([]LocationDocument, error) {
+	raw, err := s.callWithDocument("references", "references", req)
+	if err != nil {
+		return nil, err
+	}
+	return decodeLocationList(raw)
+}
+
+func (s *EditorService) SignatureHelp(req EditorRequest) (map[string]any, error) {
+	raw, err := s.callWithDocument("signatureHelp", "signatureHelp", req)
+	if err != nil {
+		return nil, err
+	}
+	obj, ok := toObjectMap(raw)
+	if !ok {
+		return nil, newBridgeError("editor_response_invalid", "failed to decode signature help response", nil)
+	}
+	return obj, nil
+}
+
+func (s *EditorService) Formatting(req EditorRequest) ([]TextEdit, error) {
+	raw, err := s.callWithDocument("formatting", "formatting", req)
+	if err != nil {
+		return nil, err
+	}
+	return decodeTextEdits(raw)
+}
+
+func (s *EditorService) CodeActions(req EditorRequest) ([]map[string]any, error) {
+	raw, err := s.callWithDocument("codeActions", "codeActions", req)
+	if err != nil {
+		return nil, err
+	}
+	var actions []map[string]any
+	if err := decodeJSON(raw, &actions); err != nil {
+		return nil, newBridgeError("editor_response_invalid", "failed to decode code actions response", err)
+	}
+	return actions, nil
+}
+
+func (s *EditorService) Rename(req EditorRequest) (WorkspaceEdit, error) {
+	raw, err := s.callWithDocument("rename", "rename", req)
+	if err != nil {
+		return WorkspaceEdit{}, err
+	}
+	return decodeWorkspaceEdit(raw)
+}
+
+func (s *EditorService) DocumentSymbols(req EditorRequest) ([]DocumentSymbol, error) {
+	raw, err := s.callWithDocument("documentSymbols", "documentSymbols", req)
+	if err != nil {
+		return nil, err
+	}
+	var symbols []DocumentSymbol
+	if err := decodeJSON(raw, &symbols); err != nil {
+		return nil, newBridgeError("editor_response_invalid", "failed to decode document symbols response", err)
+	}
+	return symbols, nil
+}
+
+func (s *EditorService) HasCapability(feature string, aliases ...string) bool {
+	if s == nil || s.bridge == nil {
+		return false
+	}
+	enabled, err := s.bridge.CapabilityEnabled(append([]string{feature}, aliases...)...)
+	return err == nil && enabled
+}
+
+func (s *EditorService) callWithDocument(command, capability string, req EditorRequest) (any, error) {
+	snapshot, err := s.resolveDocument(req.Path, req.Version)
+	if err != nil {
+		return nil, err
+	}
+	payload := map[string]any{
+		"path":    snapshot.Path,
+		"version": snapshot.Version,
+		"content": snapshot.Content,
+	}
+	if req.Position != nil {
+		payload["position"] = req.Position
+	}
+	if req.Range != nil {
+		payload["range"] = req.Range
+	}
+	if req.NewName != "" {
+		payload["newName"] = req.NewName
+	}
+	if req.WorkDir != "" {
+		payload["workDir"] = req.WorkDir
+	}
+	if len(req.Context) > 0 {
+		payload["context"] = req.Context
+	}
+	if len(req.Options) > 0 {
+		payload["options"] = req.Options
+	}
+	if req.Query != "" {
+		payload["query"] = req.Query
+	}
+	channel, err := s.ipcChannel(capability)
+	if err != nil {
+		return nil, err
+	}
+	response, err := channel.Call(command, payload)
+	if err != nil {
+		return nil, newBridgeError("editor_request_failed", fmt.Sprintf("editor %s request failed", command), err)
+	}
+	return response, nil
+}
+
+func (s *EditorService) resolveDocument(path string, version int) (DocumentSnapshot, error) {
+	if s == nil || s.documents == nil {
+		return DocumentSnapshot{}, newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", nil)
+	}
+	if version < 0 {
+		return DocumentSnapshot{}, newBridgeError("invalid_request", "document version must be zero or greater", nil)
+	}
+	snapshot, err := s.documents.DocumentBuffer(path)
+	if err != nil {
+		var bridgeErr *BridgeError
+		if errors.As(err, &bridgeErr) && bridgeErr.Code == "document_not_open" {
+			return s.documents.OpenDocument(path, version, nil)
+		}
+		return DocumentSnapshot{}, err
+	}
+	if version > 0 && snapshot.Version != version {
+		return DocumentSnapshot{}, newBridgeError("version_conflict", "document version does not match the tracked buffer", nil)
+	}
+	return snapshot, nil
+}
+
+func (s *EditorService) subscribeDiagnostics(ctx context.Context) error {
+	channel, err := s.ipcChannel("diagnostics")
+	if err != nil {
+		return err
+	}
+	events, dispose, err := channel.ListenContext(ctx, "diagnosticsChanged", map[string]any{})
+	if err != nil {
+		return newBridgeError("diagnostics_subscription_failed", "failed to subscribe to bridge diagnostics updates", err)
+	}
+
+	s.mu.Lock()
+	if old := s.diagnosticsStop; old != nil {
+		old()
+	}
+	s.diagnosticsStop = dispose
+	s.mu.Unlock()
+
+	go func(stop func(), eventCh <-chan interface{}) {
+		for {
+			select {
+			case <-ctx.Done():
+				stop()
+				return
+			case raw, ok := <-eventCh:
+				if !ok {
+					return
+				}
+				doc, err := decodeDiagnosticsDocument(raw, "", 0)
+				if err != nil {
+					continue
+				}
+				if s.bridge != nil {
+					s.bridge.Publish(BridgeEvent{Type: "bridge/diagnosticsChanged", Payload: doc})
+				}
+			}
+		}
+	}(dispose, events)
+
+	return nil
+}
+
+func (s *EditorService) disposeDiagnosticsWatcher() {
+	s.mu.Lock()
+	stop := s.diagnosticsStop
+	s.diagnosticsStop = nil
+	s.mu.Unlock()
+	if stop != nil {
+		stop()
+	}
+}
+
+func (s *EditorService) ipcChannel(feature string) (*IPCChannel, error) {
+	if s.client == nil || s.client.IPC() == nil {
+		return nil, newBridgeError("bridge_not_ready", "mobile runtime bridge is not ready", nil)
+	}
+	if s.bridge != nil {
+		enabled, err := s.bridge.CapabilityEnabled(feature, capabilityAlias(feature))
+		if err != nil {
+			return nil, err
+		}
+		if !enabled {
+			return nil, newBridgeError("capability_unavailable", fmt.Sprintf("bridge capability %s is unavailable", feature), nil)
+		}
+	}
+	return s.client.IPC().GetChannel(s.channelName), nil
+}
+
+func capabilityAlias(feature string) string {
+	switch feature {
+	case "signatureHelp":
+		return "signature_help"
+	case "codeActions":
+		return "codeAction"
+	case "documentSymbols":
+		return "documentSymbol"
+	default:
+		return ""
+	}
+}
+
+func decodeDiagnosticsDocument(raw any, fallbackPath string, fallbackVersion int) (EditorDiagnosticsDocument, error) {
+	type diagnosticsAlias struct {
+		Path        string             `json:"path"`
+		FilePath    string             `json:"filePath"`
+		URI         string             `json:"uri"`
+		Version     int                `json:"version"`
+		Diagnostics []EditorDiagnostic `json:"diagnostics"`
+		Items       []EditorDiagnostic `json:"items"`
+	}
+	var alias diagnosticsAlias
+	if err := decodeJSON(raw, &alias); err == nil && (alias.Path != "" || alias.FilePath != "" || alias.URI != "" || alias.Diagnostics != nil || alias.Items != nil) {
+		doc := EditorDiagnosticsDocument{
+			Path:        firstNonEmpty(alias.Path, alias.FilePath, alias.URI, fallbackPath),
+			Version:     alias.Version,
+			Diagnostics: alias.Diagnostics,
+		}
+		if len(doc.Diagnostics) == 0 && len(alias.Items) > 0 {
+			doc.Diagnostics = alias.Items
+		}
+		if doc.Version == 0 {
+			doc.Version = fallbackVersion
+		}
+		return doc, nil
+	}
+	var list []EditorDiagnostic
+	if err := decodeJSON(raw, &list); err == nil {
+		return EditorDiagnosticsDocument{Path: fallbackPath, Version: fallbackVersion, Diagnostics: list}, nil
+	}
+	return EditorDiagnosticsDocument{}, newBridgeError("editor_response_invalid", "failed to decode diagnostics response", nil)
+}
+
+func decodeCompletionList(raw any) (CompletionListDocument, error) {
+	type completionAlias struct {
+		IsIncomplete bool             `json:"isIncomplete"`
+		Items        []CompletionItem `json:"items"`
+	}
+	var alias completionAlias
+	if err := decodeJSON(raw, &alias); err == nil && alias.Items != nil {
+		return CompletionListDocument{IsIncomplete: alias.IsIncomplete, Items: alias.Items}, nil
+	}
+	var items []CompletionItem
+	if err := decodeJSON(raw, &items); err == nil {
+		return CompletionListDocument{Items: items}, nil
+	}
+	return CompletionListDocument{}, newBridgeError("editor_response_invalid", "failed to decode completion response", nil)
+}
+
+func decodeLocationList(raw any) ([]LocationDocument, error) {
+	var docs []LocationDocument
+	if err := decodeJSON(raw, &docs); err != nil {
+		return nil, newBridgeError("editor_response_invalid", "failed to decode location response", err)
+	}
+	return docs, nil
+}
+
+func decodeTextEdits(raw any) ([]TextEdit, error) {
+	var edits []TextEdit
+	if err := decodeJSON(raw, &edits); err != nil {
+		return nil, newBridgeError("editor_response_invalid", "failed to decode text edits response", err)
+	}
+	return edits, nil
+}
+
+func decodeWorkspaceEdit(raw any) (WorkspaceEdit, error) {
+	var edit WorkspaceEdit
+	if err := decodeJSON(raw, &edit); err != nil {
+		return WorkspaceEdit{}, newBridgeError("editor_response_invalid", "failed to decode workspace edit response", err)
+	}
+	return edit, nil
+}
+
+// CapabilityEnabled reports whether any of the named capabilities are enabled in the current bridge metadata.
+func (m *BridgeManager) CapabilityEnabled(names ...string) (bool, error) {
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		entry, err := m.Capability(name)
+		if err == nil {
+			return capabilityEnabled(entry), nil
+		}
+		var bridgeErr *BridgeError
+		if errors.As(err, &bridgeErr) && bridgeErr.Code == "capability_unavailable" {
+			continue
+		}
+		return false, err
+	}
+	return false, nil
+}
+
+func pathToDocumentURI(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	slashed := filepath.ToSlash(path)
+	if !strings.HasPrefix(slashed, "/") {
+		slashed = "/" + slashed
+	}
+	return "file://" + (&url.URL{Path: slashed}).EscapedPath()
+}

--- a/server/internal/vscode/editor.go
+++ b/server/internal/vscode/editor.go
@@ -341,13 +341,9 @@ func (s *EditorService) resolveDocument(path string, version int) (DocumentSnaps
 	}
 	snapshot, err := s.documents.DocumentBuffer(path)
 	if err != nil {
-		var bridgeErr *BridgeError
-		if errors.As(err, &bridgeErr) && bridgeErr.Code == "document_not_open" {
-			return s.documents.OpenDocument(path, version, nil)
-		}
 		return DocumentSnapshot{}, err
 	}
-	if version > 0 && snapshot.Version != version {
+	if snapshot.Version != version {
 		return DocumentSnapshot{}, newBridgeError("version_conflict", "document version does not match the tracked buffer", nil)
 	}
 	return snapshot, nil

--- a/server/internal/vscode/editor_test.go
+++ b/server/internal/vscode/editor_test.go
@@ -1,0 +1,423 @@
+package vscode
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type editorRequestCapture struct {
+	Command string
+	Payload map[string]any
+}
+
+func newEditorRuntimeServer(t *testing.T, responseFor func(command string, payload map[string]any) any) (*httptest.Server, <-chan editorRequestCapture) {
+	t.Helper()
+
+	requests := make(chan editorRequestCapture, 32)
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade failed: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		auth := mustReadEditorProtocolMessage(t, conn)
+		if auth.Type != ProtocolMessageControl {
+			t.Errorf("auth message type = %v, want control", auth.Type)
+			return
+		}
+		var authReq AuthRequest
+		if err := json.Unmarshal(auth.Data, &authReq); err != nil {
+			t.Errorf("unmarshal auth request: %v", err)
+			return
+		}
+		if authReq.Type != "auth" {
+			t.Errorf("auth request type = %q, want auth", authReq.Type)
+			return
+		}
+		mustWriteEditorControlJSON(t, conn, map[string]any{
+			"type":       "sign",
+			"data":       "challenge",
+			"signedData": "challenge",
+		})
+
+		connType := mustReadEditorProtocolMessage(t, conn)
+		if connType.Type != ProtocolMessageControl {
+			t.Errorf("connection type message type = %v, want control", connType.Type)
+			return
+		}
+		var connReq ConnectionTypeRequest
+		if err := json.Unmarshal(connType.Data, &connReq); err != nil {
+			t.Errorf("unmarshal connection type request: %v", err)
+			return
+		}
+		if connReq.Type != "connectionType" {
+			t.Errorf("connection type request type = %q, want connectionType", connReq.Type)
+			return
+		}
+		mustWriteEditorControlJSON(t, conn, map[string]any{"type": "ok"})
+
+		bootstrap := mustReadEditorProtocolMessage(t, conn)
+		if bootstrap.Type != ProtocolMessageRegular {
+			t.Errorf("bootstrap message type = %v, want regular", bootstrap.Type)
+			return
+		}
+		mustWriteEditorProtocolMessage(t, conn, &ProtocolMessage{
+			Type: ProtocolMessageRegular,
+			Data: EncodeIPCMessage([]interface{}{int(ResponseTypeInitialize)}, nil),
+		})
+
+		for {
+			msg, err := readEditorProtocolMessage(conn)
+			if err != nil {
+				return
+			}
+			if msg.Type != ProtocolMessageRegular {
+				continue
+			}
+			header, body, err := DecodeIPCMessage(msg.Data)
+			if err != nil {
+				t.Errorf("decode ipc message: %v", err)
+				return
+			}
+			hdr, ok := header.([]interface{})
+			if !ok || len(hdr) < 4 {
+				t.Errorf("header = %#v, want request header", header)
+				return
+			}
+			reqType, err := toInt(hdr[0])
+			if err != nil {
+				t.Errorf("request type: %v", err)
+				return
+			}
+			if RequestType(reqType) != RequestTypePromise {
+				t.Errorf("request type = %d, want promise", reqType)
+				return
+			}
+			id, err := toInt(hdr[1])
+			if err != nil {
+				t.Errorf("request id: %v", err)
+				return
+			}
+			command, _ := hdr[3].(string)
+			payload, _ := body.(map[string]any)
+			if payload == nil {
+				payload = map[string]any{}
+			}
+
+			select {
+			case requests <- editorRequestCapture{Command: command, Payload: payload}:
+			default:
+				t.Errorf("request buffer overflow for command %q", command)
+				return
+			}
+
+			respBody := responseFor(command, payload)
+			responseMsg := &ProtocolMessage{
+				Type: ProtocolMessageRegular,
+				Data: EncodeIPCMessage([]interface{}{int(ResponseTypePromiseSuccess), id}, respBody),
+			}
+			mustWriteEditorProtocolMessage(t, conn, responseMsg)
+		}
+	}))
+
+	t.Cleanup(ts.Close)
+	return ts, requests
+}
+
+func mustReadEditorProtocolMessage(t *testing.T, conn *websocket.Conn) *ProtocolMessage {
+	t.Helper()
+	msg, err := readEditorProtocolMessage(conn)
+	if err != nil {
+		t.Fatalf("read protocol message: %v", err)
+	}
+	return msg
+}
+
+func readEditorProtocolMessage(conn *websocket.Conn) (*ProtocolMessage, error) {
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		return nil, err
+	}
+	return DecodeProtocolMessage(bytes.NewReader(raw))
+}
+
+func mustWriteEditorControlJSON(t *testing.T, conn *websocket.Conn, payload map[string]any) {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal control payload: %v", err)
+	}
+	mustWriteEditorProtocolMessage(t, conn, &ProtocolMessage{
+		Type: ProtocolMessageControl,
+		Data: data,
+	})
+}
+
+func mustWriteEditorProtocolMessage(t *testing.T, conn *websocket.Conn, msg *ProtocolMessage) {
+	t.Helper()
+	data := EncodeProtocolMessage(msg)
+	if err := conn.WriteMessage(websocket.BinaryMessage, data); err != nil {
+		t.Fatalf("write protocol message: %v", err)
+	}
+}
+
+func connectEditorClient(t *testing.T, serverURL string) *Client {
+	t.Helper()
+
+	client := NewClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	if err := client.Connect(ctx, serverURL, ""); err != nil {
+		t.Fatalf("connect editor client: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+	return client
+}
+
+func readyEditorManager(t *testing.T, client *Client) *BridgeManager {
+	t.Helper()
+
+	metadataPath := filepath.Join(t.TempDir(), "bridge.json")
+	manager := NewBridgeManager(BridgeManagerOptions{MetadataPath: metadataPath, Client: client})
+	writeBridgeMetadataFile(t, metadataPath, BridgeMetadata{
+		Generation:      "gen-editor",
+		State:           bridgeStateReady,
+		ProtocolVersion: defaultBridgeProtocolVersion,
+		BridgeVersion:   "0.3.0",
+		Capabilities: map[string]interface{}{
+			"diagnostics":     map[string]interface{}{"enabled": true},
+			"completion":      map[string]interface{}{"enabled": true},
+			"hover":           map[string]interface{}{"enabled": true},
+			"definition":      map[string]interface{}{"enabled": true},
+			"references":      map[string]interface{}{"enabled": true},
+			"signatureHelp":   map[string]interface{}{"enabled": true},
+			"formatting":      map[string]interface{}{"enabled": true},
+			"codeActions":     map[string]interface{}{"enabled": true},
+			"rename":          map[string]interface{}{"enabled": true},
+			"documentSymbols": map[string]interface{}{"enabled": true},
+		},
+	})
+	manager.poll()
+	t.Cleanup(manager.Close)
+	return manager
+}
+
+func expectRequestPayload(t *testing.T, got editorRequestCapture, wantCommand string, mustHave, mustNotHave []string) {
+	t.Helper()
+
+	if got.Command != wantCommand {
+		t.Fatalf("command = %q, want %q", got.Command, wantCommand)
+	}
+	for _, key := range mustHave {
+		if _, ok := got.Payload[key]; !ok {
+			t.Fatalf("payload missing %q: %#v", key, got.Payload)
+		}
+	}
+	for _, key := range mustNotHave {
+		if _, ok := got.Payload[key]; ok {
+			t.Fatalf("payload unexpectedly included %q: %#v", key, got.Payload)
+		}
+	}
+}
+
+func TestEditorServiceSendsVersionedUnsavedBufferAndRequiredContext(t *testing.T) {
+	ts, requests := newEditorRuntimeServer(t, func(command string, payload map[string]any) any {
+		switch command {
+		case "completion":
+			return map[string]any{"isIncomplete": false, "items": []any{}}
+		case "hover":
+			return map[string]any{"contents": "hover"}
+		case "definition", "references", "formatting", "codeActions", "documentSymbols":
+			return []any{}
+		case "signatureHelp":
+			return map[string]any{}
+		case "rename":
+			return map[string]any{"changes": map[string]any{}}
+		default:
+			return map[string]any{}
+		}
+	})
+	client := connectEditorClient(t, ts.URL)
+	manager := readyEditorManager(t, client)
+	store := newStubDocumentStore()
+	store.files["/workspace/main.dart"] = []byte("print('disk');\n")
+	docs := NewDocumentSyncService(store)
+	editor := NewEditorService(client, manager, docs)
+
+	initial := "print('draft');\n"
+	if _, err := docs.OpenDocument("/workspace/main.dart", 1, &initial); err != nil {
+		t.Fatalf("open document: %v", err)
+	}
+	if _, err := docs.ApplyDocumentChanges("/workspace/main.dart", 2, []DocumentChange{{
+		Range: &DocumentRange{
+			Start: DocumentPosition{Line: 0, Character: 14},
+			End:   DocumentPosition{Line: 0, Character: 14},
+		},
+		Text: " // unsaved",
+	}}); err != nil {
+		t.Fatalf("apply document changes: %v", err)
+	}
+
+	unsaved := "print('draft') // unsaved;\n"
+	position := DocumentPosition{Line: 0, Character: 7}
+	rangeEdit := DocumentRange{
+		Start: DocumentPosition{Line: 0, Character: 7},
+		End:   DocumentPosition{Line: 0, Character: 13},
+	}
+
+	cases := []struct {
+		name        string
+		call        func(EditorRequest) (any, error)
+		req         EditorRequest
+		wantCommand  string
+		mustHave    []string
+		mustNotHave []string
+	}{
+		{
+			name: "completion",
+			call: func(req EditorRequest) (any, error) { return editor.Completion(req) },
+			req:  EditorRequest{Path: "/workspace/main.dart", Version: 2, Position: &position},
+			wantCommand: "completion",
+			mustHave:    []string{"path", "version", "content", "position"},
+			mustNotHave: []string{"range", "newName"},
+		},
+		{
+			name: "hover",
+			call: func(req EditorRequest) (any, error) { return editor.Hover(req) },
+			req:  EditorRequest{Path: "/workspace/main.dart", Version: 2, Position: &position},
+			wantCommand: "hover",
+			mustHave:    []string{"path", "version", "content", "position"},
+			mustNotHave: []string{"range", "newName"},
+		},
+		{
+			name: "definition",
+			call: func(req EditorRequest) (any, error) { return editor.Definition(req) },
+			req:  EditorRequest{Path: "/workspace/main.dart", Version: 2, Position: &position},
+			wantCommand: "definition",
+			mustHave:    []string{"path", "version", "content", "position"},
+			mustNotHave: []string{"range", "newName"},
+		},
+		{
+			name: "references",
+			call: func(req EditorRequest) (any, error) { return editor.References(req) },
+			req:  EditorRequest{Path: "/workspace/main.dart", Version: 2, Position: &position},
+			wantCommand: "references",
+			mustHave:    []string{"path", "version", "content", "position"},
+			mustNotHave: []string{"range", "newName"},
+		},
+		{
+			name: "signatureHelp",
+			call: func(req EditorRequest) (any, error) { return editor.SignatureHelp(req) },
+			req:  EditorRequest{Path: "/workspace/main.dart", Version: 2, Position: &position},
+			wantCommand: "signatureHelp",
+			mustHave:    []string{"path", "version", "content", "position"},
+			mustNotHave: []string{"range", "newName"},
+		},
+		{
+			name: "codeActions",
+			call: func(req EditorRequest) (any, error) { return editor.CodeActions(req) },
+			req:  EditorRequest{Path: "/workspace/main.dart", Version: 2, Range: &rangeEdit},
+			wantCommand: "codeActions",
+			mustHave:    []string{"path", "version", "content", "range"},
+			mustNotHave: []string{"position", "newName"},
+		},
+		{
+			name: "rename",
+			call: func(req EditorRequest) (any, error) { return editor.Rename(req) },
+			req:  EditorRequest{Path: "/workspace/main.dart", Version: 2, Position: &position, NewName: "renamedValue"},
+			wantCommand: "rename",
+			mustHave:    []string{"path", "version", "content", "position", "newName"},
+			mustNotHave: []string{"range"},
+		},
+		{
+			name: "formatting",
+			call: func(req EditorRequest) (any, error) { return editor.Formatting(req) },
+			req:  EditorRequest{Path: "/workspace/main.dart", Version: 2},
+			wantCommand: "formatting",
+			mustHave:    []string{"path", "version", "content"},
+			mustNotHave: []string{"position", "range", "newName"},
+		},
+		{
+			name: "documentSymbols",
+			call: func(req EditorRequest) (any, error) { return editor.DocumentSymbols(req) },
+			req:  EditorRequest{Path: "/workspace/main.dart", Version: 2},
+			wantCommand: "documentSymbols",
+			mustHave:    []string{"path", "version", "content"},
+			mustNotHave: []string{"position", "range", "newName"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.call(tc.req)
+			if err != nil {
+				t.Fatalf("%s failed: %v", tc.name, err)
+			}
+
+			req := <-requests
+			expectRequestPayload(t, req, tc.wantCommand, tc.mustHave, tc.mustNotHave)
+			if got := req.Payload["content"]; got != unsaved {
+				t.Fatalf("payload content = %#v, want %q", got, unsaved)
+			}
+			if tc.wantCommand == "rename" {
+				if got := req.Payload["newName"]; got != "renamedValue" {
+					t.Fatalf("rename newName = %#v, want %q", got, "renamedValue")
+				}
+			}
+		})
+	}
+}
+
+func TestEditorServiceRejectsStaleVersionBeforeCallingBridge(t *testing.T) {
+	ts, requests := newEditorRuntimeServer(t, func(command string, payload map[string]any) any {
+		return map[string]any{"items": []any{}}
+	})
+	client := connectEditorClient(t, ts.URL)
+	manager := readyEditorManager(t, client)
+	store := newStubDocumentStore()
+	store.files["/workspace/stale.dart"] = []byte("base\n")
+	docs := NewDocumentSyncService(store)
+	editor := NewEditorService(client, manager, docs)
+
+	initial := "draft\n"
+	if _, err := docs.OpenDocument("/workspace/stale.dart", 1, &initial); err != nil {
+		t.Fatalf("open document: %v", err)
+	}
+	if _, err := docs.ApplyDocumentChanges("/workspace/stale.dart", 2, []DocumentChange{{
+		Text: "changed\n",
+	}}); err != nil {
+		t.Fatalf("apply document changes: %v", err)
+	}
+
+	_, err := editor.Completion(EditorRequest{
+		Path:     "/workspace/stale.dart",
+		Version:  1,
+		Position: &DocumentPosition{Line: 0, Character: 0},
+	})
+	if err == nil {
+		t.Fatal("expected stale version error")
+	}
+	bridgeErr, ok := err.(*BridgeError)
+	if !ok || bridgeErr.Code != "version_conflict" {
+		t.Fatalf("error = %#v, want version_conflict", err)
+	}
+	select {
+	case req := <-requests:
+		t.Fatalf("unexpected bridge request after stale version rejection: %#v", req)
+	default:
+	}
+}


### PR DESCRIPTION
## Summary
- tighten the bridge editor request contract so diagnostics and all editor-intelligence RPCs require versioned document context and return precise bridge error mappings
- ensure diagnostics resolve from the live document-sync buffer instead of falling back to legacy disk/shell behavior when bridge-backed editor intelligence is available
- add focused API and editor-service tests covering unsaved-buffer requests, version conflicts, diagnostics event flow, and RFC-shaped completion / edit payloads

## Why
ASE-43 requires all editor intelligence to run against the runtime document buffer with VS Code-like payloads and explicit `capability_unavailable` / versioned failure modes. The remaining review fixes make that contract strict and verifiable.

## Issue
- Closes #4
- OpenASE ticket: ASE-43

## Validation
- `cd server && $HOME/go-sdk/go/bin/go test ./...`
- `cd server && $HOME/go-sdk/go/bin/go vet ./...`
- `make verify-bridge-foundation` not run in this workspace because `openvscode-server/package.json` is missing
