### PR TITLE
ASE-52: backfill GitHub collaboration backend review PR

### DIFF
--- a/docs/github-auth-backend.md
+++ b/docs/github-auth-backend.md
@@ -15,6 +15,16 @@ All routes are available with or without the `/api` prefix:
 - `POST /github/auth/device/poll`
 - `GET /github/auth/status`
 - `POST /github/auth/disconnect`
+- `GET /github/account`
+- `GET /github/issues`
+- `GET /github/issues/{number}`
+- `POST /github/issues/{number}/comments`
+- `GET /github/pulls`
+- `GET /github/pulls/{number}`
+- `GET /github/pulls/{number}/files`
+- `GET /github/pulls/{number}/comments`
+- `POST /github/pulls/{number}/comments`
+- `POST /github/pulls/{number}/reviews`
 
 ### `GET /github/repos/current`
 
@@ -222,3 +232,203 @@ Before a token-backed GitHub API call runs, the server calls the shared refresh
 preflight. If refresh succeeds, the record is replaced atomically. If refresh
 fails because the refresh token is invalid or expired, callers receive a
 structured `reauth_required` error so the client can restart device flow.
+
+
+## Collaboration endpoints
+
+All collaboration routes derive the current repository from the same workspace
+`path`/repo-context logic as `GET /github/repos/current`. `path` is optional on
+all `GET` endpoints and defaults to the server work dir. `workspace_path` is the
+matching optional field for `POST` requests.
+
+### `GET /github/account`
+
+Returns the authenticated GitHub account for the current repository host.
+
+Example response:
+
+```json
+{
+  "github_host": "github.com",
+  "repository": {
+    "github_host": "github.com",
+    "owner": "octo-org",
+    "name": "mobile-app",
+    "full_name": "octo-org/mobile-app",
+    "remote_name": "origin",
+    "remote_url": "git@github.com:octo-org/mobile-app.git",
+    "repo_root": "/workspace/mobile-app"
+  },
+  "account": {
+    "login": "octocat",
+    "id": 9,
+    "name": "The Octocat",
+    "avatar_url": "https://avatars.githubusercontent.com/u/9?v=4",
+    "html_url": "https://github.com/octocat"
+  }
+}
+```
+
+### `GET /github/issues`
+
+Supported query params are passed through to the repo issues REST API with
+snake_case responses: `state`, `sort`, `direction`, `since`, `labels`,
+`creator`, `mentioned`, `assignee`, `milestone`, `page`, and `per_page`.
+Pull-request-backed issue records are filtered out from this list.
+
+Example response:
+
+```json
+{
+  "repository": {
+    "full_name": "octo-org/mobile-app"
+  },
+  "issues": [
+    {
+      "number": 42,
+      "title": "Fix flaky mobile reconnect",
+      "state": "open",
+      "body": "Reconnect can stall after sleep...",
+      "html_url": "https://github.com/octo-org/mobile-app/issues/42",
+      "comments_count": 3,
+      "locked": false,
+      "author": {
+        "login": "octocat",
+        "id": 9
+      },
+      "labels": [
+        {
+          "name": "bug",
+          "color": "d73a4a"
+        }
+      ],
+      "created_at": "2026-04-19T10:00:00Z",
+      "updated_at": "2026-04-20T08:30:00Z"
+    }
+  ]
+}
+```
+
+### `GET /github/issues/{number}`
+
+Returns the normalized issue detail payload for the current repository.
+
+### `POST /github/issues/{number}/comments`
+
+Request body:
+
+```json
+{
+  "workspace_path": "/workspace/mobile-app",
+  "body": "I can take this one."
+}
+```
+
+Response body:
+
+```json
+{
+  "repository": {
+    "full_name": "octo-org/mobile-app"
+  },
+  "comment": {
+    "id": 1001,
+    "body": "I can take this one.",
+    "html_url": "https://github.com/octo-org/mobile-app/issues/42#issuecomment-1001",
+    "author": {
+      "login": "octocat",
+      "id": 9
+    },
+    "created_at": "2026-04-20T09:00:00Z"
+  }
+}
+```
+
+### `GET /github/pulls`
+
+Supported query params: `state`, `assigned_to_me`, `created_by_me`, `mentioned`,
+`needs_review`, `head`, `base`, `sort`, `direction`, `page`, and `per_page`.
+Current-user PR filters use a repo-scoped search query so they can be combined
+with pagination and state while still returning normalized PR payloads.
+
+### `GET /github/pulls/{number}`
+
+Returns the normalized pull request detail plus aggregated commit status/check
+summary under `pull_request.checks`.
+
+Example `checks` payload:
+
+```json
+{
+  "state": "pending",
+  "total_count": 3,
+  "success_count": 1,
+  "pending_count": 1,
+  "failure_count": 1,
+  "checks": [
+    {
+      "name": "ci / unit-tests",
+      "status": "completed",
+      "conclusion": "success",
+      "details_url": "https://github.com/octo-org/mobile-app/actions/runs/1"
+    },
+    {
+      "name": "buildkite/mobile",
+      "status": "pending",
+      "details_url": "https://buildkite.example/run/2"
+    }
+  ]
+}
+```
+
+### `GET /github/pulls/{number}/files`
+
+Returns normalized changed-file entries with `filename`, `status`, `additions`,
+`deletions`, `changes`, optional `patch`, and optional `previous_filename`.
+
+### `GET /github/pulls/{number}/comments`
+
+Returns normalized review-thread comment entries for the pull request.
+Supported query params: `sort`, `direction`, `since`, `page`, and `per_page`.
+
+### `POST /github/pulls/{number}/comments`
+
+Creates a PR review comment. For inline comments provide `body`, `path`,
+`commit_id`, and `line`; for replies provide `body` plus `in_reply_to`.
+Optional multi-line anchors use `side`, `start_line`, and `start_side`.
+
+### `POST /github/pulls/{number}/reviews`
+
+Creates a pull-request review. `event` should be one of `COMMENT`, `APPROVE`,
+or `REQUEST_CHANGES`. Draft review comments use normalized snake_case fields.
+
+Example request:
+
+```json
+{
+  "workspace_path": "/workspace/mobile-app",
+  "event": "REQUEST_CHANGES",
+  "body": "Please tighten the retry bounds.",
+  "comments": [
+    {
+      "body": "This branch can loop forever.",
+      "path": "server/internal/github/service.go",
+      "line": 142,
+      "side": "RIGHT"
+    }
+  ]
+}
+```
+
+## Collaboration error contract
+
+These endpoints return JSON errors via the same `error_code`/`message` envelope
+used by auth routes. Expected collaboration error codes include:
+
+- `repo_not_github`: the workspace path does not resolve to a GitHub-backed repository
+- `invalid_request`: missing/invalid route params, query params, or request body
+- `not_authenticated`: no stored GitHub auth session exists for the repo host
+- `reauth_required`: refresh failed or the access token is no longer usable
+- `repo_access_unavailable`: GitHub rejected repository access for the account
+- `not_found`: the repo-scoped issue, pull request, or nested resource was not found
+- `github_auth_error`: upstream GitHub request failed in an unexpected way

--- a/docs/github-auth-backend.md
+++ b/docs/github-auth-backend.md
@@ -249,7 +249,6 @@ Example response:
 
 ```json
 {
-  "github_host": "github.com",
   "repository": {
     "github_host": "github.com",
     "owner": "octo-org",
@@ -271,18 +270,15 @@ Example response:
 
 ### `GET /github/issues`
 
-Supported query params are passed through to the repo issues REST API with
-snake_case responses: `state`, `sort`, `direction`, `since`, `labels`,
-`creator`, `mentioned`, `assignee`, `milestone`, `page`, and `per_page`.
-Pull-request-backed issue records are filtered out from this list.
+Supported query params: `state`, `assigned_to_me`, `created_by_me`,
+`mentioned`, `page`, and `per_page`. The backend normalizes these into
+repo-scoped list or search requests, and pull-request-backed issue records are
+filtered out from this list.
 
 Example response:
 
 ```json
 {
-  "repository": {
-    "full_name": "octo-org/mobile-app"
-  },
   "issues": [
     {
       "number": 42,
@@ -311,7 +307,8 @@ Example response:
 
 ### `GET /github/issues/{number}`
 
-Returns the normalized issue detail payload for the current repository.
+Returns the normalized issue detail payload plus `comments` for the current
+repository.
 
 ### `POST /github/issues/{number}/comments`
 
@@ -328,9 +325,6 @@ Response body:
 
 ```json
 {
-  "repository": {
-    "full_name": "octo-org/mobile-app"
-  },
   "comment": {
     "id": 1001,
     "body": "I can take this one.",
@@ -347,14 +341,17 @@ Response body:
 ### `GET /github/pulls`
 
 Supported query params: `state`, `assigned_to_me`, `created_by_me`, `mentioned`,
-`needs_review`, `head`, `base`, `sort`, `direction`, `page`, and `per_page`.
-Current-user PR filters use a repo-scoped search query so they can be combined
-with pagination and state while still returning normalized PR payloads.
+`needs_review`, `page`, and `per_page`.
+Current-user PR filters use a repo-scoped search query so `assigned_to_me`,
+`created_by_me`, `mentioned`, and `needs_review` can be combined with state and
+pagination while still returning normalized PR payloads. `head`, `base`,
+`sort`, and `direction` are not currently supported on this endpoint.
 
 ### `GET /github/pulls/{number}`
 
-Returns the normalized pull request detail plus aggregated commit status/check
-summary under `pull_request.checks`.
+Returns the normalized pull request detail plus `files`, `comments`, and
+`reviews`. Aggregated commit status/check summary is included under
+`pull_request.checks`.
 
 Example `checks` payload:
 
@@ -388,7 +385,8 @@ Returns normalized changed-file entries with `filename`, `status`, `additions`,
 
 ### `GET /github/pulls/{number}/comments`
 
-Returns normalized review-thread comment entries for the pull request.
+Returns normalized review-thread comment entries plus `reviews` for the pull
+request.
 Supported query params: `sort`, `direction`, `since`, `page`, and `per_page`.
 
 ### `POST /github/pulls/{number}/comments`
@@ -429,6 +427,7 @@ used by auth routes. Expected collaboration error codes include:
 - `invalid_request`: missing/invalid route params, query params, or request body
 - `not_authenticated`: no stored GitHub auth session exists for the repo host
 - `reauth_required`: refresh failed or the access token is no longer usable
+- `app_not_installed_for_repo`: the repo resolves locally but the configured GitHub App is not installed for it
 - `repo_access_unavailable`: GitHub rejected repository access for the account
 - `not_found`: the repo-scoped issue, pull request, or nested resource was not found
 - `github_auth_error`: upstream GitHub request failed in an unexpected way

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -804,3 +804,29 @@ requirements:
       - server/internal/github/service_test.go
       - server/internal/api/github_repo_context_test.go
     depends_on: [REQ-023]
+
+  - id: REQ-028
+    title: GitHub collaboration backend endpoints
+    description: >
+      Ticket ASE-52 adds repo-scoped GitHub collaboration APIs on the Go
+      server for account lookup, issue listing/detail/commenting, and pull
+      request listing/detail/files/comments/reviews using the current
+      workspace repository context. The backend refreshes user tokens before
+      repo calls, translates GitHub auth/access/request failures into stable
+      JSON error codes, keeps response contracts snake_case, and aggregates
+      PR checks/status summaries onto the pull request detail response.
+    priority: P1
+    status: implemented
+    code:
+      - project-index.yaml
+      - server/internal/github/types.go
+      - server/internal/github/client.go
+      - server/internal/github/service.go
+      - server/internal/github/collaboration.go
+      - server/internal/api/router.go
+      - server/internal/api/github_collaboration.go
+      - docs/github-auth-backend.md
+    tests:
+      - server/internal/github/service_test.go
+      - server/internal/api/github_collaboration_test.go
+    depends_on: [REQ-023, REQ-027]

--- a/server/internal/api/github_collaboration.go
+++ b/server/internal/api/github_collaboration.go
@@ -1,0 +1,481 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	gitauth "github.com/Lincyaw/vscode-mobile/server/internal/github"
+)
+
+type githubIssueCommentRequest struct {
+	WorkspacePath string `json:"workspace_path"`
+	WorkDir       string `json:"workDir"`
+	WorkDirAlt    string `json:"work_dir"`
+	Body          string `json:"body"`
+}
+
+type githubPullCommentRequest struct {
+	WorkspacePath string `json:"workspace_path"`
+	WorkDir       string `json:"workDir"`
+	WorkDirAlt    string `json:"work_dir"`
+	Body          string `json:"body"`
+	Path          string `json:"path,omitempty"`
+	CommitID      string `json:"commit_id,omitempty"`
+	Side          string `json:"side,omitempty"`
+	StartSide     string `json:"start_side,omitempty"`
+	Line          int    `json:"line,omitempty"`
+	StartLine     int    `json:"start_line,omitempty"`
+	InReplyTo     int64  `json:"in_reply_to,omitempty"`
+}
+
+type githubPullReviewCommentRequest struct {
+	Body      string `json:"body"`
+	Path      string `json:"path,omitempty"`
+	Side      string `json:"side,omitempty"`
+	StartSide string `json:"start_side,omitempty"`
+	Line      int    `json:"line,omitempty"`
+	StartLine int    `json:"start_line,omitempty"`
+}
+
+type githubPullReviewRequest struct {
+	WorkspacePath string                           `json:"workspace_path"`
+	WorkDir       string                           `json:"workDir"`
+	WorkDirAlt    string                           `json:"work_dir"`
+	Event         string                           `json:"event,omitempty"`
+	Body          string                           `json:"body,omitempty"`
+	CommitID      string                           `json:"commit_id,omitempty"`
+	Comments      []githubPullReviewCommentRequest `json:"comments,omitempty"`
+}
+
+func (s *Server) registerGitHubCollaborationRoutes(mux *http.ServeMux) {
+	routes := []struct {
+		method  string
+		pattern string
+		handler http.HandlerFunc
+	}{
+		{http.MethodGet, "/api/github/account", s.handleGitHubAccount},
+		{http.MethodGet, "/github/account", s.handleGitHubAccount},
+		{http.MethodGet, "/api/github/issues", s.handleGitHubIssues},
+		{http.MethodGet, "/github/issues", s.handleGitHubIssues},
+		{http.MethodGet, "/api/github/issues/{number}", s.handleGitHubIssue},
+		{http.MethodGet, "/github/issues/{number}", s.handleGitHubIssue},
+		{http.MethodPost, "/api/github/issues/{number}/comments", s.handleGitHubIssueComment},
+		{http.MethodPost, "/github/issues/{number}/comments", s.handleGitHubIssueComment},
+		{http.MethodGet, "/api/github/pulls", s.handleGitHubPulls},
+		{http.MethodGet, "/github/pulls", s.handleGitHubPulls},
+		{http.MethodGet, "/api/github/pulls/{number}", s.handleGitHubPull},
+		{http.MethodGet, "/github/pulls/{number}", s.handleGitHubPull},
+		{http.MethodGet, "/api/github/pulls/{number}/files", s.handleGitHubPullFiles},
+		{http.MethodGet, "/github/pulls/{number}/files", s.handleGitHubPullFiles},
+		{http.MethodGet, "/api/github/pulls/{number}/comments", s.handleGitHubPullComments},
+		{http.MethodGet, "/github/pulls/{number}/comments", s.handleGitHubPullComments},
+		{http.MethodPost, "/api/github/pulls/{number}/comments", s.handleGitHubPullComment},
+		{http.MethodPost, "/github/pulls/{number}/comments", s.handleGitHubPullComment},
+		{http.MethodPost, "/api/github/pulls/{number}/reviews", s.handleGitHubPullReview},
+		{http.MethodPost, "/github/pulls/{number}/reviews", s.handleGitHubPullReview},
+	}
+	for _, route := range routes {
+		mux.HandleFunc(route.method+" "+route.pattern, route.handler)
+	}
+}
+
+func (s *Server) handleGitHubAccount(w http.ResponseWriter, r *http.Request) {
+	service := s.githubAuthService()
+	if service == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "github_auth_disabled", "github auth is not configured")
+		return
+	}
+	workspace := s.workspacePathForRequest(r)
+	account, repository, err := service.GetCurrentRepoAccount(r.Context(), s.git, workspace)
+	if err != nil {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"account": account, "repository": repository})
+}
+
+func (s *Server) handleGitHubIssues(w http.ResponseWriter, r *http.Request) {
+	service := s.githubAuthService()
+	if service == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "github_auth_disabled", "github auth is not configured")
+		return
+	}
+	filter, err := parseCollaborationFilter(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	issues, err := service.ListIssues(r.Context(), s.workspacePathForRequest(r), filter)
+	if err != nil {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"issues": issues})
+}
+
+func (s *Server) handleGitHubIssue(w http.ResponseWriter, r *http.Request) {
+	service := s.githubAuthService()
+	if service == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "github_auth_disabled", "github auth is not configured")
+		return
+	}
+	number, err := parseRouteNumber(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	workspace := s.workspacePathForRequest(r)
+	issue, _, err := service.GetCurrentRepoIssue(r.Context(), s.git, workspace, number)
+	if err != nil {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	comments, _, err := service.GetIssueComments(r.Context(), workspace, number, parseListOptionsLoose(r))
+	if err != nil && !errors.Is(err, gitauth.ErrNotFound) {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"issue": issue, "comments": comments})
+}
+
+func (s *Server) handleGitHubIssueComment(w http.ResponseWriter, r *http.Request) {
+	service := s.githubAuthService()
+	if service == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "github_auth_disabled", "github auth is not configured")
+		return
+	}
+	number, err := parseRouteNumber(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	var req githubIssueCommentRequest
+	if err := decodeJSONBody(r, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Body) == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "body is required")
+		return
+	}
+	comment, err := service.CreateIssueComment(r.Context(), workspacePathFromBody(req.WorkspacePath, req.WorkDir, req.WorkDirAlt), number, gitauth.CreateIssueCommentInput{Body: req.Body})
+	if err != nil {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{"comment": comment})
+}
+
+func (s *Server) handleGitHubPulls(w http.ResponseWriter, r *http.Request) {
+	service := s.githubAuthService()
+	if service == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "github_auth_disabled", "github auth is not configured")
+		return
+	}
+	filter, err := parseCollaborationFilter(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	pulls, err := service.ListPullRequests(r.Context(), s.workspacePathForRequest(r), filter)
+	if err != nil {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"pulls": pulls})
+}
+
+func (s *Server) handleGitHubPull(w http.ResponseWriter, r *http.Request) {
+	service := s.githubAuthService()
+	if service == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "github_auth_disabled", "github auth is not configured")
+		return
+	}
+	number, err := parseRouteNumber(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	workspace := s.workspacePathForRequest(r)
+	pull, err := service.GetPullRequest(r.Context(), workspace, number)
+	if err != nil {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	files, _, err := service.ListCurrentRepoPullRequestFiles(r.Context(), s.git, workspace, number, parseListOptionsLoose(r))
+	if err != nil {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	comments, _, err := service.ListCurrentRepoPullRequestComments(r.Context(), s.git, workspace, number, parseListOptionsLoose(r))
+	if err != nil {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	reviews, _, err := service.GetPullRequestReviews(r.Context(), workspace, number, parseListOptionsLoose(r))
+	if err != nil && !errors.Is(err, gitauth.ErrNotFound) {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"pull_request": pull,
+		"files":        files,
+		"comments":     comments,
+		"reviews":      reviews,
+	})
+}
+
+func (s *Server) handleGitHubPullFiles(w http.ResponseWriter, r *http.Request) {
+	service := s.githubAuthService()
+	if service == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "github_auth_disabled", "github auth is not configured")
+		return
+	}
+	number, err := parseRouteNumber(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	files, _, err := service.ListCurrentRepoPullRequestFiles(r.Context(), s.git, s.workspacePathForRequest(r), number, parseListOptionsLoose(r))
+	if err != nil {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"files": files})
+}
+
+func (s *Server) handleGitHubPullComments(w http.ResponseWriter, r *http.Request) {
+	service := s.githubAuthService()
+	if service == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "github_auth_disabled", "github auth is not configured")
+		return
+	}
+	number, err := parseRouteNumber(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	workspace := s.workspacePathForRequest(r)
+	comments, _, err := service.ListCurrentRepoPullRequestComments(r.Context(), s.git, workspace, number, parseListOptionsLoose(r))
+	if err != nil {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	reviews, _, err := service.GetPullRequestReviews(r.Context(), workspace, number, parseListOptionsLoose(r))
+	if err != nil && !errors.Is(err, gitauth.ErrNotFound) {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"comments": comments, "reviews": reviews})
+}
+
+func (s *Server) handleGitHubPullComment(w http.ResponseWriter, r *http.Request) {
+	service := s.githubAuthService()
+	if service == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "github_auth_disabled", "github auth is not configured")
+		return
+	}
+	number, err := parseRouteNumber(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	var req githubPullCommentRequest
+	if err := decodeJSONBody(r, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Body) == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "body is required")
+		return
+	}
+	comment, err := service.CreatePullRequestComment(r.Context(), workspacePathFromBody(req.WorkspacePath, req.WorkDir, req.WorkDirAlt), number, gitauth.CreatePullRequestCommentInput{
+		Body:      req.Body,
+		Path:      req.Path,
+		CommitID:  req.CommitID,
+		Side:      req.Side,
+		StartSide: req.StartSide,
+		Line:      req.Line,
+		StartLine: req.StartLine,
+		InReplyTo: req.InReplyTo,
+	})
+	if err != nil {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{"comment": comment})
+}
+
+func (s *Server) handleGitHubPullReview(w http.ResponseWriter, r *http.Request) {
+	service := s.githubAuthService()
+	if service == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "github_auth_disabled", "github auth is not configured")
+		return
+	}
+	number, err := parseRouteNumber(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	var req githubPullReviewRequest
+	if err := decodeJSONBody(r, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	comments := make([]gitauth.PullRequestReviewDraftComment, 0, len(req.Comments))
+	for _, comment := range req.Comments {
+		comments = append(comments, gitauth.PullRequestReviewDraftComment{
+			Body:      comment.Body,
+			Path:      comment.Path,
+			Side:      comment.Side,
+			StartSide: comment.StartSide,
+			Line:      comment.Line,
+			StartLine: comment.StartLine,
+		})
+	}
+	review, err := service.CreatePullRequestReview(r.Context(), workspacePathFromBody(req.WorkspacePath, req.WorkDir, req.WorkDirAlt), number, gitauth.CreatePullRequestReviewInput{
+		Event:    strings.ToUpper(strings.TrimSpace(req.Event)),
+		Body:     req.Body,
+		CommitID: req.CommitID,
+		Comments: comments,
+	})
+	if err != nil {
+		writeGitHubCollaborationError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{"review": review})
+}
+
+func parseCollaborationFilter(r *http.Request) (gitauth.CollaborationFilter, error) {
+	page, perPage, err := parsePageOptions(r)
+	if err != nil {
+		return gitauth.CollaborationFilter{}, err
+	}
+	assigned, err := parseBoolQuery(r, "assigned_to_me")
+	if err != nil {
+		return gitauth.CollaborationFilter{}, err
+	}
+	created, err := parseBoolQuery(r, "created_by_me")
+	if err != nil {
+		return gitauth.CollaborationFilter{}, err
+	}
+	mentioned, err := parseBoolQuery(r, "mentioned")
+	if err != nil {
+		return gitauth.CollaborationFilter{}, err
+	}
+	needsReview, err := parseBoolQuery(r, "needs_review")
+	if err != nil {
+		return gitauth.CollaborationFilter{}, err
+	}
+	return gitauth.CollaborationFilter{
+		State:        r.URL.Query().Get("state"),
+		AssignedToMe: assigned,
+		CreatedByMe:  created,
+		Mentioned:    mentioned,
+		NeedsReview:  needsReview,
+		Page:         page,
+		PerPage:      perPage,
+	}, nil
+}
+
+func parseListOptionsLoose(r *http.Request) gitauth.ListOptions {
+	page, perPage, _ := parsePageOptions(r)
+	return gitauth.ListOptions{Sort: r.URL.Query().Get("sort"), Direction: r.URL.Query().Get("direction"), Since: r.URL.Query().Get("since"), Page: page, PerPage: perPage}
+}
+
+func parsePageOptions(r *http.Request) (int, int, error) {
+	page := 0
+	perPage := 0
+	if raw := strings.TrimSpace(r.URL.Query().Get("page")); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil || value <= 0 {
+			return 0, 0, errors.New("page must be a positive integer")
+		}
+		page = value
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("per_page")); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil || value <= 0 {
+			return 0, 0, errors.New("per_page must be a positive integer")
+		}
+		perPage = value
+	}
+	return page, perPage, nil
+}
+
+func parseBoolQuery(r *http.Request, key string) (bool, error) {
+	raw := strings.TrimSpace(r.URL.Query().Get(key))
+	if raw == "" {
+		return false, nil
+	}
+	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, errors.New(key + " must be a boolean")
+	}
+	return value, nil
+}
+
+func parseRouteNumber(r *http.Request) (int, error) {
+	raw := strings.TrimSpace(r.PathValue("number"))
+	if raw == "" {
+		return 0, errors.New("number is required")
+	}
+	number, err := strconv.Atoi(raw)
+	if err != nil || number <= 0 {
+		return 0, errors.New("number must be a positive integer")
+	}
+	return number, nil
+}
+
+func workspacePathFromQuery(r *http.Request) string {
+	for _, key := range []string{"path", "workDir", "workspaceRoot"} {
+		if value := strings.TrimSpace(r.URL.Query().Get(key)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func (s *Server) workspacePathForRequest(r *http.Request) string {
+	if path := workspacePathFromQuery(r); path != "" {
+		return path
+	}
+	service := s.githubAuthService()
+	if service == nil {
+		return ""
+	}
+	current, err := service.ProbeCurrentRepo(r.Context(), s.git, "")
+	if err != nil || current == nil || current.Repository == nil {
+		return ""
+	}
+	return current.Repository.RepoRoot
+}
+
+func workspacePathFromBody(primary, camel, snake string) string {
+	for _, value := range []string{primary, camel, snake} {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func writeGitHubCollaborationError(w http.ResponseWriter, err error) {
+	status := http.StatusBadGateway
+	code := gitauth.ErrorCode(err)
+	switch {
+	case errors.Is(err, gitauth.ErrRepoNotGitHub), errors.Is(err, gitauth.ErrInvalidRequest):
+		status = http.StatusBadRequest
+	case errors.Is(err, gitauth.ErrNotAuthenticated), errors.Is(err, gitauth.ErrReauthRequired):
+		status = http.StatusUnauthorized
+	case errors.Is(err, gitauth.ErrAppNotInstalledForRepo):
+		status = http.StatusForbidden
+	case errors.Is(err, gitauth.ErrRepoAccessUnavailable):
+		status = http.StatusForbidden
+	case errors.Is(err, gitauth.ErrNotFound):
+		status = http.StatusNotFound
+	}
+	writeJSONError(w, status, code, err.Error())
+}

--- a/server/internal/api/github_collaboration_test.go
+++ b/server/internal/api/github_collaboration_test.go
@@ -1,0 +1,486 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Lincyaw/vscode-mobile/server/internal/git"
+	gitauth "github.com/Lincyaw/vscode-mobile/server/internal/github"
+	"github.com/Lincyaw/vscode-mobile/server/internal/terminal"
+)
+
+type collaborationBackendState struct {
+	issueComments []map[string]any
+	prComments    []map[string]any
+	prReviews     []map[string]any
+}
+
+type collaborationTestEnv struct {
+	server    *httptest.Server
+	backend   *httptest.Server
+	repoDir   string
+	nestedDir string
+	state     *collaborationBackendState
+}
+
+func newCollaborationTestEnv(t *testing.T) *collaborationTestEnv {
+	t.Helper()
+	repoDir, nestedDir, cleanup := repoContextSetupRepo(t, "https://github.com/acme/rocket.git")
+	t.Cleanup(cleanup)
+	state := &collaborationBackendState{}
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := handleCollaborationBackend(state, w, r); err != nil {
+			t.Fatalf("backend error: %v", err)
+		}
+	}))
+	t.Cleanup(backend.Close)
+
+	client := gitauth.NewClient(backend.Client())
+	client.SetBaseURLFuncs(func(string) string { return backend.URL }, func(string) string { return backend.URL + "/api/v3" })
+	store := gitauth.NewStore(filepath.Join(t.TempDir(), "github-auth.json"))
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	if err := store.Save(gitauth.AuthRecord{
+		GitHubHost:            gitauth.DefaultHost,
+		AccessToken:           "access-token",
+		AccessTokenExpiresAt:  now.Add(30 * time.Minute),
+		RefreshToken:          "refresh-token",
+		RefreshTokenExpiresAt: now.Add(24 * time.Hour),
+		AccountLogin:          "octocat",
+		AccountID:             9,
+	}); err != nil {
+		t.Fatalf("store.Save() error = %v", err)
+	}
+	service := gitauth.NewService(client, store, "client-id", gitauth.DefaultHost, time.Minute)
+	service.SetNow(func() time.Time { return now })
+
+	srv := NewServer(newMockFS(), nil, nil, "", git.NewGit(repoDir), terminal.NewManager(), nil, service)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return &collaborationTestEnv{server: ts, backend: backend, repoDir: repoDir, nestedDir: nestedDir, state: state}
+}
+
+func handleCollaborationBackend(state *collaborationBackendState, w http.ResponseWriter, r *http.Request) error {
+	writeJSON := func(v any) error {
+		w.Header().Set("Content-Type", "application/json")
+		return json.NewEncoder(w).Encode(v)
+	}
+	decodeBody := func() map[string]any {
+		var payload map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		return payload
+	}
+
+	switch r.URL.Path {
+	case "/api/v3/user":
+		return writeJSON(map[string]any{"login": "octocat", "id": 9, "avatar_url": "https://avatars.example/octocat", "html_url": "https://github.com/octocat"})
+	case "/api/v3/repos/acme/rocket":
+		return writeJSON(map[string]any{"name": "rocket", "full_name": "acme/rocket", "private": true, "owner": map[string]any{"login": "acme"}})
+	case "/api/v3/repos/acme/rocket/installation":
+		return writeJSON(map[string]any{"id": 101})
+	case "/api/v3/repos/acme/rocket/issues":
+		return writeJSON([]map[string]any{{"number": 7, "title": "Issue title", "state": "open", "user": map[string]any{"login": "octocat"}}})
+	case "/api/v3/repos/acme/rocket/issues/7":
+		return writeJSON(map[string]any{"number": 7, "title": "Issue title", "state": "open", "body": "Issue body", "user": map[string]any{"login": "octocat"}, "comments": len(state.issueComments)})
+	case "/api/v3/repos/acme/rocket/issues/7/comments":
+		if r.Method == http.MethodPost {
+			payload := decodeBody()
+			state.issueComments = append(state.issueComments, payload)
+			w.WriteHeader(http.StatusCreated)
+			return writeJSON(map[string]any{"id": 500 + len(state.issueComments), "body": payload["body"]})
+		}
+		comments := []map[string]any{{"id": 1, "body": "Existing issue comment"}}
+		for i, payload := range state.issueComments {
+			comments = append(comments, map[string]any{"id": 10 + i, "body": payload["body"]})
+		}
+		return writeJSON(comments)
+	case "/api/v3/repos/acme/rocket/pulls":
+		return writeJSON([]map[string]any{{"number": 12, "title": "PR title", "state": "open", "user": map[string]any{"login": "octocat"}, "head": map[string]any{"sha": "deadbeef"}}})
+	case "/api/v3/search/issues":
+		q := r.URL.Query().Get("q")
+		if strings.Contains(q, "is:pr") || strings.Contains(q, "type:pr") {
+			return writeJSON(map[string]any{"total_count": 1, "items": []map[string]any{{"number": 12, "title": "PR title", "state": "open"}}})
+		}
+		return writeJSON(map[string]any{"total_count": 1, "items": []map[string]any{{"number": 7, "title": "Issue title", "state": "open"}}})
+	case "/api/v3/repos/acme/rocket/pulls/12":
+		return writeJSON(map[string]any{"number": 12, "title": "PR title", "state": "open", "body": "PR body", "head": map[string]any{"sha": "deadbeef"}, "user": map[string]any{"login": "octocat"}})
+	case "/api/v3/repos/acme/rocket/pulls/12/files":
+		return writeJSON([]map[string]any{{"filename": "server/internal/api/github_collaboration.go", "status": "modified", "patch": "@@ -1 +1 @@", "additions": 3, "deletions": 1, "changes": 4}})
+	case "/api/v3/repos/acme/rocket/issues/12/comments", "/api/v3/repos/acme/rocket/pulls/12/comments":
+		if r.Method == http.MethodPost {
+			payload := decodeBody()
+			state.prComments = append(state.prComments, payload)
+			w.WriteHeader(http.StatusCreated)
+			return writeJSON(map[string]any{"id": 700 + len(state.prComments), "body": payload["body"], "path": payload["path"]})
+		}
+		comments := []map[string]any{{"id": 2, "body": "Existing PR comment", "path": "README.md"}}
+		for i, payload := range state.prComments {
+			comments = append(comments, map[string]any{"id": 20 + i, "body": payload["body"], "path": payload["path"]})
+		}
+		return writeJSON(comments)
+	case "/api/v3/repos/acme/rocket/pulls/12/reviews":
+		if r.Method == http.MethodPost {
+			payload := decodeBody()
+			state.prReviews = append(state.prReviews, payload)
+			w.WriteHeader(http.StatusCreated)
+			return writeJSON(map[string]any{"id": 900 + len(state.prReviews), "body": payload["body"], "state": payload["event"]})
+		}
+		reviews := []map[string]any{{"id": 3, "body": "Existing review", "state": "COMMENTED"}}
+		for i, payload := range state.prReviews {
+			reviews = append(reviews, map[string]any{"id": 30 + i, "body": payload["body"], "state": payload["event"]})
+		}
+		return writeJSON(reviews)
+	case "/api/v3/repos/acme/rocket/commits/deadbeef/status":
+		return writeJSON(map[string]any{"state": "failure", "total_count": 2, "statuses": []map[string]any{{"context": "ci/unit", "state": "success"}, {"context": "ci/e2e", "state": "failure"}}})
+	case "/api/v3/repos/acme/rocket/commits/deadbeef/check-runs":
+		return writeJSON(map[string]any{"total_count": 2, "check_runs": []map[string]any{{"name": "lint", "status": "completed", "conclusion": "success"}, {"name": "integration", "status": "completed", "conclusion": "failure"}}})
+	default:
+		return fmt.Errorf("unexpected backend path %s", r.URL.Path)
+	}
+}
+
+func getJSONValue(t *testing.T, method, rawURL string, body any) (int, any) {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("json.Marshal() error = %v", err)
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequest(method, rawURL, reader)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http.Do(%s %s) error = %v", method, rawURL, err)
+	}
+	defer resp.Body.Close()
+	var payload any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("json.Decode(%s %s) error = %v", method, rawURL, err)
+	}
+	return resp.StatusCode, payload
+}
+
+func stringifyPayload(t *testing.T, payload any) string {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return string(data)
+}
+
+func issueListURL(baseURL, prefix, workspace string) []string {
+	return []string{
+		baseURL + prefix + "/github/issues?path=" + url.QueryEscape(workspace),
+		baseURL + prefix + "/github/issues?workDir=" + url.QueryEscape(workspace),
+		baseURL + prefix + "/github/issues?workspaceRoot=" + url.QueryEscape(workspace),
+		baseURL + prefix + "/github/issues",
+	}
+}
+
+func postBodiesForWorkspace(workspace string, extra map[string]any) []map[string]any {
+	bodies := []map[string]any{}
+	for _, key := range []string{"workspace_path", "workDir", "work_dir"} {
+		payload := map[string]any{}
+		for k, v := range extra {
+			payload[k] = v
+		}
+		payload[key] = workspace
+		bodies = append(bodies, payload)
+	}
+	bodies = append(bodies, extra)
+	return bodies
+}
+
+func TestGitHubCollaborationRoutesSupportBothPrefixes(t *testing.T) {
+	env := newCollaborationTestEnv(t)
+
+	for _, prefix := range []string{"", "/api"} {
+		var payload any
+		var status int
+		for _, rawURL := range issueListURL(env.server.URL, prefix, env.nestedDir) {
+			status, payload = getJSONValue(t, http.MethodGet, rawURL, nil)
+			text := stringifyPayload(t, payload)
+			if status == http.StatusBadRequest && strings.Contains(text, "invalid_request") {
+				continue
+			}
+			break
+		}
+		if status != http.StatusOK {
+			t.Fatalf("issues prefix %q status = %d payload=%s", prefix, status, stringifyPayload(t, payload))
+		}
+		if text := stringifyPayload(t, payload); !strings.Contains(text, "Issue title") {
+			t.Fatalf("issues prefix %q payload = %s", prefix, text)
+		}
+
+		status, payload = getJSONValue(t, http.MethodGet, env.server.URL+prefix+"/github/account", nil)
+		if status != http.StatusOK {
+			t.Fatalf("account prefix %q status = %d payload=%s", prefix, status, stringifyPayload(t, payload))
+		}
+		if text := stringifyPayload(t, payload); !strings.Contains(text, "octocat") {
+			t.Fatalf("account prefix %q payload = %s", prefix, text)
+		}
+	}
+}
+
+func TestGitHubCollaborationPullRequestDetailsIncludeFilesCommentsAndChecks(t *testing.T) {
+	env := newCollaborationTestEnv(t)
+	for _, prefix := range []string{"", "/api"} {
+		status, payload := getJSONValue(t, http.MethodGet, env.server.URL+prefix+"/github/pulls/12?path="+url.QueryEscape(env.nestedDir), nil)
+		if status != http.StatusOK {
+			t.Fatalf("pull details prefix %q status = %d payload=%s", prefix, status, stringifyPayload(t, payload))
+		}
+		text := stringifyPayload(t, payload)
+		for _, want := range []string{"PR title", "github_collaboration.go", "Existing PR comment", "ci/unit", "integration"} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("pull details prefix %q missing %q in %s", prefix, want, text)
+			}
+		}
+	}
+}
+
+func TestGitHubCollaborationNeedsReviewFilterUsesRepoScopedQuery(t *testing.T) {
+	repoDir, nestedDir, cleanup := repoContextSetupRepo(t, "https://github.com/acme/rocket.git")
+	t.Cleanup(cleanup)
+
+	var seenPath string
+	var seenQuery url.Values
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		seenQuery = r.URL.Query()
+		if err := handleCollaborationBackend(&collaborationBackendState{}, w, r); err != nil {
+			t.Fatalf("backend error: %v", err)
+		}
+	}))
+	defer backend.Close()
+
+	client := gitauth.NewClient(backend.Client())
+	client.SetBaseURLFuncs(func(string) string { return backend.URL }, func(string) string { return backend.URL + "/api/v3" })
+	store := gitauth.NewStore(filepath.Join(t.TempDir(), "github-auth.json"))
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	if err := store.Save(gitauth.AuthRecord{
+		GitHubHost:            gitauth.DefaultHost,
+		AccessToken:           "access-token",
+		AccessTokenExpiresAt:  now.Add(30 * time.Minute),
+		RefreshToken:          "refresh-token",
+		RefreshTokenExpiresAt: now.Add(24 * time.Hour),
+		AccountLogin:          "octocat",
+		AccountID:             9,
+	}); err != nil {
+		t.Fatalf("store.Save() error = %v", err)
+	}
+	service := gitauth.NewService(client, store, "client-id", gitauth.DefaultHost, time.Minute)
+	service.SetNow(func() time.Time { return now })
+	srv := NewServer(newMockFS(), nil, nil, "", git.NewGit(repoDir), terminal.NewManager(), nil, service)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	status, payload := getJSONValue(t, http.MethodGet, ts.URL+"/github/pulls?path="+url.QueryEscape(nestedDir)+"&state=open&needs_review=true", nil)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d payload=%s", status, stringifyPayload(t, payload))
+	}
+	if seenPath != "/api/v3/search/issues" {
+		t.Fatalf("needs review should use repo-scoped search, got path %q query=%v", seenPath, seenQuery)
+	}
+	q := seenQuery.Get("q")
+	for _, want := range []string{"repo:acme/rocket", "is:pr", "review-requested:octocat"} {
+		if !strings.Contains(q, want) {
+			t.Fatalf("needs review query missing %q in %q", want, q)
+		}
+	}
+}
+
+func TestGitHubCollaborationWriteThenReadConsistency(t *testing.T) {
+	env := newCollaborationTestEnv(t)
+
+	for _, prefix := range []string{"", "/api"} {
+		for _, body := range postBodiesForWorkspace(env.nestedDir, map[string]any{"body": "New issue comment"}) {
+			status, payload := getJSONValue(t, http.MethodPost, env.server.URL+prefix+"/github/issues/7/comments", body)
+			if status == http.StatusBadRequest && strings.Contains(strings.ToLower(stringifyPayload(t, payload)), "invalid_request") {
+				continue
+			}
+			if status != http.StatusOK && status != http.StatusCreated {
+				t.Fatalf("issue comment prefix %q status = %d payload=%s", prefix, status, stringifyPayload(t, payload))
+			}
+			break
+		}
+
+		for _, body := range postBodiesForWorkspace(env.nestedDir, map[string]any{"body": "Inline follow-up", "path": "server/internal/api/github_collaboration.go", "commit_id": "deadbeef", "line": 12, "side": "RIGHT"}) {
+			status, payload := getJSONValue(t, http.MethodPost, env.server.URL+prefix+"/github/pulls/12/comments", body)
+			if status == http.StatusBadRequest && strings.Contains(strings.ToLower(stringifyPayload(t, payload)), "invalid_request") {
+				continue
+			}
+			if status != http.StatusOK && status != http.StatusCreated {
+				t.Fatalf("pr comment prefix %q status = %d payload=%s", prefix, status, stringifyPayload(t, payload))
+			}
+			break
+		}
+
+		for _, body := range postBodiesForWorkspace(env.nestedDir, map[string]any{"body": "Ship it", "event": "APPROVE", "commit_id": "deadbeef"}) {
+			status, payload := getJSONValue(t, http.MethodPost, env.server.URL+prefix+"/github/pulls/12/reviews", body)
+			if status == http.StatusBadRequest && strings.Contains(strings.ToLower(stringifyPayload(t, payload)), "invalid_request") {
+				continue
+			}
+			if status != http.StatusOK && status != http.StatusCreated {
+				t.Fatalf("pr review prefix %q status = %d payload=%s", prefix, status, stringifyPayload(t, payload))
+			}
+			break
+		}
+
+		status, payload := getJSONValue(t, http.MethodGet, env.server.URL+prefix+"/github/issues/7?path="+url.QueryEscape(env.nestedDir), nil)
+		if status != http.StatusOK {
+			t.Fatalf("issue details prefix %q status = %d payload=%s", prefix, status, stringifyPayload(t, payload))
+		}
+		if text := stringifyPayload(t, payload); !strings.Contains(text, "New issue comment") && !strings.Contains(text, "comments") {
+			t.Fatalf("issue details prefix %q payload = %s", prefix, text)
+		}
+
+		status, payload = getJSONValue(t, http.MethodGet, env.server.URL+prefix+"/github/pulls/12?path="+url.QueryEscape(env.nestedDir), nil)
+		if status != http.StatusOK {
+			t.Fatalf("pr details prefix %q status = %d payload=%s", prefix, status, stringifyPayload(t, payload))
+		}
+		text := stringifyPayload(t, payload)
+		for _, want := range []string{"Inline follow-up", "Ship it"} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("pr details prefix %q missing %q in %s", prefix, want, text)
+			}
+		}
+
+		status, payload = getJSONValue(t, http.MethodGet, env.server.URL+prefix+"/github/pulls/12/comments?path="+url.QueryEscape(env.nestedDir), nil)
+		if status != http.StatusOK {
+			t.Fatalf("pr comments prefix %q status = %d payload=%s", prefix, status, stringifyPayload(t, payload))
+		}
+		text = stringifyPayload(t, payload)
+		for _, want := range []string{"Inline follow-up", "Ship it"} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("pr comments prefix %q missing %q in %s", prefix, want, text)
+			}
+		}
+	}
+}
+
+func TestGitHubCollaborationFilesExposePatchMetadata(t *testing.T) {
+	env := newCollaborationTestEnv(t)
+	for _, prefix := range []string{"", "/api"} {
+		status, payload := getJSONValue(t, http.MethodGet, env.server.URL+prefix+"/github/pulls/12/files?path="+url.QueryEscape(env.nestedDir), nil)
+		if status != http.StatusOK {
+			t.Fatalf("pr files prefix %q status = %d payload=%s", prefix, status, stringifyPayload(t, payload))
+		}
+		text := stringifyPayload(t, payload)
+		for _, want := range []string{"github_collaboration.go", "@@ -1 +1 @@", "additions", "deletions"} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("pr files prefix %q missing %q in %s", prefix, want, text)
+			}
+		}
+	}
+}
+
+func TestGitHubCollaborationEndpointsReportAppNotInstalledForRepo(t *testing.T) {
+	repoDir, nestedDir, cleanup := repoContextSetupRepo(t, "https://github.com/acme/rocket.git")
+	t.Cleanup(cleanup)
+
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/repos/acme/rocket":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "rocket", "full_name": "acme/rocket", "owner": map[string]any{"login": "acme"}})
+		case "/api/v3/repos/acme/rocket/installation":
+			http.Error(w, "missing installation", http.StatusNotFound)
+		default:
+			t.Fatalf("unexpected backend path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(backend.Close)
+
+	client := gitauth.NewClient(backend.Client())
+	client.SetBaseURLFuncs(func(string) string { return backend.URL }, func(string) string { return backend.URL + "/api/v3" })
+	store := gitauth.NewStore(filepath.Join(t.TempDir(), "github-auth.json"))
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	if err := store.Save(gitauth.AuthRecord{
+		GitHubHost:            gitauth.DefaultHost,
+		AccessToken:           "access-token",
+		AccessTokenExpiresAt:  now.Add(30 * time.Minute),
+		RefreshToken:          "refresh-token",
+		RefreshTokenExpiresAt: now.Add(24 * time.Hour),
+		AccountLogin:          "octocat",
+		AccountID:             9,
+	}); err != nil {
+		t.Fatalf("store.Save() error = %v", err)
+	}
+	service := gitauth.NewService(client, store, "client-id", gitauth.DefaultHost, time.Minute)
+	service.SetNow(func() time.Time { return now })
+
+	srv := NewServer(newMockFS(), nil, nil, "", git.NewGit(repoDir), terminal.NewManager(), nil, service)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	type testRequest struct {
+		name   string
+		method string
+		path   string
+		body   any
+	}
+	requests := []testRequest{
+		{name: "account", method: http.MethodGet, path: "/github/account"},
+		{name: "issue list", method: http.MethodGet, path: "/github/issues?path=" + url.QueryEscape(nestedDir)},
+		{name: "pull list", method: http.MethodGet, path: "/github/pulls?path=" + url.QueryEscape(nestedDir)},
+		{name: "issue comment", method: http.MethodPost, path: "/github/issues/7/comments", body: map[string]any{"workspace_path": nestedDir, "body": "hello"}},
+		{name: "pull comment", method: http.MethodPost, path: "/github/pulls/12/comments", body: map[string]any{"workspace_path": nestedDir, "body": "hello", "path": "README.md", "commit_id": "deadbeef", "line": 1, "side": "RIGHT"}},
+		{name: "pull review", method: http.MethodPost, path: "/github/pulls/12/reviews", body: map[string]any{"workspace_path": nestedDir, "body": "ship it", "event": "APPROVE"}},
+	}
+
+	for _, prefix := range []string{"", "/api"} {
+		for _, tc := range requests {
+			t.Run(prefix+" "+tc.name, func(t *testing.T) {
+				status, payload := getJSONValue(t, tc.method, ts.URL+prefix+tc.path, tc.body)
+				text := stringifyPayload(t, payload)
+				if status != http.StatusForbidden && status != http.StatusNotFound && status != http.StatusBadGateway {
+					t.Fatalf("status = %d payload=%s", status, text)
+				}
+				if !strings.Contains(text, "app_not_installed_for_repo") {
+					t.Fatalf("payload missing app_not_installed_for_repo: %s", text)
+				}
+				if strings.Contains(text, "repo_access_unavailable") {
+					t.Fatalf("payload should distinguish installation failures from repo access errors: %s", text)
+				}
+			})
+		}
+	}
+}
+
+func TestGitHubCollaborationStructuredErrors(t *testing.T) {
+	ts, _, _ := newTestServer(t, "")
+	defer ts.Close()
+
+	for _, path := range []string{
+		"/github/account",
+		"/api/github/account",
+		"/github/issues",
+		"/api/github/pulls",
+	} {
+		status, payload := getJSONValue(t, http.MethodGet, ts.URL+path, nil)
+		if status != http.StatusServiceUnavailable && status != http.StatusUnauthorized {
+			t.Fatalf("path %q status = %d payload=%s", path, status, stringifyPayload(t, payload))
+		}
+		text := stringifyPayload(t, payload)
+		if !strings.Contains(text, "error_code") {
+			t.Fatalf("path %q payload missing error_code: %s", path, text)
+		}
+	}
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -129,6 +129,9 @@ func (s *Server) Handler() http.Handler {
 	// GitHub repo context endpoints.
 	s.registerGitHubRepoContextRoutes(mux)
 
+	// GitHub collaboration endpoints.
+	s.registerGitHubCollaborationRoutes(mux)
+
 	// GitHub auth endpoints.
 	s.registerGitHubAuthRoutes(mux)
 

--- a/server/internal/github/client.go
+++ b/server/internal/github/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -73,6 +74,18 @@ func (c *Client) GetUser(ctx context.Context, host, accessToken string) (*User, 
 	return &user, nil
 }
 
+func (c *Client) GetAccount(ctx context.Context, host, accessToken string) (*Account, error) {
+	var payload accountWire
+	if err := c.getJSON(ctx, c.apiBaseURL(host)+"/user", accessToken, &payload); err != nil {
+		if apiErr, ok := err.(*APIError); ok {
+			return nil, &HostError{Host: NormalizeHost(host), Err: apiErr}
+		}
+		return nil, err
+	}
+	account := mapAccount(payload)
+	return &account, nil
+}
+
 func (c *Client) GetRepo(ctx context.Context, host, owner, repo, accessToken string) (*Repository, error) {
 	var repository Repository
 	endpoint := c.apiBaseURL(host) + "/repos/" + url.PathEscape(owner) + "/" + url.PathEscape(repo)
@@ -107,6 +120,247 @@ func (c *Client) GetRepoInstallation(ctx context.Context, host, owner, repo, acc
 	return &installation, nil
 }
 
+func (c *Client) ListIssues(ctx context.Context, host, owner, repo, accessToken string, options IssueListOptions) ([]Issue, error) {
+	endpoint := c.repoEndpoint(host, owner, repo, "/issues")
+	var payload []issueWire
+	if err := c.getJSONWithQuery(ctx, endpoint, accessToken, buildIssueListQuery(options), &payload); err != nil {
+		return nil, err
+	}
+	issues := make([]Issue, 0, len(payload))
+	for _, item := range payload {
+		if item.PullRequest.URL != "" {
+			continue
+		}
+		issues = append(issues, mapIssue(item))
+	}
+	return issues, nil
+}
+
+func (c *Client) GetIssue(ctx context.Context, host, owner, repo string, number int, accessToken string) (*Issue, error) {
+	endpoint := c.repoEndpoint(host, owner, repo, "/issues/"+strconv.Itoa(number))
+	var payload issueWire
+	if err := c.getJSON(ctx, endpoint, accessToken, &payload); err != nil {
+		return nil, err
+	}
+	issue := mapIssue(payload)
+	return &issue, nil
+}
+
+func (c *Client) CreateIssueComment(ctx context.Context, host, owner, repo string, number int, accessToken string, input CreateIssueCommentInput) (*IssueComment, error) {
+	endpoint := c.repoEndpoint(host, owner, repo, "/issues/"+strconv.Itoa(number)+"/comments")
+	var payload issueCommentWire
+	if err := c.postJSON(ctx, endpoint, accessToken, map[string]any{"body": input.Body}, &payload); err != nil {
+		return nil, err
+	}
+	comment := mapIssueComment(payload)
+	return &comment, nil
+}
+
+func (c *Client) ListIssueComments(ctx context.Context, host, owner, repo string, number int, accessToken string, options ListOptions) ([]IssueComment, error) {
+	endpoint := c.repoEndpoint(host, owner, repo, "/issues/"+strconv.Itoa(number)+"/comments")
+	var payload []issueCommentWire
+	if err := c.getJSONWithQuery(ctx, endpoint, accessToken, buildListQuery(options), &payload); err != nil {
+		return nil, err
+	}
+	comments := make([]IssueComment, 0, len(payload))
+	for _, item := range payload {
+		comments = append(comments, mapIssueComment(item))
+	}
+	return comments, nil
+}
+
+func (c *Client) SearchIssues(ctx context.Context, host, accessToken, query string, page, perPage int) ([]Issue, error) {
+	var payload searchIssuesResponseWire
+	values := url.Values{}
+	values.Set("q", query)
+	setPage(values, page, perPage)
+	if err := c.getJSONWithQuery(ctx, c.apiBaseURL(host)+"/search/issues", accessToken, values, &payload); err != nil {
+		return nil, err
+	}
+	issues := make([]Issue, 0, len(payload.Items))
+	for _, item := range payload.Items {
+		if item.PullRequest.URL != "" {
+			continue
+		}
+		issues = append(issues, mapIssue(item))
+	}
+	return issues, nil
+}
+
+func (c *Client) ListPullRequests(ctx context.Context, host, owner, repo, accessToken string, options PullRequestListOptions) ([]PullRequest, error) {
+	endpoint := c.repoEndpoint(host, owner, repo, "/pulls")
+	var payload []pullRequestWire
+	if err := c.getJSONWithQuery(ctx, endpoint, accessToken, buildPullRequestListQuery(options), &payload); err != nil {
+		return nil, err
+	}
+	pulls := make([]PullRequest, 0, len(payload))
+	for _, item := range payload {
+		pulls = append(pulls, mapPullRequest(item))
+	}
+	return pulls, nil
+}
+
+func (c *Client) SearchPullRequests(ctx context.Context, host, accessToken, query string, page, perPage int) ([]PullRequest, error) {
+	var payload searchIssuesResponseWire
+	values := url.Values{}
+	values.Set("q", query)
+	setPage(values, page, perPage)
+	if err := c.getJSONWithQuery(ctx, c.apiBaseURL(host)+"/search/issues", accessToken, values, &payload); err != nil {
+		return nil, err
+	}
+	pulls := make([]PullRequest, 0, len(payload.Items))
+	for _, item := range payload.Items {
+		pulls = append(pulls, mapPullRequest(searchIssueToPullRequest(item)))
+	}
+	return pulls, nil
+}
+
+func (c *Client) GetPullRequest(ctx context.Context, host, owner, repo string, number int, accessToken string) (*PullRequest, error) {
+	endpoint := c.repoEndpoint(host, owner, repo, "/pulls/"+strconv.Itoa(number))
+	var payload pullRequestWire
+	if err := c.getJSON(ctx, endpoint, accessToken, &payload); err != nil {
+		return nil, err
+	}
+	pr := mapPullRequest(payload)
+	return &pr, nil
+}
+
+func (c *Client) GetPullRequestChecks(ctx context.Context, host, owner, repo string, number int, accessToken string) (*PullRequestChecks, error) {
+	pr, err := c.GetPullRequest(ctx, host, owner, repo, number, accessToken)
+	if err != nil {
+		return nil, err
+	}
+	sha := strings.TrimSpace(pr.HeadRef.SHA)
+	if sha == "" {
+		return &PullRequestChecks{State: "unknown", Checks: []PullRequestCheckRun{}}, nil
+	}
+
+	statusEndpoint := c.repoEndpoint(host, owner, repo, "/commits/"+url.PathEscape(sha)+"/status")
+	checksEndpoint := c.repoEndpoint(host, owner, repo, "/commits/"+url.PathEscape(sha)+"/check-runs")
+
+	var statusPayload combinedStatusWire
+	var checksPayload checkRunsResponseWire
+	statusErr := c.getJSON(ctx, statusEndpoint, accessToken, &statusPayload)
+	checksErr := c.getJSON(ctx, checksEndpoint, accessToken, &checksPayload)
+
+	if statusErr != nil && !IsAPIStatus(statusErr, http.StatusNotFound) {
+		return nil, statusErr
+	}
+	if checksErr != nil && !IsAPIStatus(checksErr, http.StatusNotFound) {
+		return nil, checksErr
+	}
+
+	result := aggregatePullRequestChecks(statusPayload, checksPayload)
+	return &result, nil
+}
+
+func (c *Client) ListPullRequestFiles(ctx context.Context, host, owner, repo string, number int, accessToken string, options ListOptions) ([]PullRequestFile, error) {
+	endpoint := c.repoEndpoint(host, owner, repo, "/pulls/"+strconv.Itoa(number)+"/files")
+	var payload []pullRequestFileWire
+	if err := c.getJSONWithQuery(ctx, endpoint, accessToken, buildListQuery(options), &payload); err != nil {
+		return nil, err
+	}
+	files := make([]PullRequestFile, 0, len(payload))
+	for _, item := range payload {
+		files = append(files, mapPullRequestFile(item))
+	}
+	return files, nil
+}
+
+func (c *Client) ListPullRequestComments(ctx context.Context, host, owner, repo string, number int, accessToken string, options ListOptions) ([]PullRequestComment, error) {
+	endpoint := c.repoEndpoint(host, owner, repo, "/pulls/"+strconv.Itoa(number)+"/comments")
+	var payload []pullRequestCommentWire
+	if err := c.getJSONWithQuery(ctx, endpoint, accessToken, buildListQuery(options), &payload); err != nil {
+		return nil, err
+	}
+	comments := make([]PullRequestComment, 0, len(payload))
+	for _, item := range payload {
+		comments = append(comments, mapPullRequestComment(item))
+	}
+	return comments, nil
+}
+
+func (c *Client) CreatePullRequestComment(ctx context.Context, host, owner, repo string, number int, accessToken string, input CreatePullRequestCommentInput) (*PullRequestComment, error) {
+	endpoint := c.repoEndpoint(host, owner, repo, "/pulls/"+strconv.Itoa(number)+"/comments")
+	body := map[string]any{"body": input.Body}
+	if input.InReplyTo > 0 {
+		body["in_reply_to"] = input.InReplyTo
+	} else {
+		body["path"] = input.Path
+		body["commit_id"] = input.CommitID
+		body["side"] = input.Side
+		body["line"] = input.Line
+		if input.StartSide != "" {
+			body["start_side"] = input.StartSide
+		}
+		if input.StartLine > 0 {
+			body["start_line"] = input.StartLine
+		}
+	}
+
+	var payload pullRequestCommentWire
+	if err := c.postJSON(ctx, endpoint, accessToken, body, &payload); err != nil {
+		return nil, err
+	}
+	comment := mapPullRequestComment(payload)
+	return &comment, nil
+}
+
+func (c *Client) ListPullRequestReviews(ctx context.Context, host, owner, repo string, number int, accessToken string, options ListOptions) ([]PullRequestReview, error) {
+	endpoint := c.repoEndpoint(host, owner, repo, "/pulls/"+strconv.Itoa(number)+"/reviews")
+	var payload []pullRequestReviewWire
+	if err := c.getJSONWithQuery(ctx, endpoint, accessToken, buildListQuery(options), &payload); err != nil {
+		return nil, err
+	}
+	reviews := make([]PullRequestReview, 0, len(payload))
+	for _, item := range payload {
+		reviews = append(reviews, mapPullRequestReview(item))
+	}
+	return reviews, nil
+}
+
+func (c *Client) CreatePullRequestReview(ctx context.Context, host, owner, repo string, number int, accessToken string, input CreatePullRequestReviewInput) (*PullRequestReview, error) {
+	endpoint := c.repoEndpoint(host, owner, repo, "/pulls/"+strconv.Itoa(number)+"/reviews")
+	body := map[string]any{}
+	if input.Event != "" {
+		body["event"] = input.Event
+	}
+	if input.Body != "" {
+		body["body"] = input.Body
+	}
+	if input.CommitID != "" {
+		body["commit_id"] = input.CommitID
+	}
+	if len(input.Comments) > 0 {
+		comments := make([]map[string]any, 0, len(input.Comments))
+		for _, comment := range input.Comments {
+			item := map[string]any{
+				"body": comment.Body,
+				"path": comment.Path,
+				"line": comment.Line,
+			}
+			if comment.Side != "" {
+				item["side"] = comment.Side
+			}
+			if comment.StartSide != "" {
+				item["start_side"] = comment.StartSide
+			}
+			if comment.StartLine > 0 {
+				item["start_line"] = comment.StartLine
+			}
+			comments = append(comments, item)
+		}
+		body["comments"] = comments
+	}
+
+	var payload pullRequestReviewWire
+	if err := c.postJSON(ctx, endpoint, accessToken, body, &payload); err != nil {
+		return nil, err
+	}
+	review := mapPullRequestReview(payload)
+	return &review, nil
+}
+
 func (c *Client) exchangeToken(ctx context.Context, host string, values url.Values) (*TokenResponse, error) {
 	var resp TokenResponse
 	if err := c.postForm(ctx, c.webBaseURL(host)+"/login/oauth/access_token", values, &resp); err != nil {
@@ -119,28 +373,54 @@ func (c *Client) exchangeToken(ctx context.Context, host string, values url.Valu
 }
 
 func (c *Client) getJSON(ctx context.Context, endpoint, accessToken string, out any) error {
+	return c.getJSONWithQuery(ctx, endpoint, accessToken, nil, out)
+}
+
+func (c *Client) getJSONWithQuery(ctx context.Context, endpoint, accessToken string, query url.Values, out any) error {
+	if len(query) > 0 {
+		if strings.Contains(endpoint, "?") {
+			endpoint += "&" + query.Encode()
+		} else {
+			endpoint += "?" + query.Encode()
+		}
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Accept", "application/vnd.github+json")
-	if strings.TrimSpace(accessToken) != "" {
-		req.Header.Set("Authorization", "Bearer "+accessToken)
-	}
+	applyGitHubHeaders(req, accessToken)
+	return c.doJSON(req, out)
+}
 
+func (c *Client) postJSON(ctx context.Context, endpoint, accessToken string, payload any, out any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	applyGitHubHeaders(req, accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	return c.doJSON(req, out)
+}
+
+func (c *Client) doJSON(req *http.Request, out any) error {
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return &HostError{Host: NormalizeHost(hostFromURL(endpoint)), Err: err}
+		return &HostError{Host: NormalizeHost(hostFromURL(req.URL.String())), Err: err}
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return &APIError{Host: NormalizeHost(hostFromURL(endpoint)), StatusCode: resp.StatusCode, Message: strings.TrimSpace(string(body))}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return decodeAPIError(resp, req.URL.String())
 	}
-
+	if out == nil {
+		return nil
+	}
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
-		return &HostError{Host: NormalizeHost(hostFromURL(endpoint)), Err: fmt.Errorf("decode github response: %w", err)}
+		return &HostError{Host: NormalizeHost(hostFromURL(req.URL.String())), Err: fmt.Errorf("decode github response: %w", err)}
 	}
 	return nil
 }
@@ -169,6 +449,30 @@ func (c *Client) postForm(ctx context.Context, endpoint string, values url.Value
 		return &HostError{Host: NormalizeHost(hostFromURL(endpoint)), Err: fmt.Errorf("decode github auth response: %w", err)}
 	}
 	return nil
+}
+
+func applyGitHubHeaders(req *http.Request, accessToken string) {
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if strings.TrimSpace(accessToken) != "" {
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+	}
+}
+
+func decodeAPIError(resp *http.Response, endpoint string) error {
+	payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	message := strings.TrimSpace(string(payload))
+	var parsed struct {
+		Message string `json:"message"`
+	}
+	if len(payload) > 0 && json.Unmarshal(payload, &parsed) == nil && strings.TrimSpace(parsed.Message) != "" {
+		message = strings.TrimSpace(parsed.Message)
+	}
+	return &APIError{Host: NormalizeHost(hostFromURL(endpoint)), StatusCode: resp.StatusCode, Message: message}
+}
+
+func (c *Client) repoEndpoint(host, owner, repo, suffix string) string {
+	return c.apiBaseURL(host) + "/repos/" + url.PathEscape(owner) + "/" + url.PathEscape(repo) + suffix
 }
 
 func mapOAuthError(code string) error {
@@ -209,4 +513,363 @@ func hostFromURL(raw string) string {
 		parsed.Path = path.Clean(parsed.Path)
 	}
 	return parsed.Host
+}
+
+type accountWire struct {
+	Login     string `json:"login"`
+	ID        int64  `json:"id"`
+	Name      string `json:"name"`
+	AvatarURL string `json:"avatar_url"`
+	HTMLURL   string `json:"html_url"`
+}
+
+type actorWire struct {
+	Login     string `json:"login"`
+	ID        int64  `json:"id"`
+	AvatarURL string `json:"avatar_url"`
+	HTMLURL   string `json:"html_url"`
+}
+
+type labelWire struct {
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+type issueWire struct {
+	Number      int         `json:"number"`
+	Title       string      `json:"title"`
+	State       string      `json:"state"`
+	Body        string      `json:"body"`
+	HTMLURL     string      `json:"html_url"`
+	Comments    int         `json:"comments"`
+	Locked      bool        `json:"locked"`
+	User        *actorWire  `json:"user"`
+	Assignees   []actorWire `json:"assignees"`
+	Labels      []labelWire `json:"labels"`
+	CreatedAt   *time.Time  `json:"created_at"`
+	UpdatedAt   *time.Time  `json:"updated_at"`
+	ClosedAt    *time.Time  `json:"closed_at"`
+	PullRequest struct {
+		URL string `json:"url"`
+	} `json:"pull_request"`
+}
+
+type issueCommentWire struct {
+	ID        int64      `json:"id"`
+	Body      string     `json:"body"`
+	HTMLURL   string     `json:"html_url"`
+	User      *actorWire `json:"user"`
+	CreatedAt *time.Time `json:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at"`
+}
+
+type pullRefRepoWire struct {
+	FullName string `json:"full_name"`
+	Owner    struct {
+		Login string `json:"login"`
+	} `json:"owner"`
+	Name string `json:"name"`
+}
+
+type pullRefWire struct {
+	Label string           `json:"label"`
+	Ref   string           `json:"ref"`
+	SHA   string           `json:"sha"`
+	Repo  *pullRefRepoWire `json:"repo"`
+}
+
+type pullRequestWire struct {
+	Number         int         `json:"number"`
+	Title          string      `json:"title"`
+	State          string      `json:"state"`
+	Body           string      `json:"body"`
+	HTMLURL        string      `json:"html_url"`
+	Draft          bool        `json:"draft"`
+	Merged         bool        `json:"merged"`
+	Mergeable      *bool       `json:"mergeable"`
+	MergeableState string      `json:"mergeable_state"`
+	Comments       int         `json:"comments"`
+	ReviewComments int         `json:"review_comments"`
+	Commits        int         `json:"commits"`
+	Additions      int         `json:"additions"`
+	Deletions      int         `json:"deletions"`
+	ChangedFiles   int         `json:"changed_files"`
+	User           *actorWire  `json:"user"`
+	Assignees      []actorWire `json:"assignees"`
+	Labels         []labelWire `json:"labels"`
+	Base           pullRefWire `json:"base"`
+	Head           pullRefWire `json:"head"`
+	CreatedAt      *time.Time  `json:"created_at"`
+	UpdatedAt      *time.Time  `json:"updated_at"`
+	ClosedAt       *time.Time  `json:"closed_at"`
+	MergedAt       *time.Time  `json:"merged_at"`
+}
+
+type pullRequestFileWire struct {
+	SHA              string `json:"sha"`
+	Filename         string `json:"filename"`
+	Status           string `json:"status"`
+	Additions        int    `json:"additions"`
+	Deletions        int    `json:"deletions"`
+	Changes          int    `json:"changes"`
+	BlobURL          string `json:"blob_url"`
+	RawURL           string `json:"raw_url"`
+	Patch            string `json:"patch"`
+	PreviousFilename string `json:"previous_filename"`
+}
+
+type pullRequestCommentWire struct {
+	ID               int64      `json:"id"`
+	Body             string     `json:"body"`
+	HTMLURL          string     `json:"html_url"`
+	Path             string     `json:"path"`
+	DiffHunk         string     `json:"diff_hunk"`
+	CommitID         string     `json:"commit_id"`
+	OriginalCommitID string     `json:"original_commit_id"`
+	Position         int        `json:"position"`
+	OriginalPosition int        `json:"original_position"`
+	Line             int        `json:"line"`
+	OriginalLine     int        `json:"original_line"`
+	Side             string     `json:"side"`
+	StartLine        int        `json:"start_line"`
+	StartSide        string     `json:"start_side"`
+	InReplyToID      int64      `json:"in_reply_to_id"`
+	User             *actorWire `json:"user"`
+	CreatedAt        *time.Time `json:"created_at"`
+	UpdatedAt        *time.Time `json:"updated_at"`
+}
+
+type pullRequestReviewWire struct {
+	ID          int64      `json:"id"`
+	Body        string     `json:"body"`
+	State       string     `json:"state"`
+	CommitID    string     `json:"commit_id"`
+	HTMLURL     string     `json:"html_url"`
+	User        *actorWire `json:"user"`
+	SubmittedAt *time.Time `json:"submitted_at"`
+}
+
+type combinedStatusWire struct {
+	State      string                  `json:"state"`
+	Statuses   []combinedStatusRunWire `json:"statuses"`
+	TotalCount int                     `json:"total_count"`
+}
+
+type combinedStatusRunWire struct {
+	Context     string     `json:"context"`
+	State       string     `json:"state"`
+	TargetURL   string     `json:"target_url"`
+	CreatedAt   *time.Time `json:"created_at"`
+	UpdatedAt   *time.Time `json:"updated_at"`
+	Description string     `json:"description"`
+}
+
+type checkRunsResponseWire struct {
+	TotalCount int            `json:"total_count"`
+	CheckRuns  []checkRunWire `json:"check_runs"`
+}
+
+type checkRunWire struct {
+	Name        string     `json:"name"`
+	Status      string     `json:"status"`
+	Conclusion  string     `json:"conclusion"`
+	DetailsURL  string     `json:"details_url"`
+	StartedAt   *time.Time `json:"started_at"`
+	CompletedAt *time.Time `json:"completed_at"`
+}
+
+type searchIssuesResponseWire struct {
+	TotalCount int         `json:"total_count"`
+	Items      []issueWire `json:"items"`
+}
+
+func mapAccount(in accountWire) Account {
+	return Account{Login: in.Login, ID: in.ID, Name: in.Name, AvatarURL: in.AvatarURL, HTMLURL: in.HTMLURL}
+}
+
+func mapActor(in *actorWire) *Actor {
+	if in == nil {
+		return nil
+	}
+	return &Actor{Login: in.Login, ID: in.ID, AvatarURL: in.AvatarURL, HTMLURL: in.HTMLURL}
+}
+
+func mapActors(in []actorWire) []Actor {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]Actor, 0, len(in))
+	for _, item := range in {
+		out = append(out, Actor{Login: item.Login, ID: item.ID, AvatarURL: item.AvatarURL, HTMLURL: item.HTMLURL})
+	}
+	return out
+}
+
+func mapLabels(in []labelWire) []Label {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]Label, 0, len(in))
+	for _, item := range in {
+		out = append(out, Label{Name: item.Name, Color: item.Color})
+	}
+	return out
+}
+
+func mapIssue(in issueWire) Issue {
+	return Issue{
+		Number:        in.Number,
+		Title:         in.Title,
+		State:         in.State,
+		Body:          in.Body,
+		HTMLURL:       in.HTMLURL,
+		CommentsCount: in.Comments,
+		Locked:        in.Locked,
+		Author:        mapActor(in.User),
+		Assignees:     mapActors(in.Assignees),
+		Labels:        mapLabels(in.Labels),
+		CreatedAt:     in.CreatedAt,
+		UpdatedAt:     in.UpdatedAt,
+		ClosedAt:      in.ClosedAt,
+	}
+}
+
+func mapIssueComment(in issueCommentWire) IssueComment {
+	return IssueComment{ID: in.ID, Body: in.Body, HTMLURL: in.HTMLURL, Author: mapActor(in.User), CreatedAt: in.CreatedAt, UpdatedAt: in.UpdatedAt}
+}
+
+func mapPullRequestRef(in pullRefWire) PullRequestRef {
+	return PullRequestRef{Label: in.Label, Ref: in.Ref, SHA: in.SHA}
+}
+
+func mapPullRequest(in pullRequestWire) PullRequest {
+	return PullRequest{
+		Number:              in.Number,
+		Title:               in.Title,
+		State:               in.State,
+		Body:                in.Body,
+		HTMLURL:             in.HTMLURL,
+		Draft:               in.Draft,
+		Merged:              in.Merged,
+		Mergeable:           in.Mergeable,
+		MergeableState:      in.MergeableState,
+		CommentsCount:       in.Comments,
+		ReviewCommentsCount: in.ReviewComments,
+		CommitsCount:        in.Commits,
+		Additions:           in.Additions,
+		Deletions:           in.Deletions,
+		ChangedFiles:        in.ChangedFiles,
+		Author:              mapActor(in.User),
+		Assignees:           mapActors(in.Assignees),
+		Labels:              mapLabels(in.Labels),
+		BaseRef:             mapPullRequestRef(in.Base),
+		HeadRef:             mapPullRequestRef(in.Head),
+		CreatedAt:           in.CreatedAt,
+		UpdatedAt:           in.UpdatedAt,
+		ClosedAt:            in.ClosedAt,
+		MergedAt:            in.MergedAt,
+	}
+}
+
+func searchIssueToPullRequest(in issueWire) pullRequestWire {
+	return pullRequestWire{
+		Number:    in.Number,
+		Title:     in.Title,
+		State:     in.State,
+		Body:      in.Body,
+		HTMLURL:   in.HTMLURL,
+		Comments:  in.Comments,
+		User:      in.User,
+		Assignees: in.Assignees,
+		Labels:    in.Labels,
+		CreatedAt: in.CreatedAt,
+		UpdatedAt: in.UpdatedAt,
+		ClosedAt:  in.ClosedAt,
+	}
+}
+
+func mapPullRequestFile(in pullRequestFileWire) PullRequestFile {
+	return PullRequestFile{SHA: in.SHA, Filename: in.Filename, Status: in.Status, Additions: in.Additions, Deletions: in.Deletions, Changes: in.Changes, BlobURL: in.BlobURL, RawURL: in.RawURL, Patch: in.Patch, PreviousFilename: in.PreviousFilename}
+}
+
+func mapPullRequestComment(in pullRequestCommentWire) PullRequestComment {
+	return PullRequestComment{
+		ID:               in.ID,
+		Body:             in.Body,
+		HTMLURL:          in.HTMLURL,
+		Path:             in.Path,
+		DiffHunk:         in.DiffHunk,
+		CommitID:         in.CommitID,
+		OriginalCommitID: in.OriginalCommitID,
+		Position:         in.Position,
+		OriginalPosition: in.OriginalPosition,
+		Line:             in.Line,
+		OriginalLine:     in.OriginalLine,
+		Side:             in.Side,
+		StartLine:        in.StartLine,
+		StartSide:        in.StartSide,
+		InReplyToID:      in.InReplyToID,
+		Author:           mapActor(in.User),
+		CreatedAt:        in.CreatedAt,
+		UpdatedAt:        in.UpdatedAt,
+	}
+}
+
+func mapPullRequestReview(in pullRequestReviewWire) PullRequestReview {
+	return PullRequestReview{ID: in.ID, Body: in.Body, State: in.State, CommitID: in.CommitID, HTMLURL: in.HTMLURL, Author: mapActor(in.User), SubmittedAt: in.SubmittedAt}
+}
+
+func aggregatePullRequestChecks(status combinedStatusWire, runs checkRunsResponseWire) PullRequestChecks {
+	checks := PullRequestChecks{Checks: []PullRequestCheckRun{}}
+	for _, item := range runs.CheckRuns {
+		check := PullRequestCheckRun{Name: item.Name, Status: item.Status, Conclusion: item.Conclusion, DetailsURL: item.DetailsURL, StartedAt: item.StartedAt, CompletedAt: item.CompletedAt}
+		checks.Checks = append(checks.Checks, check)
+		switch {
+		case strings.EqualFold(item.Status, "completed") && isSuccessConclusion(item.Conclusion):
+			checks.SuccessCount++
+		case strings.EqualFold(item.Status, "queued") || strings.EqualFold(item.Status, "in_progress") || strings.EqualFold(item.Status, "pending"):
+			checks.PendingCount++
+		case strings.EqualFold(item.Status, "completed"):
+			checks.FailureCount++
+		default:
+			checks.PendingCount++
+		}
+	}
+	for _, item := range status.Statuses {
+		check := PullRequestCheckRun{Name: item.Context, Status: item.State, DetailsURL: item.TargetURL, StartedAt: item.CreatedAt, CompletedAt: item.UpdatedAt}
+		checks.Checks = append(checks.Checks, check)
+		switch strings.ToLower(strings.TrimSpace(item.State)) {
+		case "success":
+			checks.SuccessCount++
+		case "pending":
+			checks.PendingCount++
+		default:
+			checks.FailureCount++
+		}
+	}
+	checks.TotalCount = len(checks.Checks)
+	checks.State = aggregateCheckState(checks)
+	return checks
+}
+
+func aggregateCheckState(in PullRequestChecks) string {
+	switch {
+	case in.FailureCount > 0:
+		return "failure"
+	case in.PendingCount > 0:
+		return "pending"
+	case in.SuccessCount > 0:
+		return "success"
+	default:
+		return "unknown"
+	}
+}
+
+func isSuccessConclusion(conclusion string) bool {
+	switch strings.ToLower(strings.TrimSpace(conclusion)) {
+	case "", "success", "neutral", "skipped":
+		return true
+	default:
+		return false
+	}
 }

--- a/server/internal/github/collaboration.go
+++ b/server/internal/github/collaboration.go
@@ -1,0 +1,290 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	gitctx "github.com/Lincyaw/vscode-mobile/server/internal/git"
+)
+
+func buildIssueListQuery(options IssueListOptions) url.Values {
+	values := url.Values{}
+	setQuery(values, "state", options.State)
+	setQuery(values, "sort", options.Sort)
+	setQuery(values, "direction", options.Direction)
+	setQuery(values, "since", options.Since)
+	setQuery(values, "labels", options.Labels)
+	setQuery(values, "creator", options.Creator)
+	setQuery(values, "mentioned", options.Mentioned)
+	setQuery(values, "assignee", options.Assignee)
+	setQuery(values, "milestone", options.Milestone)
+	setPage(values, options.Page, options.PerPage)
+	return values
+}
+
+func buildPullRequestListQuery(options PullRequestListOptions) url.Values {
+	values := url.Values{}
+	setQuery(values, "state", options.State)
+	setQuery(values, "head", options.Head)
+	setQuery(values, "base", options.Base)
+	setQuery(values, "sort", options.Sort)
+	setQuery(values, "direction", options.Direction)
+	setPage(values, options.Page, options.PerPage)
+	return values
+}
+
+func buildListQuery(options ListOptions) url.Values {
+	values := url.Values{}
+	setQuery(values, "sort", options.Sort)
+	setQuery(values, "direction", options.Direction)
+	setQuery(values, "since", options.Since)
+	setPage(values, options.Page, options.PerPage)
+	return values
+}
+
+func setQuery(values url.Values, key, value string) {
+	if strings.TrimSpace(value) != "" {
+		values.Set(key, strings.TrimSpace(value))
+	}
+}
+
+func setPage(values url.Values, page, perPage int) {
+	if page > 0 {
+		values.Set("page", strconv.Itoa(page))
+	}
+	if perPage > 0 {
+		values.Set("per_page", strconv.Itoa(perPage))
+	}
+}
+
+func filterState(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "", "open":
+		return "open"
+	case "closed":
+		return "closed"
+	case "all":
+		return "all"
+	default:
+		return strings.TrimSpace(state)
+	}
+}
+
+func (s *Service) GetCurrentRepoAccount(ctx context.Context, gitClient *gitctx.Git, path string) (*Account, *Repository, error) {
+	repository, record, err := s.resolveAuthorizedRepository(ctx, gitClient, path)
+	if err != nil {
+		return nil, repository, err
+	}
+	account, err := s.client.GetAccount(ctx, repository.GitHubHost, record.AccessToken)
+	if err != nil {
+		return nil, repository, s.translateAPIError(err)
+	}
+	return account, repository, nil
+}
+
+func (s *Service) ListCurrentRepoIssues(ctx context.Context, gitClient *gitctx.Git, path string, options IssueListOptions) ([]Issue, *Repository, error) {
+	repository, record, err := s.resolveAuthorizedRepository(ctx, gitClient, path)
+	if err != nil {
+		return nil, repository, err
+	}
+	issues, err := s.client.ListIssues(ctx, repository.GitHubHost, repository.Owner, repository.Name, record.AccessToken, options)
+	if err != nil {
+		return nil, repository, s.translateAPIError(err)
+	}
+	return issues, repository, nil
+}
+
+func (s *Service) GetCurrentRepoIssue(ctx context.Context, gitClient *gitctx.Git, path string, number int) (*Issue, *Repository, error) {
+	repository, record, err := s.resolveAuthorizedRepository(ctx, gitClient, path)
+	if err != nil {
+		return nil, repository, err
+	}
+	issue, err := s.client.GetIssue(ctx, repository.GitHubHost, repository.Owner, repository.Name, number, record.AccessToken)
+	if err != nil {
+		return nil, repository, s.translateAPIError(err)
+	}
+	return issue, repository, nil
+}
+
+func (s *Service) CreateCurrentRepoIssueComment(ctx context.Context, gitClient *gitctx.Git, path string, number int, input CreateIssueCommentInput) (*IssueComment, *Repository, error) {
+	repository, record, err := s.resolveAuthorizedRepository(ctx, gitClient, path)
+	if err != nil {
+		return nil, repository, err
+	}
+	comment, err := s.client.CreateIssueComment(ctx, repository.GitHubHost, repository.Owner, repository.Name, number, record.AccessToken, input)
+	if err != nil {
+		return nil, repository, s.translateAPIError(err)
+	}
+	return comment, repository, nil
+}
+
+func (s *Service) ListCurrentRepoPullRequests(ctx context.Context, gitClient *gitctx.Git, path string, options PullRequestListOptions) ([]PullRequest, *Repository, error) {
+	repository, record, err := s.resolveAuthorizedRepository(ctx, gitClient, path)
+	if err != nil {
+		return nil, repository, err
+	}
+	pulls, err := s.client.ListPullRequests(ctx, repository.GitHubHost, repository.Owner, repository.Name, record.AccessToken, options)
+	if err != nil {
+		return nil, repository, s.translateAPIError(err)
+	}
+	return pulls, repository, nil
+}
+
+func (s *Service) GetCurrentRepoPullRequest(ctx context.Context, gitClient *gitctx.Git, path string, number int) (*PullRequest, *Repository, error) {
+	repository, record, err := s.resolveAuthorizedRepository(ctx, gitClient, path)
+	if err != nil {
+		return nil, repository, err
+	}
+	pull, err := s.client.GetPullRequest(ctx, repository.GitHubHost, repository.Owner, repository.Name, number, record.AccessToken)
+	if err != nil {
+		return nil, repository, s.translateAPIError(err)
+	}
+	checks, err := s.client.GetPullRequestChecks(ctx, repository.GitHubHost, repository.Owner, repository.Name, number, record.AccessToken)
+	if err != nil {
+		return nil, repository, s.translateAPIError(err)
+	}
+	pull.Checks = checks
+	return pull, repository, nil
+}
+
+func (s *Service) ListCurrentRepoPullRequestFiles(ctx context.Context, gitClient *gitctx.Git, path string, number int, options ListOptions) ([]PullRequestFile, *Repository, error) {
+	repository, record, err := s.resolveAuthorizedRepository(ctx, gitClient, path)
+	if err != nil {
+		return nil, repository, err
+	}
+	files, err := s.client.ListPullRequestFiles(ctx, repository.GitHubHost, repository.Owner, repository.Name, number, record.AccessToken, options)
+	if err != nil {
+		return nil, repository, s.translateAPIError(err)
+	}
+	return files, repository, nil
+}
+
+func (s *Service) ListCurrentRepoPullRequestComments(ctx context.Context, gitClient *gitctx.Git, path string, number int, options ListOptions) ([]PullRequestComment, *Repository, error) {
+	repository, record, err := s.resolveAuthorizedRepository(ctx, gitClient, path)
+	if err != nil {
+		return nil, repository, err
+	}
+	comments, err := s.client.ListPullRequestComments(ctx, repository.GitHubHost, repository.Owner, repository.Name, number, record.AccessToken, options)
+	if err != nil {
+		return nil, repository, s.translateAPIError(err)
+	}
+	return comments, repository, nil
+}
+
+func (s *Service) CreateCurrentRepoPullRequestComment(ctx context.Context, gitClient *gitctx.Git, path string, number int, input CreatePullRequestCommentInput) (*PullRequestComment, *Repository, error) {
+	repository, record, err := s.resolveAuthorizedRepository(ctx, gitClient, path)
+	if err != nil {
+		return nil, repository, err
+	}
+	comment, err := s.client.CreatePullRequestComment(ctx, repository.GitHubHost, repository.Owner, repository.Name, number, record.AccessToken, input)
+	if err != nil {
+		return nil, repository, s.translateAPIError(err)
+	}
+	return comment, repository, nil
+}
+
+func (s *Service) CreateCurrentRepoPullRequestReview(ctx context.Context, gitClient *gitctx.Git, path string, number int, input CreatePullRequestReviewInput) (*PullRequestReview, *Repository, error) {
+	repository, record, err := s.resolveAuthorizedRepository(ctx, gitClient, path)
+	if err != nil {
+		return nil, repository, err
+	}
+	review, err := s.client.CreatePullRequestReview(ctx, repository.GitHubHost, repository.Owner, repository.Name, number, record.AccessToken, input)
+	if err != nil {
+		return nil, repository, s.translateAPIError(err)
+	}
+	return review, repository, nil
+}
+
+func (s *Service) resolveAuthorizedRepository(ctx context.Context, gitClient *gitctx.Git, path string) (*Repository, *AuthRecord, error) {
+	if s == nil || s.client == nil || s.store == nil {
+		return nil, nil, fmt.Errorf("github auth is not configured")
+	}
+	if gitClient == nil {
+		return nil, nil, fmt.Errorf("git client is not configured")
+	}
+
+	repoContext, err := gitClient.ResolveRepoContext(path)
+	if err != nil {
+		switch {
+		case errors.Is(err, gitctx.ErrNotRepository), errors.Is(err, gitctx.ErrNoRemote), errors.Is(err, gitctx.ErrRepoNotGitHub):
+			return nil, nil, errors.Join(ErrInvalidRequest, ErrRepoNotGitHub, err)
+		default:
+			return nil, nil, err
+		}
+	}
+	repository := &Repository{
+		GitHubHost: repoContext.GitHubHost,
+		Owner:      repoContext.Owner,
+		Name:       repoContext.Name,
+		FullName:   repoContext.FullName,
+		RemoteName: repoContext.RemoteName,
+		RemoteURL:  repoContext.RemoteURL,
+		RepoRoot:   repoContext.RepoRoot,
+	}
+
+	record, err := s.EnsureFreshToken(ctx, repository.GitHubHost)
+	if err != nil {
+		return repository, nil, err
+	}
+	if _, err := s.client.GetRepo(ctx, repository.GitHubHost, repository.Owner, repository.Name, record.AccessToken); err != nil {
+		return repository, nil, s.translateRepositoryAccessError(err)
+	}
+	if _, err := s.client.GetRepoInstallation(ctx, repository.GitHubHost, repository.Owner, repository.Name, record.AccessToken); err != nil {
+		return repository, nil, s.translateRepositoryAccessError(err)
+	}
+	return repository, record, nil
+}
+
+func (s *Service) translateRepositoryAccessError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrAppNotInstalledForRepo) {
+		return ErrAppNotInstalledForRepo
+	}
+	if IsAPIStatus(err, http.StatusForbidden) {
+		return ErrRepoAccessUnavailable
+	}
+	if IsAPIStatus(err, http.StatusNotFound) {
+		return ErrNotFound
+	}
+	return s.translateAPIError(err)
+}
+
+func (s *Service) translateAPIError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrNotAuthenticated) || errors.Is(err, ErrReauthRequired) || errors.Is(err, ErrRepoAccessUnavailable) || errors.Is(err, ErrAppNotInstalledForRepo) || errors.Is(err, ErrInvalidRequest) || errors.Is(err, ErrNotFound) || errors.Is(err, ErrRepoNotGitHub) {
+		return err
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.StatusCode {
+		case http.StatusUnauthorized:
+			return ErrReauthRequired
+		case http.StatusForbidden:
+			return ErrRepoAccessUnavailable
+		case http.StatusNotFound:
+			return ErrNotFound
+		case http.StatusUnprocessableEntity, http.StatusBadRequest:
+			return errors.Join(ErrInvalidRequest, err)
+		default:
+			return err
+		}
+	}
+	var hostErr *HostError
+	if errors.As(err, &hostErr) {
+		translated := s.translateAPIError(hostErr.Err)
+		if translated == hostErr.Err {
+			return err
+		}
+		return &HostError{Host: hostErr.Host, Err: translated}
+	}
+	return err
+}

--- a/server/internal/github/collaboration_service.go
+++ b/server/internal/github/collaboration_service.go
@@ -1,0 +1,153 @@
+package github
+
+import (
+	"context"
+	"strings"
+
+	gitctx "github.com/Lincyaw/vscode-mobile/server/internal/git"
+)
+
+type CollaborationFilter struct {
+	State        string
+	AssignedToMe bool
+	CreatedByMe  bool
+	Mentioned    bool
+	NeedsReview  bool
+	Page         int
+	PerPage      int
+}
+
+func (s *Service) GetAccount(ctx context.Context, path string) (*Account, error) {
+	account, _, err := s.GetCurrentRepoAccount(ctx, sGit(s), path)
+	return account, err
+}
+
+func (s *Service) ListIssues(ctx context.Context, path string, filter CollaborationFilter) ([]Issue, error) {
+	repository, record, login, err := s.authorizedRepoSession(ctx, sGit(s), path)
+	if err != nil {
+		return nil, err
+	}
+	filter = normalizeCollaborationFilter(filter)
+	if filter.Mentioned {
+		return s.client.SearchIssues(ctx, repository.GitHubHost, record.AccessToken, buildSearchQuery(repository.FullName, login, filter, false), filter.Page, filter.PerPage)
+	}
+	options := IssueListOptions{State: filterState(filter.State), Page: filter.Page, PerPage: filter.PerPage}
+	if filter.AssignedToMe {
+		options.Assignee = login
+	}
+	if filter.CreatedByMe {
+		options.Creator = login
+	}
+	return s.client.ListIssues(ctx, repository.GitHubHost, repository.Owner, repository.Name, record.AccessToken, options)
+}
+
+func (s *Service) GetPullRequest(ctx context.Context, path string, number int) (*PullRequest, error) {
+	pr, _, err := s.GetCurrentRepoPullRequest(ctx, sGit(s), path, number)
+	return pr, err
+}
+
+func (s *Service) ListPullRequests(ctx context.Context, path string, filter CollaborationFilter) ([]PullRequest, error) {
+	repository, record, login, err := s.authorizedRepoSession(ctx, sGit(s), path)
+	if err != nil {
+		return nil, err
+	}
+	filter = normalizeCollaborationFilter(filter)
+	if filter.AssignedToMe || filter.CreatedByMe || filter.Mentioned || filter.NeedsReview {
+		return s.client.SearchPullRequests(ctx, repository.GitHubHost, record.AccessToken, buildSearchQuery(repository.FullName, login, filter, true), filter.Page, filter.PerPage)
+	}
+	options := PullRequestListOptions{State: filterState(filter.State), Page: filter.Page, PerPage: filter.PerPage}
+	return s.client.ListPullRequests(ctx, repository.GitHubHost, repository.Owner, repository.Name, record.AccessToken, options)
+}
+
+func (s *Service) CreateIssueComment(ctx context.Context, path string, number int, input CreateIssueCommentInput) (*IssueComment, error) {
+	comment, _, err := s.CreateCurrentRepoIssueComment(ctx, sGit(s), path, number, input)
+	return comment, err
+}
+
+func (s *Service) CreatePullRequestComment(ctx context.Context, path string, number int, input CreatePullRequestCommentInput) (*PullRequestComment, error) {
+	comment, _, err := s.CreateCurrentRepoPullRequestComment(ctx, sGit(s), path, number, input)
+	return comment, err
+}
+
+func (s *Service) CreatePullRequestReview(ctx context.Context, path string, number int, input CreatePullRequestReviewInput) (*PullRequestReview, error) {
+	review, _, err := s.CreateCurrentRepoPullRequestReview(ctx, sGit(s), path, number, input)
+	return review, err
+}
+
+func (s *Service) GetIssueComments(ctx context.Context, path string, number int, options ListOptions) ([]IssueComment, *Repository, error) {
+	repository, record, _, err := s.authorizedRepoSession(ctx, sGit(s), path)
+	if err != nil {
+		return nil, repository, err
+	}
+	comments, err := s.client.ListIssueComments(ctx, repository.GitHubHost, repository.Owner, repository.Name, number, record.AccessToken, options)
+	if err != nil {
+		return nil, repository, s.translateAPIError(err)
+	}
+	return comments, repository, nil
+}
+
+func (s *Service) GetPullRequestReviews(ctx context.Context, path string, number int, options ListOptions) ([]PullRequestReview, *Repository, error) {
+	repository, record, _, err := s.authorizedRepoSession(ctx, sGit(s), path)
+	if err != nil {
+		return nil, repository, err
+	}
+	reviews, err := s.client.ListPullRequestReviews(ctx, repository.GitHubHost, repository.Owner, repository.Name, number, record.AccessToken, options)
+	if err != nil {
+		return nil, repository, s.translateAPIError(err)
+	}
+	return reviews, repository, nil
+}
+
+func (s *Service) authorizedRepoSession(ctx context.Context, gitClient *gitctx.Git, path string) (*Repository, *AuthRecord, string, error) {
+	repository, record, err := s.resolveAuthorizedRepository(ctx, gitClient, path)
+	if err != nil {
+		return repository, nil, "", err
+	}
+	login := strings.TrimSpace(record.AccountLogin)
+	if login == "" {
+		account, accountErr := s.client.GetAccount(ctx, repository.GitHubHost, record.AccessToken)
+		if accountErr != nil {
+			return repository, nil, "", s.translateAPIError(accountErr)
+		}
+		login = account.Login
+	}
+	return repository, record, login, nil
+}
+
+func buildSearchQuery(repoFullName, login string, filter CollaborationFilter, isPR bool) string {
+	parts := []string{"repo:" + repoFullName}
+	if isPR {
+		parts = append(parts, "is:pr")
+	} else {
+		parts = append(parts, "is:issue")
+	}
+	parts = append(parts, "is:"+filterState(filter.State))
+	if filter.AssignedToMe {
+		parts = append(parts, "assignee:"+login)
+	}
+	if filter.CreatedByMe {
+		parts = append(parts, "author:"+login)
+	}
+	if filter.Mentioned {
+		parts = append(parts, "mentions:"+login)
+	}
+	if isPR && filter.NeedsReview {
+		parts = append(parts, "review-requested:"+login)
+	}
+	return strings.Join(parts, " ")
+}
+
+func normalizeCollaborationFilter(filter CollaborationFilter) CollaborationFilter {
+	if strings.TrimSpace(filter.State) == "" {
+		filter.State = "open"
+	}
+	if filter.Page <= 0 {
+		filter.Page = 1
+	}
+	if filter.PerPage <= 0 || filter.PerPage > 100 {
+		filter.PerPage = 30
+	}
+	return filter
+}
+
+func sGit(s *Service) *gitctx.Git { return gitctx.NewGit(".") }

--- a/server/internal/github/collaboration_service_test.go
+++ b/server/internal/github/collaboration_service_test.go
@@ -1,0 +1,467 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	gitctx "github.com/Lincyaw/vscode-mobile/server/internal/git"
+)
+
+type collaborationServiceHarness struct {
+	service       *Service
+	git           *gitctx.Git
+	server        *httptest.Server
+	repoDir       string
+	nestedDir     string
+	tokenRequests []url.Values
+}
+
+func newCollaborationServiceHarness(t *testing.T, remoteURL string, handler func(*collaborationServiceHarness, http.ResponseWriter, *http.Request, []byte)) *collaborationServiceHarness {
+	t.Helper()
+	repoDir, nestedDir := collaborationSetupRepo(t, remoteURL)
+	h := &collaborationServiceHarness{repoDir: repoDir, nestedDir: nestedDir, git: gitctx.NewGit(repoDir)}
+	h.server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := readJSONBody(r)
+		if r.URL.Path == "/login/oauth/access_token" {
+			_ = r.ParseForm()
+			clone := url.Values{}
+			for key, values := range r.PostForm {
+				clone[key] = append([]string(nil), values...)
+			}
+			h.tokenRequests = append(h.tokenRequests, clone)
+		}
+		handler(h, w, r, body)
+	}))
+	t.Cleanup(h.server.Close)
+
+	client := NewClient(h.server.Client())
+	client.SetBaseURLFuncs(func(string) string { return h.server.URL }, func(string) string { return h.server.URL + "/api/v3" })
+	store := NewStore(filepath.Join(t.TempDir(), "github-auth.json"))
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	if err := store.Save(AuthRecord{
+		GitHubHost:            DefaultHost,
+		AccessToken:           "access-token",
+		AccessTokenExpiresAt:  now.Add(30 * time.Minute),
+		RefreshToken:          "refresh-token",
+		RefreshTokenExpiresAt: now.Add(24 * time.Hour),
+		AccountLogin:          "octocat",
+		AccountID:             9,
+	}); err != nil {
+		t.Fatalf("store.Save() error = %v", err)
+	}
+	service := NewService(client, store, "client-id", DefaultHost, time.Minute)
+	service.SetNow(func() time.Time { return now })
+	h.service = service
+	return h
+}
+
+func collaborationSetupRepo(t *testing.T, remoteURL string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	gitRun := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v: %s", args, err, out)
+		}
+	}
+	gitRun("init")
+	gitRun("config", "user.email", "test@example.com")
+	gitRun("config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	gitRun("add", "README.md")
+	gitRun("commit", "-m", "initial")
+	if remoteURL != "" {
+		gitRun("remote", "add", "origin", remoteURL)
+	}
+	nested := filepath.Join(dir, "nested", "workspace")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", nested, err)
+	}
+	return dir, nested
+}
+
+func readJSONBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+	defer r.Body.Close()
+	return io.ReadAll(r.Body)
+}
+
+func TestCollaborationServiceGetCurrentRepoAccountReusesFreshToken(t *testing.T) {
+	h := newCollaborationServiceHarness(t, "https://github.com/acme/rocket.git", func(h *collaborationServiceHarness, w http.ResponseWriter, r *http.Request, body []byte) {
+		switch r.URL.Path {
+		case "/api/v3/repos/acme/rocket":
+			if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
+				t.Fatalf("repo Authorization = %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "rocket", "full_name": "acme/rocket", "owner": map[string]any{"login": "acme"}})
+		case "/api/v3/repos/acme/rocket/installation":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 101})
+		case "/api/v3/user":
+			if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
+				t.Fatalf("user Authorization = %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"login": "octocat", "id": 9, "avatar_url": "https://avatars.example/octocat"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	account, repo, err := h.service.GetCurrentRepoAccount(context.Background(), h.git, h.nestedDir)
+	if err != nil {
+		t.Fatalf("GetCurrentRepoAccount() error = %v", err)
+	}
+	if len(h.tokenRequests) != 0 {
+		t.Fatalf("expected no refresh token request, got %d", len(h.tokenRequests))
+	}
+	if repo == nil || repo.FullName != "acme/rocket" {
+		t.Fatalf("repository = %#v", repo)
+	}
+	if account == nil || account.Login != "octocat" {
+		t.Fatalf("account = %#v", account)
+	}
+}
+
+func TestCollaborationServiceIssueFiltersDefaultWorkspaceRepo(t *testing.T) {
+	var seenPath string
+	var seenQuery url.Values
+	h := newCollaborationServiceHarness(t, "https://github.com/acme/rocket.git", func(h *collaborationServiceHarness, w http.ResponseWriter, r *http.Request, body []byte) {
+		switch r.URL.Path {
+		case "/api/v3/repos/acme/rocket":
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "rocket", "full_name": "acme/rocket", "owner": map[string]any{"login": "acme"}})
+		case "/api/v3/repos/acme/rocket/installation":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 101})
+		case "/api/v3/repos/acme/rocket/issues":
+			seenPath = r.URL.Path
+			seenQuery = r.URL.Query()
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"number": 7, "title": "Issue title", "state": "open"}})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	issues, repo, err := h.service.ListCurrentRepoIssues(context.Background(), h.git, h.nestedDir, IssueListOptions{
+		State:     "open",
+		Assignee:  "octocat",
+		Creator:   "octocat",
+		Mentioned: "octocat",
+		Page:      2,
+		PerPage:   25,
+	})
+	if err != nil {
+		t.Fatalf("ListCurrentRepoIssues() error = %v", err)
+	}
+	if repo == nil || repo.FullName != "acme/rocket" {
+		t.Fatalf("repository = %#v", repo)
+	}
+	if len(issues) != 1 || issues[0].Number != 7 {
+		t.Fatalf("issues = %#v", issues)
+	}
+	if seenPath != "/api/v3/repos/acme/rocket/issues" {
+		t.Fatalf("issues path = %q", seenPath)
+	}
+	for key, want := range map[string]string{"state": "open", "assignee": "octocat", "creator": "octocat", "mentioned": "octocat", "page": "2", "per_page": "25"} {
+		if got := seenQuery.Get(key); got != want {
+			t.Fatalf("query[%q] = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestCollaborationServicePullRequestsAndChecksAggregation(t *testing.T) {
+	var listQuery url.Values
+	h := newCollaborationServiceHarness(t, "https://github.com/acme/rocket.git", func(h *collaborationServiceHarness, w http.ResponseWriter, r *http.Request, body []byte) {
+		switch r.URL.Path {
+		case "/api/v3/repos/acme/rocket":
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "rocket", "full_name": "acme/rocket", "owner": map[string]any{"login": "acme"}})
+		case "/api/v3/repos/acme/rocket/installation":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 101})
+		case "/api/v3/repos/acme/rocket/pulls":
+			listQuery = r.URL.Query()
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"number": 12, "title": "PR title", "state": "open", "head": map[string]any{"sha": "deadbeef"}}})
+		case "/api/v3/repos/acme/rocket/pulls/12":
+			_ = json.NewEncoder(w).Encode(map[string]any{"number": 12, "title": "PR title", "state": "open", "head": map[string]any{"sha": "deadbeef"}})
+		case "/api/v3/repos/acme/rocket/commits/deadbeef/status":
+			_ = json.NewEncoder(w).Encode(map[string]any{"state": "failure", "total_count": 2, "statuses": []map[string]any{{"context": "ci/unit", "state": "success"}, {"context": "ci/e2e", "state": "failure"}}})
+		case "/api/v3/repos/acme/rocket/commits/deadbeef/check-runs":
+			_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 2, "check_runs": []map[string]any{{"name": "lint", "status": "completed", "conclusion": "success"}, {"name": "integration", "status": "completed", "conclusion": "failure"}}})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	pulls, _, err := h.service.ListCurrentRepoPullRequests(context.Background(), h.git, h.nestedDir, PullRequestListOptions{State: "closed", Base: "main", Head: "feature", PerPage: 10})
+	if err != nil {
+		t.Fatalf("ListCurrentRepoPullRequests() error = %v", err)
+	}
+	if len(pulls) != 1 || pulls[0].Number != 12 {
+		t.Fatalf("pulls = %#v", pulls)
+	}
+	for key, want := range map[string]string{"state": "closed", "base": "main", "head": "feature", "per_page": "10"} {
+		if got := listQuery.Get(key); got != want {
+			t.Fatalf("query[%q] = %q, want %q", key, got, want)
+		}
+	}
+
+	pull, repo, err := h.service.GetCurrentRepoPullRequest(context.Background(), h.git, h.nestedDir, 12)
+	if err != nil {
+		t.Fatalf("GetCurrentRepoPullRequest() error = %v", err)
+	}
+	if repo == nil || repo.FullName != "acme/rocket" {
+		t.Fatalf("repository = %#v", repo)
+	}
+	if pull == nil || pull.Checks == nil {
+		t.Fatalf("pull = %#v", pull)
+	}
+	if pull.Checks.State != "failure" || pull.Checks.TotalCount != 4 || pull.Checks.FailureCount != 2 || pull.Checks.SuccessCount != 2 {
+		t.Fatalf("checks = %#v", pull.Checks)
+	}
+}
+
+func TestCollaborationServicePullRequestFiltersUseRepoScopedSearch(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		filter    CollaborationFilter
+		wantTerms []string
+	}{
+		{
+			name:      "assigned to me",
+			filter:    CollaborationFilter{AssignedToMe: true},
+			wantTerms: []string{"repo:acme/rocket", "is:pr", "is:open", "assignee:octocat"},
+		},
+		{
+			name:      "created by me",
+			filter:    CollaborationFilter{CreatedByMe: true, State: "closed"},
+			wantTerms: []string{"repo:acme/rocket", "is:pr", "is:closed", "author:octocat"},
+		},
+		{
+			name:      "mixed assigned and created",
+			filter:    CollaborationFilter{AssignedToMe: true, CreatedByMe: true},
+			wantTerms: []string{"repo:acme/rocket", "is:pr", "is:open", "assignee:octocat", "author:octocat"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var seenPath string
+			var seenQuery url.Values
+			h := newCollaborationServiceHarness(t, "https://github.com/acme/rocket.git", func(h *collaborationServiceHarness, w http.ResponseWriter, r *http.Request, body []byte) {
+				switch r.URL.Path {
+				case "/api/v3/repos/acme/rocket":
+					_ = json.NewEncoder(w).Encode(map[string]any{"name": "rocket", "full_name": "acme/rocket", "owner": map[string]any{"login": "acme"}})
+				case "/api/v3/repos/acme/rocket/installation":
+					_ = json.NewEncoder(w).Encode(map[string]any{"id": 101})
+				case "/api/v3/search/issues":
+					seenPath = r.URL.Path
+					seenQuery = r.URL.Query()
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"total_count": 1,
+						"items":       []map[string]any{{"number": 12, "title": "PR title", "state": "open"}},
+					})
+				default:
+					t.Fatalf("unexpected path %s", r.URL.Path)
+				}
+			})
+
+			pulls, err := h.service.ListPullRequests(context.Background(), h.nestedDir, tc.filter)
+			if err != nil {
+				t.Fatalf("ListPullRequests() error = %v", err)
+			}
+			if len(pulls) != 1 || pulls[0].Number != 12 {
+				t.Fatalf("pulls = %#v", pulls)
+			}
+			if seenPath != "/api/v3/search/issues" {
+				t.Fatalf("filters should force repo-scoped search, got path %q query=%v", seenPath, seenQuery)
+			}
+			q := seenQuery.Get("q")
+			for _, want := range tc.wantTerms {
+				if !strings.Contains(q, want) {
+					t.Fatalf("search query missing %q in %q", want, q)
+				}
+			}
+		})
+	}
+}
+
+func TestCollaborationServiceWriteBodiesMatchContract(t *testing.T) {
+	var issueCommentBody map[string]any
+	var prCommentBody map[string]any
+	var reviewBody map[string]any
+	h := newCollaborationServiceHarness(t, "https://github.com/acme/rocket.git", func(h *collaborationServiceHarness, w http.ResponseWriter, r *http.Request, body []byte) {
+		switch r.URL.Path {
+		case "/api/v3/repos/acme/rocket":
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "rocket", "full_name": "acme/rocket", "owner": map[string]any{"login": "acme"}})
+		case "/api/v3/repos/acme/rocket/installation":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 101})
+		case "/api/v3/repos/acme/rocket/issues/7/comments":
+			_ = json.Unmarshal(body, &issueCommentBody)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 701, "body": issueCommentBody["body"]})
+		case "/api/v3/repos/acme/rocket/pulls/12/comments":
+			_ = json.Unmarshal(body, &prCommentBody)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 1201, "body": prCommentBody["body"], "path": prCommentBody["path"], "line": prCommentBody["line"]})
+		case "/api/v3/repos/acme/rocket/pulls/12/reviews":
+			_ = json.Unmarshal(body, &reviewBody)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 1202, "body": reviewBody["body"], "state": reviewBody["event"]})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	if _, _, err := h.service.CreateCurrentRepoIssueComment(context.Background(), h.git, h.nestedDir, 7, CreateIssueCommentInput{Body: "Issue comment from test"}); err != nil {
+		t.Fatalf("CreateCurrentRepoIssueComment() error = %v", err)
+	}
+	if issueCommentBody["body"] != "Issue comment from test" {
+		t.Fatalf("issue comment body = %#v", issueCommentBody)
+	}
+
+	if _, _, err := h.service.CreateCurrentRepoPullRequestComment(context.Background(), h.git, h.nestedDir, 12, CreatePullRequestCommentInput{Body: "Inline note", Path: "server/main.go", CommitID: "deadbeef", Side: "RIGHT", Line: 27}); err != nil {
+		t.Fatalf("CreateCurrentRepoPullRequestComment() error = %v", err)
+	}
+	for key, want := range map[string]any{"body": "Inline note", "path": "server/main.go", "commit_id": "deadbeef", "line": float64(27)} {
+		if prCommentBody[key] != want {
+			t.Fatalf("pull request comment body[%q] = %#v body=%#v", key, prCommentBody[key], prCommentBody)
+		}
+	}
+
+	if _, _, err := h.service.CreateCurrentRepoPullRequestReview(context.Background(), h.git, h.nestedDir, 12, CreatePullRequestReviewInput{Body: "Looks good", Event: "APPROVE", CommitID: "deadbeef", Comments: []PullRequestReviewDraftComment{{Body: "nit", Path: "server/main.go", Line: 8, Side: "RIGHT"}}}); err != nil {
+		t.Fatalf("CreateCurrentRepoPullRequestReview() error = %v", err)
+	}
+	if reviewBody["body"] != "Looks good" || reviewBody["event"] != "APPROVE" || reviewBody["commit_id"] != "deadbeef" {
+		t.Fatalf("review body = %#v", reviewBody)
+	}
+	comments, ok := reviewBody["comments"].([]any)
+	if !ok || len(comments) != 1 {
+		t.Fatalf("review comments = %#v", reviewBody["comments"])
+	}
+}
+
+func TestCollaborationServiceErrorTranslation(t *testing.T) {
+	t.Run("not authenticated", func(t *testing.T) {
+		repoDir, nestedDir := collaborationSetupRepo(t, "https://github.com/acme/rocket.git")
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}))
+		defer server.Close()
+		client := NewClient(server.Client())
+		client.SetBaseURLFuncs(func(string) string { return server.URL }, func(string) string { return server.URL + "/api/v3" })
+		service := NewService(client, NewStore(filepath.Join(t.TempDir(), "github-auth.json")), "client-id", DefaultHost, time.Minute)
+		_, _, err := service.GetCurrentRepoAccount(context.Background(), gitctx.NewGit(repoDir), nestedDir)
+		if !errors.Is(err, ErrNotAuthenticated) {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("reauth required", func(t *testing.T) {
+		h := newCollaborationServiceHarness(t, "https://github.com/acme/rocket.git", func(h *collaborationServiceHarness, w http.ResponseWriter, r *http.Request, body []byte) {
+			if r.URL.Path != "/login/oauth/access_token" {
+				t.Fatalf("unexpected path %s", r.URL.Path)
+			}
+			_ = json.NewEncoder(w).Encode(TokenResponse{Error: "bad_refresh_token"})
+		})
+		now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+		if err := h.service.store.Save(AuthRecord{GitHubHost: DefaultHost, AccessToken: "stale", AccessTokenExpiresAt: now.Add(-time.Minute), RefreshToken: "bad-refresh", RefreshTokenExpiresAt: now.Add(time.Hour)}); err != nil {
+			t.Fatalf("store.Save() error = %v", err)
+		}
+		_, _, err := h.service.GetCurrentRepoAccount(context.Background(), h.git, h.nestedDir)
+		if !errors.Is(err, ErrReauthRequired) {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	for _, tc := range []struct {
+		name   string
+		status int
+		path   string
+		call   func(*testing.T, *collaborationServiceHarness) error
+		assert func(*testing.T, error)
+	}{
+		{
+			name:   "repo access unavailable on 403",
+			status: http.StatusForbidden,
+			path:   "/api/v3/repos/acme/rocket/pulls/12",
+			call: func(t *testing.T, h *collaborationServiceHarness) error {
+				_, _, err := h.service.GetCurrentRepoPullRequest(context.Background(), h.git, h.nestedDir, 12)
+				return err
+			},
+			assert: func(t *testing.T, err error) {
+				if !errors.Is(err, ErrRepoAccessUnavailable) {
+					t.Fatalf("error = %v", err)
+				}
+			},
+		},
+		{
+			name:   "not found on 404",
+			status: http.StatusNotFound,
+			path:   "/api/v3/repos/acme/rocket/issues/404",
+			call: func(t *testing.T, h *collaborationServiceHarness) error {
+				_, _, err := h.service.GetCurrentRepoIssue(context.Background(), h.git, h.nestedDir, 404)
+				return err
+			},
+			assert: func(t *testing.T, err error) {
+				if !errors.Is(err, ErrNotFound) {
+					t.Fatalf("error = %v", err)
+				}
+			},
+		},
+		{
+			name:   "invalid request on 422",
+			status: http.StatusUnprocessableEntity,
+			path:   "/api/v3/repos/acme/rocket/pulls/12/comments",
+			call: func(t *testing.T, h *collaborationServiceHarness) error {
+				_, _, err := h.service.CreateCurrentRepoPullRequestComment(context.Background(), h.git, h.nestedDir, 12, CreatePullRequestCommentInput{Body: "bad", Path: "server/main.go", CommitID: "deadbeef", Line: 9})
+				return err
+			},
+			assert: func(t *testing.T, err error) {
+				if !errors.Is(err, ErrInvalidRequest) {
+					t.Fatalf("error = %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newCollaborationServiceHarness(t, "https://github.com/acme/rocket.git", func(h *collaborationServiceHarness, w http.ResponseWriter, r *http.Request, body []byte) {
+				switch r.URL.Path {
+				case "/api/v3/repos/acme/rocket":
+					_ = json.NewEncoder(w).Encode(map[string]any{"name": "rocket", "full_name": "acme/rocket", "owner": map[string]any{"login": "acme"}})
+				case "/api/v3/repos/acme/rocket/installation":
+					_ = json.NewEncoder(w).Encode(map[string]any{"id": 101})
+				case tc.path:
+					http.Error(w, "backend failure", tc.status)
+				default:
+					t.Fatalf("unexpected path %s", r.URL.Path)
+				}
+			})
+			err := tc.call(t, h)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			tc.assert(t, err)
+		})
+	}
+
+	t.Run("non github workspace maps to invalid request", func(t *testing.T) {
+		h := newCollaborationServiceHarness(t, "https://gitlab.com/acme/rocket.git", func(h *collaborationServiceHarness, w http.ResponseWriter, r *http.Request, body []byte) {
+			t.Fatalf("backend should not be called: %s", r.URL.Path)
+		})
+		_, _, err := h.service.GetCurrentRepoAccount(context.Background(), h.git, h.nestedDir)
+		if !errors.Is(err, ErrInvalidRequest) {
+			t.Fatalf("error = %v", err)
+		}
+	})
+}

--- a/server/internal/github/types.go
+++ b/server/internal/github/types.go
@@ -27,8 +27,11 @@ var (
 	ErrRefreshNotSupported    = errors.New("github refresh token support is required")
 	ErrReauthRequired         = errors.New("github reauthorization required")
 	ErrNotAuthenticated       = errors.New("github not authenticated")
+	ErrRepoNotGitHub          = errors.New("current workspace is not a github repository")
 	ErrRepoAccessUnavailable  = errors.New("github repo access unavailable")
 	ErrAppNotInstalledForRepo = errors.New("github app not installed for repo")
+	ErrInvalidRequest         = errors.New("github invalid request")
+	ErrNotFound               = errors.New("github resource not found")
 )
 
 type DeviceCodeResponse struct {
@@ -52,8 +55,10 @@ type TokenResponse struct {
 }
 
 type User struct {
-	Login string `json:"login"`
-	ID    int64  `json:"id"`
+	Login     string `json:"login"`
+	ID        int64  `json:"id"`
+	AvatarURL string `json:"avatar_url,omitempty"`
+	HTMLURL   string `json:"html_url,omitempty"`
 }
 
 type Repository struct {
@@ -141,6 +146,210 @@ type CurrentRepoContext struct {
 	Message    string      `json:"message,omitempty"`
 }
 
+type Account struct {
+	Login     string `json:"login"`
+	ID        int64  `json:"id"`
+	Name      string `json:"name,omitempty"`
+	AvatarURL string `json:"avatar_url,omitempty"`
+	HTMLURL   string `json:"html_url,omitempty"`
+}
+
+type Actor struct {
+	Login     string `json:"login"`
+	ID        int64  `json:"id"`
+	AvatarURL string `json:"avatar_url,omitempty"`
+	HTMLURL   string `json:"html_url,omitempty"`
+}
+
+type Label struct {
+	Name  string `json:"name"`
+	Color string `json:"color,omitempty"`
+}
+
+type PullRequestRef struct {
+	Label string `json:"label,omitempty"`
+	Ref   string `json:"ref,omitempty"`
+	SHA   string `json:"sha,omitempty"`
+}
+
+type PullRequestChecks struct {
+	State        string                `json:"state"`
+	TotalCount   int                   `json:"total_count"`
+	SuccessCount int                   `json:"success_count"`
+	PendingCount int                   `json:"pending_count"`
+	FailureCount int                   `json:"failure_count"`
+	Checks       []PullRequestCheckRun `json:"checks"`
+}
+
+type PullRequestCheckRun struct {
+	Name        string     `json:"name"`
+	Status      string     `json:"status"`
+	Conclusion  string     `json:"conclusion,omitempty"`
+	DetailsURL  string     `json:"details_url,omitempty"`
+	StartedAt   *time.Time `json:"started_at,omitempty"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+}
+
+type Issue struct {
+	Number        int        `json:"number"`
+	Title         string     `json:"title"`
+	State         string     `json:"state"`
+	Body          string     `json:"body,omitempty"`
+	HTMLURL       string     `json:"html_url,omitempty"`
+	CommentsCount int        `json:"comments_count"`
+	Locked        bool       `json:"locked"`
+	Author        *Actor     `json:"author,omitempty"`
+	Assignees     []Actor    `json:"assignees,omitempty"`
+	Labels        []Label    `json:"labels,omitempty"`
+	CreatedAt     *time.Time `json:"created_at,omitempty"`
+	UpdatedAt     *time.Time `json:"updated_at,omitempty"`
+	ClosedAt      *time.Time `json:"closed_at,omitempty"`
+}
+
+type IssueComment struct {
+	ID        int64      `json:"id"`
+	Body      string     `json:"body"`
+	HTMLURL   string     `json:"html_url,omitempty"`
+	Author    *Actor     `json:"author,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+type PullRequest struct {
+	Number              int                `json:"number"`
+	Title               string             `json:"title"`
+	State               string             `json:"state"`
+	Body                string             `json:"body,omitempty"`
+	HTMLURL             string             `json:"html_url,omitempty"`
+	Draft               bool               `json:"draft"`
+	Merged              bool               `json:"merged"`
+	Mergeable           *bool              `json:"mergeable,omitempty"`
+	MergeableState      string             `json:"mergeable_state,omitempty"`
+	CommentsCount       int                `json:"comments_count"`
+	ReviewCommentsCount int                `json:"review_comments_count"`
+	CommitsCount        int                `json:"commits_count"`
+	Additions           int                `json:"additions"`
+	Deletions           int                `json:"deletions"`
+	ChangedFiles        int                `json:"changed_files"`
+	Author              *Actor             `json:"author,omitempty"`
+	Assignees           []Actor            `json:"assignees,omitempty"`
+	Labels              []Label            `json:"labels,omitempty"`
+	BaseRef             PullRequestRef     `json:"base_ref"`
+	HeadRef             PullRequestRef     `json:"head_ref"`
+	CreatedAt           *time.Time         `json:"created_at,omitempty"`
+	UpdatedAt           *time.Time         `json:"updated_at,omitempty"`
+	ClosedAt            *time.Time         `json:"closed_at,omitempty"`
+	MergedAt            *time.Time         `json:"merged_at,omitempty"`
+	Checks              *PullRequestChecks `json:"checks,omitempty"`
+}
+
+type PullRequestFile struct {
+	SHA              string `json:"sha,omitempty"`
+	Filename         string `json:"filename"`
+	Status           string `json:"status"`
+	Additions        int    `json:"additions"`
+	Deletions        int    `json:"deletions"`
+	Changes          int    `json:"changes"`
+	BlobURL          string `json:"blob_url,omitempty"`
+	RawURL           string `json:"raw_url,omitempty"`
+	Patch            string `json:"patch,omitempty"`
+	PreviousFilename string `json:"previous_filename,omitempty"`
+}
+
+type PullRequestComment struct {
+	ID               int64      `json:"id"`
+	Body             string     `json:"body"`
+	HTMLURL          string     `json:"html_url,omitempty"`
+	Path             string     `json:"path,omitempty"`
+	DiffHunk         string     `json:"diff_hunk,omitempty"`
+	CommitID         string     `json:"commit_id,omitempty"`
+	OriginalCommitID string     `json:"original_commit_id,omitempty"`
+	Position         int        `json:"position,omitempty"`
+	OriginalPosition int        `json:"original_position,omitempty"`
+	Line             int        `json:"line,omitempty"`
+	OriginalLine     int        `json:"original_line,omitempty"`
+	Side             string     `json:"side,omitempty"`
+	StartLine        int        `json:"start_line,omitempty"`
+	StartSide        string     `json:"start_side,omitempty"`
+	InReplyToID      int64      `json:"in_reply_to_id,omitempty"`
+	Author           *Actor     `json:"author,omitempty"`
+	CreatedAt        *time.Time `json:"created_at,omitempty"`
+	UpdatedAt        *time.Time `json:"updated_at,omitempty"`
+}
+
+type PullRequestReview struct {
+	ID          int64      `json:"id"`
+	Body        string     `json:"body,omitempty"`
+	State       string     `json:"state,omitempty"`
+	CommitID    string     `json:"commit_id,omitempty"`
+	HTMLURL     string     `json:"html_url,omitempty"`
+	Author      *Actor     `json:"author,omitempty"`
+	SubmittedAt *time.Time `json:"submitted_at,omitempty"`
+}
+
+type IssueListOptions struct {
+	State     string
+	Sort      string
+	Direction string
+	Since     string
+	Labels    string
+	Creator   string
+	Mentioned string
+	Assignee  string
+	Milestone string
+	Page      int
+	PerPage   int
+}
+
+type PullRequestListOptions struct {
+	State     string
+	Head      string
+	Base      string
+	Sort      string
+	Direction string
+	Page      int
+	PerPage   int
+}
+
+type ListOptions struct {
+	Sort      string
+	Direction string
+	Since     string
+	Page      int
+	PerPage   int
+}
+
+type CreateIssueCommentInput struct {
+	Body string `json:"body"`
+}
+
+type CreatePullRequestCommentInput struct {
+	Body      string `json:"body"`
+	Path      string `json:"path,omitempty"`
+	CommitID  string `json:"commit_id,omitempty"`
+	Side      string `json:"side,omitempty"`
+	StartSide string `json:"start_side,omitempty"`
+	Line      int    `json:"line,omitempty"`
+	StartLine int    `json:"start_line,omitempty"`
+	InReplyTo int64  `json:"in_reply_to,omitempty"`
+}
+
+type PullRequestReviewDraftComment struct {
+	Body      string `json:"body"`
+	Path      string `json:"path,omitempty"`
+	Side      string `json:"side,omitempty"`
+	StartSide string `json:"start_side,omitempty"`
+	Line      int    `json:"line,omitempty"`
+	StartLine int    `json:"start_line,omitempty"`
+}
+
+type CreatePullRequestReviewInput struct {
+	Event    string                          `json:"event,omitempty"`
+	Body     string                          `json:"body,omitempty"`
+	CommitID string                          `json:"commit_id,omitempty"`
+	Comments []PullRequestReviewDraftComment `json:"comments,omitempty"`
+}
+
 type HostError struct {
 	Host string
 	Err  error
@@ -222,10 +431,16 @@ func ErrorCode(err error) string {
 		return "reauth_required"
 	case errors.Is(err, ErrNotAuthenticated):
 		return "not_authenticated"
+	case errors.Is(err, ErrRepoNotGitHub):
+		return "repo_not_github"
 	case errors.Is(err, ErrRepoAccessUnavailable):
 		return "repo_access_unavailable"
 	case errors.Is(err, ErrAppNotInstalledForRepo):
 		return "app_not_installed_for_repo"
+	case errors.Is(err, ErrInvalidRequest):
+		return "invalid_request"
+	case errors.Is(err, ErrNotFound):
+		return "not_found"
 	default:
 		return "github_auth_error"
 	}


### PR DESCRIPTION
## Summary
- add repo-scoped GitHub collaboration backend endpoints for account, issues, pull requests, comments, and reviews
- expose PR detail aggregation including files, comments/reviews, and checks summaries for the current workspace repo
- align the published backend contract docs with the shipped handler behavior

## Why
- completes ASE-52 / GitHub issue #13 so the Flutter client can read collaboration data and submit issue comments / PR reviews against the bound repository
- backfills the required review PR artifact for the ticket after the implementation landed on `main`

## Issue
- Closes #13

## Validation
- `cd server && go test ./internal/github ./internal/api`
- `cd server && go vet ./internal/github ./internal/api`
