### PR TITLE
ASE-54: add GitHub collaboration UX

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -6,6 +6,7 @@ import 'providers/chat_provider.dart';
 import 'providers/editor_provider.dart';
 import 'providers/file_provider.dart';
 import 'providers/git_provider.dart';
+import 'providers/github_collaboration_provider.dart';
 import 'providers/github_auth_provider.dart';
 import 'providers/search_provider.dart';
 import 'providers/workspace_provider.dart';
@@ -13,6 +14,7 @@ import 'services/api_client.dart';
 import 'services/browser_launcher.dart';
 import 'services/chat_api_client.dart';
 import 'services/git_api_client.dart';
+import 'services/github_collaboration_api_client.dart';
 import 'services/github_auth_api_client.dart';
 import 'services/settings_service.dart';
 
@@ -26,6 +28,9 @@ void main() async {
   final chatApiClient = ChatApiClient(settings: settings);
   final gitApiClient = GitApiClient(settings: settings);
   final githubAuthApiClient = GitHubAuthApiClient(settings: settings);
+  final githubCollaborationApiClient = GitHubCollaborationApiClient(
+    settings: settings,
+  );
   final browserLauncher = BrowserLauncher();
 
   final workspaceProvider = WorkspaceProvider();
@@ -67,6 +72,19 @@ void main() async {
           ),
           update: (_, workspace, githubAuthProvider) {
             final provider = githubAuthProvider!;
+            provider.setWorkspacePath(workspace.currentPath);
+            return provider;
+          },
+        ),
+        ChangeNotifierProxyProvider<
+          WorkspaceProvider,
+          GitHubCollaborationProvider
+        >(
+          create: (_) => GitHubCollaborationProvider(
+            apiClient: githubCollaborationApiClient,
+          ),
+          update: (_, workspace, collaborationProvider) {
+            final provider = collaborationProvider!;
             provider.setWorkspacePath(workspace.currentPath);
             return provider;
           },

--- a/app/lib/models/github_collaboration_models.dart
+++ b/app/lib/models/github_collaboration_models.dart
@@ -1,0 +1,930 @@
+import 'github_auth_models.dart';
+
+class GitHubRepositoryContext {
+  final int? id;
+  final String githubHost;
+  final String owner;
+  final String name;
+  final String fullName;
+  final String remoteName;
+  final String remoteUrl;
+  final String repoRoot;
+  final bool isPrivate;
+
+  const GitHubRepositoryContext({
+    required this.id,
+    required this.githubHost,
+    required this.owner,
+    required this.name,
+    required this.fullName,
+    required this.remoteName,
+    required this.remoteUrl,
+    required this.repoRoot,
+    required this.isPrivate,
+  });
+
+  factory GitHubRepositoryContext.fromJson(Map<String, dynamic> json) {
+    return GitHubRepositoryContext(
+      id: _readNullableInt(json['id']),
+      githubHost: (json['github_host'] as String?)?.trim() ?? 'github.com',
+      owner: _readOwner(json['owner']),
+      name: (json['name'] as String?)?.trim() ?? '',
+      fullName: (json['full_name'] as String?)?.trim() ?? '',
+      remoteName: (json['remote_name'] as String?)?.trim() ?? '',
+      remoteUrl: (json['remote_url'] as String?)?.trim() ?? '',
+      repoRoot: (json['repo_root'] as String?)?.trim() ?? '',
+      isPrivate: json['private'] == true,
+    );
+  }
+}
+
+class GitHubCurrentRepoContext {
+  final String status;
+  final String? errorCode;
+  final GitHubRepositoryContext? repository;
+  final GitHubAuthStatus? auth;
+  final String? message;
+
+  const GitHubCurrentRepoContext({
+    required this.status,
+    required this.errorCode,
+    required this.repository,
+    required this.auth,
+    required this.message,
+  });
+
+  bool get isOk => status == 'ok';
+
+  bool get needsAuthAction =>
+      status == 'not_authenticated' || status == 'reauth_required';
+
+  bool get isRepoUnavailable =>
+      status == 'repo_not_github' ||
+      status == 'repo_access_unavailable' ||
+      status == 'app_not_installed_for_repo';
+
+  factory GitHubCurrentRepoContext.fromJson(Map<String, dynamic> json) {
+    return GitHubCurrentRepoContext(
+      status: (json['status'] as String?)?.trim() ?? 'repo_not_github',
+      errorCode: (json['error_code'] as String?)?.trim(),
+      repository: json['repository'] is Map<String, dynamic>
+          ? GitHubRepositoryContext.fromJson(
+              json['repository'] as Map<String, dynamic>,
+            )
+          : null,
+      auth: json['auth'] is Map<String, dynamic>
+          ? GitHubAuthStatus.fromJson(json['auth'] as Map<String, dynamic>)
+          : null,
+      message: (json['message'] as String?)?.trim(),
+    );
+  }
+}
+
+class GitHubAccount {
+  final String login;
+  final int id;
+  final String name;
+  final String avatarUrl;
+  final String htmlUrl;
+
+  const GitHubAccount({
+    required this.login,
+    required this.id,
+    required this.name,
+    required this.avatarUrl,
+    required this.htmlUrl,
+  });
+
+  factory GitHubAccount.fromJson(Map<String, dynamic> json) {
+    return GitHubAccount(
+      login: (json['login'] as String?)?.trim() ?? '',
+      id: _readInt(json['id']),
+      name: (json['name'] as String?)?.trim() ?? '',
+      avatarUrl: (json['avatar_url'] as String?)?.trim() ?? '',
+      htmlUrl: (json['html_url'] as String?)?.trim() ?? '',
+    );
+  }
+}
+
+class GitHubAccountContext {
+  final GitHubRepositoryContext repository;
+  final GitHubAccount account;
+
+  const GitHubAccountContext({required this.repository, required this.account});
+
+  factory GitHubAccountContext.fromJson(Map<String, dynamic> json) {
+    return GitHubAccountContext(
+      repository: GitHubRepositoryContext.fromJson(
+        json['repository'] as Map<String, dynamic>? ?? const {},
+      ),
+      account: GitHubAccount.fromJson(
+        json['account'] as Map<String, dynamic>? ?? const {},
+      ),
+    );
+  }
+}
+
+class GitHubActor {
+  final String login;
+  final int id;
+  final String avatarUrl;
+  final String htmlUrl;
+
+  const GitHubActor({
+    required this.login,
+    required this.id,
+    required this.avatarUrl,
+    required this.htmlUrl,
+  });
+
+  factory GitHubActor.fromJson(Map<String, dynamic> json) {
+    return GitHubActor(
+      login: (json['login'] as String?)?.trim() ?? '',
+      id: _readInt(json['id']),
+      avatarUrl: (json['avatar_url'] as String?)?.trim() ?? '',
+      htmlUrl: (json['html_url'] as String?)?.trim() ?? '',
+    );
+  }
+}
+
+class GitHubLabel {
+  final String name;
+  final String color;
+
+  const GitHubLabel({required this.name, required this.color});
+
+  factory GitHubLabel.fromJson(Map<String, dynamic> json) {
+    return GitHubLabel(
+      name: (json['name'] as String?)?.trim() ?? '',
+      color: (json['color'] as String?)?.trim() ?? '',
+    );
+  }
+}
+
+class GitHubPullRequestRef {
+  final String label;
+  final String ref;
+  final String sha;
+
+  const GitHubPullRequestRef({
+    required this.label,
+    required this.ref,
+    required this.sha,
+  });
+
+  factory GitHubPullRequestRef.fromJson(Map<String, dynamic> json) {
+    return GitHubPullRequestRef(
+      label: (json['label'] as String?)?.trim() ?? '',
+      ref: (json['ref'] as String?)?.trim() ?? '',
+      sha: (json['sha'] as String?)?.trim() ?? '',
+    );
+  }
+}
+
+class GitHubPullRequestCheckRun {
+  final String name;
+  final String status;
+  final String conclusion;
+  final String detailsUrl;
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+
+  const GitHubPullRequestCheckRun({
+    required this.name,
+    required this.status,
+    required this.conclusion,
+    required this.detailsUrl,
+    required this.startedAt,
+    required this.completedAt,
+  });
+
+  factory GitHubPullRequestCheckRun.fromJson(Map<String, dynamic> json) {
+    return GitHubPullRequestCheckRun(
+      name: (json['name'] as String?)?.trim() ?? '',
+      status: (json['status'] as String?)?.trim() ?? '',
+      conclusion: (json['conclusion'] as String?)?.trim() ?? '',
+      detailsUrl: (json['details_url'] as String?)?.trim() ?? '',
+      startedAt: _readDateTime(json['started_at']),
+      completedAt: _readDateTime(json['completed_at']),
+    );
+  }
+}
+
+class GitHubPullRequestChecks {
+  final String state;
+  final int totalCount;
+  final int successCount;
+  final int pendingCount;
+  final int failureCount;
+  final List<GitHubPullRequestCheckRun> checks;
+
+  const GitHubPullRequestChecks({
+    required this.state,
+    required this.totalCount,
+    required this.successCount,
+    required this.pendingCount,
+    required this.failureCount,
+    required this.checks,
+  });
+
+  factory GitHubPullRequestChecks.fromJson(Map<String, dynamic> json) {
+    return GitHubPullRequestChecks(
+      state: (json['state'] as String?)?.trim() ?? 'unknown',
+      totalCount: _readInt(json['total_count']),
+      successCount: _readInt(json['success_count']),
+      pendingCount: _readInt(json['pending_count']),
+      failureCount: _readInt(json['failure_count']),
+      checks: _mapList(
+        json['checks'],
+        (item) => GitHubPullRequestCheckRun.fromJson(item),
+      ),
+    );
+  }
+}
+
+class GitHubIssue {
+  final int number;
+  final String title;
+  final String state;
+  final String body;
+  final String htmlUrl;
+  final int commentsCount;
+  final bool locked;
+  final GitHubActor? author;
+  final List<GitHubActor> assignees;
+  final List<GitHubLabel> labels;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final DateTime? closedAt;
+
+  const GitHubIssue({
+    required this.number,
+    required this.title,
+    required this.state,
+    required this.body,
+    required this.htmlUrl,
+    required this.commentsCount,
+    required this.locked,
+    required this.author,
+    required this.assignees,
+    required this.labels,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.closedAt,
+  });
+
+  factory GitHubIssue.fromJson(Map<String, dynamic> json) {
+    return GitHubIssue(
+      number: _readInt(json['number']),
+      title: (json['title'] as String?)?.trim() ?? '',
+      state: (json['state'] as String?)?.trim() ?? '',
+      body: (json['body'] as String?)?.trim() ?? '',
+      htmlUrl: (json['html_url'] as String?)?.trim() ?? '',
+      commentsCount: _readInt(json['comments_count']),
+      locked: json['locked'] == true,
+      author: json['author'] is Map<String, dynamic>
+          ? GitHubActor.fromJson(json['author'] as Map<String, dynamic>)
+          : null,
+      assignees: _mapList(
+        json['assignees'],
+        (item) => GitHubActor.fromJson(item),
+      ),
+      labels: _mapList(json['labels'], (item) => GitHubLabel.fromJson(item)),
+      createdAt: _readDateTime(json['created_at']),
+      updatedAt: _readDateTime(json['updated_at']),
+      closedAt: _readDateTime(json['closed_at']),
+    );
+  }
+}
+
+class GitHubIssueComment {
+  final int id;
+  final String body;
+  final String htmlUrl;
+  final GitHubActor? author;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  const GitHubIssueComment({
+    required this.id,
+    required this.body,
+    required this.htmlUrl,
+    required this.author,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory GitHubIssueComment.fromJson(Map<String, dynamic> json) {
+    return GitHubIssueComment(
+      id: _readInt(json['id']),
+      body: (json['body'] as String?)?.trim() ?? '',
+      htmlUrl: (json['html_url'] as String?)?.trim() ?? '',
+      author: json['author'] is Map<String, dynamic>
+          ? GitHubActor.fromJson(json['author'] as Map<String, dynamic>)
+          : null,
+      createdAt: _readDateTime(json['created_at']),
+      updatedAt: _readDateTime(json['updated_at']),
+    );
+  }
+}
+
+class GitHubIssueDetail {
+  final GitHubIssue issue;
+  final List<GitHubIssueComment> comments;
+
+  const GitHubIssueDetail({required this.issue, required this.comments});
+
+  factory GitHubIssueDetail.fromJson(Map<String, dynamic> json) {
+    return GitHubIssueDetail(
+      issue: GitHubIssue.fromJson(
+        json['issue'] as Map<String, dynamic>? ?? const {},
+      ),
+      comments: _mapList(
+        json['comments'],
+        (item) => GitHubIssueComment.fromJson(item),
+      ),
+    );
+  }
+}
+
+class GitHubPullRequest {
+  final int number;
+  final String title;
+  final String state;
+  final String body;
+  final String htmlUrl;
+  final bool draft;
+  final bool merged;
+  final bool? mergeable;
+  final String mergeableState;
+  final int commentsCount;
+  final int reviewCommentsCount;
+  final int commitsCount;
+  final int additions;
+  final int deletions;
+  final int changedFiles;
+  final GitHubActor? author;
+  final List<GitHubActor> assignees;
+  final List<GitHubLabel> labels;
+  final GitHubPullRequestRef baseRef;
+  final GitHubPullRequestRef headRef;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final DateTime? closedAt;
+  final DateTime? mergedAt;
+  final GitHubPullRequestChecks? checks;
+
+  const GitHubPullRequest({
+    required this.number,
+    required this.title,
+    required this.state,
+    required this.body,
+    required this.htmlUrl,
+    required this.draft,
+    required this.merged,
+    required this.mergeable,
+    required this.mergeableState,
+    required this.commentsCount,
+    required this.reviewCommentsCount,
+    required this.commitsCount,
+    required this.additions,
+    required this.deletions,
+    required this.changedFiles,
+    required this.author,
+    required this.assignees,
+    required this.labels,
+    required this.baseRef,
+    required this.headRef,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.closedAt,
+    required this.mergedAt,
+    required this.checks,
+  });
+
+  factory GitHubPullRequest.fromJson(Map<String, dynamic> json) {
+    final mergeableValue = json['mergeable'];
+    bool? mergeable;
+    if (mergeableValue is bool) {
+      mergeable = mergeableValue;
+    }
+
+    return GitHubPullRequest(
+      number: _readInt(json['number']),
+      title: (json['title'] as String?)?.trim() ?? '',
+      state: (json['state'] as String?)?.trim() ?? '',
+      body: (json['body'] as String?)?.trim() ?? '',
+      htmlUrl: (json['html_url'] as String?)?.trim() ?? '',
+      draft: json['draft'] == true,
+      merged: json['merged'] == true,
+      mergeable: mergeable,
+      mergeableState: (json['mergeable_state'] as String?)?.trim() ?? '',
+      commentsCount: _readInt(json['comments_count']),
+      reviewCommentsCount: _readInt(json['review_comments_count']),
+      commitsCount: _readInt(json['commits_count']),
+      additions: _readInt(json['additions']),
+      deletions: _readInt(json['deletions']),
+      changedFiles: _readInt(json['changed_files']),
+      author: json['author'] is Map<String, dynamic>
+          ? GitHubActor.fromJson(json['author'] as Map<String, dynamic>)
+          : null,
+      assignees: _mapList(
+        json['assignees'],
+        (item) => GitHubActor.fromJson(item),
+      ),
+      labels: _mapList(json['labels'], (item) => GitHubLabel.fromJson(item)),
+      baseRef: GitHubPullRequestRef.fromJson(
+        json['base_ref'] as Map<String, dynamic>? ?? const {},
+      ),
+      headRef: GitHubPullRequestRef.fromJson(
+        json['head_ref'] as Map<String, dynamic>? ?? const {},
+      ),
+      createdAt: _readDateTime(json['created_at']),
+      updatedAt: _readDateTime(json['updated_at']),
+      closedAt: _readDateTime(json['closed_at']),
+      mergedAt: _readDateTime(json['merged_at']),
+      checks: json['checks'] is Map<String, dynamic>
+          ? GitHubPullRequestChecks.fromJson(
+              json['checks'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+}
+
+class GitHubPullRequestFile {
+  final String sha;
+  final String filename;
+  final String status;
+  final int additions;
+  final int deletions;
+  final int changes;
+  final String blobUrl;
+  final String rawUrl;
+  final String patch;
+  final String previousFilename;
+
+  const GitHubPullRequestFile({
+    required this.sha,
+    required this.filename,
+    required this.status,
+    required this.additions,
+    required this.deletions,
+    required this.changes,
+    required this.blobUrl,
+    required this.rawUrl,
+    required this.patch,
+    required this.previousFilename,
+  });
+
+  factory GitHubPullRequestFile.fromJson(Map<String, dynamic> json) {
+    return GitHubPullRequestFile(
+      sha: (json['sha'] as String?)?.trim() ?? '',
+      filename: (json['filename'] as String?)?.trim() ?? '',
+      status: (json['status'] as String?)?.trim() ?? '',
+      additions: _readInt(json['additions']),
+      deletions: _readInt(json['deletions']),
+      changes: _readInt(json['changes']),
+      blobUrl: (json['blob_url'] as String?)?.trim() ?? '',
+      rawUrl: (json['raw_url'] as String?)?.trim() ?? '',
+      patch: (json['patch'] as String?) ?? '',
+      previousFilename: (json['previous_filename'] as String?)?.trim() ?? '',
+    );
+  }
+}
+
+class GitHubPullRequestComment {
+  final int id;
+  final String body;
+  final String htmlUrl;
+  final String path;
+  final String diffHunk;
+  final String commitId;
+  final String originalCommitId;
+  final int position;
+  final int originalPosition;
+  final int line;
+  final int originalLine;
+  final String side;
+  final int startLine;
+  final String startSide;
+  final int inReplyToId;
+  final GitHubActor? author;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  const GitHubPullRequestComment({
+    required this.id,
+    required this.body,
+    required this.htmlUrl,
+    required this.path,
+    required this.diffHunk,
+    required this.commitId,
+    required this.originalCommitId,
+    required this.position,
+    required this.originalPosition,
+    required this.line,
+    required this.originalLine,
+    required this.side,
+    required this.startLine,
+    required this.startSide,
+    required this.inReplyToId,
+    required this.author,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  bool get isInline => path.isNotEmpty || line > 0 || diffHunk.isNotEmpty;
+
+  factory GitHubPullRequestComment.fromJson(Map<String, dynamic> json) {
+    return GitHubPullRequestComment(
+      id: _readInt(json['id']),
+      body: (json['body'] as String?)?.trim() ?? '',
+      htmlUrl: (json['html_url'] as String?)?.trim() ?? '',
+      path: (json['path'] as String?)?.trim() ?? '',
+      diffHunk: (json['diff_hunk'] as String?) ?? '',
+      commitId: (json['commit_id'] as String?)?.trim() ?? '',
+      originalCommitId: (json['original_commit_id'] as String?)?.trim() ?? '',
+      position: _readInt(json['position']),
+      originalPosition: _readInt(json['original_position']),
+      line: _readInt(json['line']),
+      originalLine: _readInt(json['original_line']),
+      side: (json['side'] as String?)?.trim() ?? '',
+      startLine: _readInt(json['start_line']),
+      startSide: (json['start_side'] as String?)?.trim() ?? '',
+      inReplyToId: _readInt(json['in_reply_to_id']),
+      author: json['author'] is Map<String, dynamic>
+          ? GitHubActor.fromJson(json['author'] as Map<String, dynamic>)
+          : null,
+      createdAt: _readDateTime(json['created_at']),
+      updatedAt: _readDateTime(json['updated_at']),
+    );
+  }
+}
+
+class GitHubPullRequestReview {
+  final int id;
+  final String body;
+  final String state;
+  final String commitId;
+  final String htmlUrl;
+  final GitHubActor? author;
+  final DateTime? submittedAt;
+
+  const GitHubPullRequestReview({
+    required this.id,
+    required this.body,
+    required this.state,
+    required this.commitId,
+    required this.htmlUrl,
+    required this.author,
+    required this.submittedAt,
+  });
+
+  factory GitHubPullRequestReview.fromJson(Map<String, dynamic> json) {
+    return GitHubPullRequestReview(
+      id: _readInt(json['id']),
+      body: (json['body'] as String?)?.trim() ?? '',
+      state: (json['state'] as String?)?.trim() ?? '',
+      commitId: (json['commit_id'] as String?)?.trim() ?? '',
+      htmlUrl: (json['html_url'] as String?)?.trim() ?? '',
+      author: json['author'] is Map<String, dynamic>
+          ? GitHubActor.fromJson(json['author'] as Map<String, dynamic>)
+          : null,
+      submittedAt: _readDateTime(json['submitted_at']),
+    );
+  }
+}
+
+class GitHubPullRequestDetail {
+  final GitHubPullRequest pullRequest;
+  final List<GitHubPullRequestFile> files;
+  final List<GitHubPullRequestComment> comments;
+  final List<GitHubPullRequestReview> reviews;
+
+  const GitHubPullRequestDetail({
+    required this.pullRequest,
+    required this.files,
+    required this.comments,
+    required this.reviews,
+  });
+
+  factory GitHubPullRequestDetail.fromJson(Map<String, dynamic> json) {
+    return GitHubPullRequestDetail(
+      pullRequest: GitHubPullRequest.fromJson(
+        json['pull_request'] as Map<String, dynamic>? ?? const {},
+      ),
+      files: _mapList(
+        json['files'],
+        (item) => GitHubPullRequestFile.fromJson(item),
+      ),
+      comments: _mapList(
+        json['comments'],
+        (item) => GitHubPullRequestComment.fromJson(item),
+      ),
+      reviews: _mapList(
+        json['reviews'],
+        (item) => GitHubPullRequestReview.fromJson(item),
+      ),
+    );
+  }
+}
+
+class GitHubPullRequestConversation {
+  final List<GitHubPullRequestComment> comments;
+  final List<GitHubPullRequestReview> reviews;
+
+  const GitHubPullRequestConversation({
+    required this.comments,
+    required this.reviews,
+  });
+
+  factory GitHubPullRequestConversation.fromJson(Map<String, dynamic> json) {
+    return GitHubPullRequestConversation(
+      comments: _mapList(
+        json['comments'],
+        (item) => GitHubPullRequestComment.fromJson(item),
+      ),
+      reviews: _mapList(
+        json['reviews'],
+        (item) => GitHubPullRequestReview.fromJson(item),
+      ),
+    );
+  }
+}
+
+class GitHubResolveLocalFileResult {
+  final String repoRoot;
+  final String relativePath;
+  final String localPath;
+  final bool exists;
+
+  const GitHubResolveLocalFileResult({
+    required this.repoRoot,
+    required this.relativePath,
+    required this.localPath,
+    required this.exists,
+  });
+
+  factory GitHubResolveLocalFileResult.fromJson(Map<String, dynamic> json) {
+    return GitHubResolveLocalFileResult(
+      repoRoot: (json['repo_root'] as String?)?.trim() ?? '',
+      relativePath: (json['relative_path'] as String?)?.trim() ?? '',
+      localPath: (json['local_path'] as String?)?.trim() ?? '',
+      exists: json['exists'] == true,
+    );
+  }
+}
+
+class GitHubCollaborationFilter {
+  final String state;
+  final bool assignedToMe;
+  final bool createdByMe;
+  final bool mentioned;
+  final bool needsReview;
+  final int? page;
+  final int? perPage;
+
+  const GitHubCollaborationFilter({
+    this.state = '',
+    this.assignedToMe = false,
+    this.createdByMe = false,
+    this.mentioned = false,
+    this.needsReview = false,
+    this.page,
+    this.perPage,
+  });
+
+  GitHubCollaborationFilter copyWith({
+    String? state,
+    bool? assignedToMe,
+    bool? createdByMe,
+    bool? mentioned,
+    bool? needsReview,
+    int? page,
+    int? perPage,
+  }) {
+    return GitHubCollaborationFilter(
+      state: state ?? this.state,
+      assignedToMe: assignedToMe ?? this.assignedToMe,
+      createdByMe: createdByMe ?? this.createdByMe,
+      mentioned: mentioned ?? this.mentioned,
+      needsReview: needsReview ?? this.needsReview,
+      page: page ?? this.page,
+      perPage: perPage ?? this.perPage,
+    );
+  }
+
+  Map<String, String> toQueryParameters({bool includeNeedsReview = true}) {
+    final params = <String, String>{};
+    if (state.trim().isNotEmpty) {
+      params['state'] = state.trim();
+    }
+    if (assignedToMe) {
+      params['assigned_to_me'] = 'true';
+    }
+    if (createdByMe) {
+      params['created_by_me'] = 'true';
+    }
+    if (mentioned) {
+      params['mentioned'] = 'true';
+    }
+    if (includeNeedsReview && needsReview) {
+      params['needs_review'] = 'true';
+    }
+    if (page != null && page! > 0) {
+      params['page'] = '${page!}';
+    }
+    if (perPage != null && perPage! > 0) {
+      params['per_page'] = '${perPage!}';
+    }
+    return params;
+  }
+}
+
+class GitHubIssueCommentInput {
+  final String body;
+
+  const GitHubIssueCommentInput({required this.body});
+}
+
+class GitHubPullRequestCommentInput {
+  final String body;
+  final String path;
+  final String commitId;
+  final String side;
+  final String startSide;
+  final int? line;
+  final int? startLine;
+  final int? inReplyTo;
+
+  const GitHubPullRequestCommentInput({
+    required this.body,
+    this.path = '',
+    this.commitId = '',
+    this.side = '',
+    this.startSide = '',
+    this.line,
+    this.startLine,
+    this.inReplyTo,
+  });
+
+  Map<String, dynamic> toJson(String workspacePath) {
+    return <String, dynamic>{
+      'workspace_path': workspacePath,
+      'body': body,
+      if (path.trim().isNotEmpty) 'path': path.trim(),
+      if (commitId.trim().isNotEmpty) 'commit_id': commitId.trim(),
+      if (side.trim().isNotEmpty) 'side': side.trim(),
+      if (startSide.trim().isNotEmpty) 'start_side': startSide.trim(),
+      if (line != null && line! > 0) 'line': line,
+      if (startLine != null && startLine! > 0) 'start_line': startLine,
+      if (inReplyTo != null && inReplyTo! > 0) 'in_reply_to': inReplyTo,
+    };
+  }
+}
+
+class GitHubPullRequestReviewDraftComment {
+  final String body;
+  final String path;
+  final String side;
+  final String startSide;
+  final int? line;
+  final int? startLine;
+
+  const GitHubPullRequestReviewDraftComment({
+    required this.body,
+    this.path = '',
+    this.side = '',
+    this.startSide = '',
+    this.line,
+    this.startLine,
+  });
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'body': body,
+      if (path.trim().isNotEmpty) 'path': path.trim(),
+      if (side.trim().isNotEmpty) 'side': side.trim(),
+      if (startSide.trim().isNotEmpty) 'start_side': startSide.trim(),
+      if (line != null && line! > 0) 'line': line,
+      if (startLine != null && startLine! > 0) 'start_line': startLine,
+    };
+  }
+}
+
+class GitHubPullRequestReviewInput {
+  final String event;
+  final String body;
+  final String commitId;
+  final List<GitHubPullRequestReviewDraftComment> comments;
+
+  const GitHubPullRequestReviewInput({
+    required this.event,
+    this.body = '',
+    this.commitId = '',
+    this.comments = const [],
+  });
+
+  Map<String, dynamic> toJson(String workspacePath) {
+    return <String, dynamic>{
+      'workspace_path': workspacePath,
+      'event': event.trim().toUpperCase(),
+      if (body.trim().isNotEmpty) 'body': body.trim(),
+      if (commitId.trim().isNotEmpty) 'commit_id': commitId.trim(),
+      if (comments.isNotEmpty)
+        'comments': comments.map((comment) => comment.toJson()).toList(),
+    };
+  }
+}
+
+class GitHubCollaborationException implements Exception {
+  final int statusCode;
+  final String errorCode;
+  final String message;
+
+  const GitHubCollaborationException({
+    required this.statusCode,
+    required this.errorCode,
+    required this.message,
+  });
+
+  bool get needsAuthAction =>
+      errorCode == 'not_authenticated' || errorCode == 'reauth_required';
+
+  String toDisplayMessage() {
+    switch (errorCode) {
+      case 'github_auth_disabled':
+        return 'GitHub collaboration is not enabled on this server.';
+      case 'not_authenticated':
+        return 'GitHub is not connected on this server yet.';
+      case 'reauth_required':
+        return 'Your GitHub session expired. Reconnect to continue.';
+      case 'repo_not_github':
+        return 'The current workspace is not backed by a GitHub repository.';
+      case 'repo_access_unavailable':
+        return 'The connected account cannot access this repository.';
+      case 'app_not_installed_for_repo':
+        return 'The configured GitHub App is not installed for this repository.';
+      case 'not_found':
+        return 'The requested GitHub resource could not be found.';
+      default:
+        return message;
+    }
+  }
+
+  @override
+  String toString() {
+    return 'GitHubCollaborationException($statusCode, $errorCode): $message';
+  }
+}
+
+List<T> _mapList<T>(
+  Object? value,
+  T Function(Map<String, dynamic> item) builder,
+) {
+  if (value is! List) {
+    return List<T>.empty(growable: false);
+  }
+  return value
+      .whereType<Map<String, dynamic>>()
+      .map(builder)
+      .toList(growable: false);
+}
+
+String _readOwner(Object? rawOwner) {
+  if (rawOwner is String) {
+    return rawOwner.trim();
+  }
+  if (rawOwner is Map<String, dynamic>) {
+    return (rawOwner['login'] as String?)?.trim() ?? '';
+  }
+  return '';
+}
+
+int _readInt(Object? value, {int fallback = 0}) {
+  if (value is int) {
+    return value;
+  }
+  if (value is num) {
+    return value.toInt();
+  }
+  if (value is String) {
+    return int.tryParse(value) ?? fallback;
+  }
+  return fallback;
+}
+
+int? _readNullableInt(Object? value) {
+  if (value == null) {
+    return null;
+  }
+  return _readInt(value);
+}
+
+DateTime? _readDateTime(Object? value) {
+  if (value is! String || value.trim().isEmpty) {
+    return null;
+  }
+  return DateTime.tryParse(value)?.toUtc();
+}

--- a/app/lib/providers/editor_provider.dart
+++ b/app/lib/providers/editor_provider.dart
@@ -29,6 +29,7 @@ class EditorProvider extends ChangeNotifier {
   int _currentFileIndex = -1;
   EditorCursor? _cursor;
   EditorSelection? _selection;
+  int _revealNonce = 0;
   bool _isLoading = false;
   String? _error;
 
@@ -48,6 +49,7 @@ class EditorProvider extends ChangeNotifier {
   int get currentFileIndex => _currentFileIndex;
   EditorCursor? get cursor => _cursor;
   EditorSelection? get selection => _selection;
+  int get revealNonce => _revealNonce;
   bool get isLoading => _isLoading;
   String? get error => _error;
   EditorChatContext get chatContext => EditorChatContext(
@@ -57,11 +59,11 @@ class EditorProvider extends ChangeNotifier {
   );
 
   /// Open a file by path. If already open, switch to it.
-  Future<void> openFile(String path) async {
+  Future<void> openFile(String path, {EditorCursor? cursor}) async {
     final existingIndex = _openFiles.indexWhere((f) => f.path == path);
     if (existingIndex >= 0) {
       _currentFileIndex = existingIndex;
-      _resetContextForCurrentFile();
+      _resetContextForCurrentFile(cursor: cursor);
       notifyListeners();
       return;
     }
@@ -76,7 +78,7 @@ class EditorProvider extends ChangeNotifier {
       final file = OpenFile(path: path, name: name, originalContent: content);
       _openFiles.add(file);
       _currentFileIndex = _openFiles.length - 1;
-      _resetContextForCurrentFile();
+      _resetContextForCurrentFile(cursor: cursor);
       loadDiagnostics();
     } catch (e) {
       _error = e.toString();
@@ -220,13 +222,18 @@ class EditorProvider extends ChangeNotifier {
     return '/';
   }
 
-  void _resetContextForCurrentFile() {
+  void _resetContextForCurrentFile({EditorCursor? cursor}) {
     if (currentFile == null) {
       _cursor = null;
       _selection = null;
       return;
     }
-    _cursor = const EditorCursor(line: 1, column: 1);
+    if (cursor != null) {
+      _cursor = cursor;
+      _revealNonce++;
+    } else {
+      _cursor = const EditorCursor(line: 1, column: 1);
+    }
     _selection = null;
   }
 }

--- a/app/lib/providers/github_collaboration_provider.dart
+++ b/app/lib/providers/github_collaboration_provider.dart
@@ -1,0 +1,485 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/github_collaboration_models.dart';
+import '../services/github_collaboration_api_client.dart';
+
+class GitHubCollaborationFileAction {
+  final bool shouldOpenLocalFile;
+  final String localPath;
+  final int? line;
+  final String patchPath;
+  final String patch;
+
+  const GitHubCollaborationFileAction._({
+    required this.shouldOpenLocalFile,
+    required this.localPath,
+    required this.line,
+    required this.patchPath,
+    required this.patch,
+  });
+
+  const GitHubCollaborationFileAction.openLocalFile({
+    required String localPath,
+    required int? line,
+  }) : this._(
+         shouldOpenLocalFile: true,
+         localPath: localPath,
+         line: line,
+         patchPath: '',
+         patch: '',
+       );
+
+  const GitHubCollaborationFileAction.showPatch({
+    required String patchPath,
+    required String patch,
+  }) : this._(
+         shouldOpenLocalFile: false,
+         localPath: '',
+         line: null,
+         patchPath: patchPath,
+         patch: patch,
+       );
+}
+
+class GitHubCollaborationProvider extends ChangeNotifier {
+  final GitHubCollaborationApiClient _apiClient;
+
+  GitHubCollaborationProvider({required GitHubCollaborationApiClient apiClient})
+    : _apiClient = apiClient;
+
+  String _workspacePath = '';
+  bool _initialized = false;
+  bool _isLoadingRepo = false;
+  bool _isLoadingIssues = false;
+  bool _isLoadingPulls = false;
+  String? _repoLoadError;
+  String? _issuesLoadError;
+  String? _pullsLoadError;
+  GitHubCurrentRepoContext? _repoContext;
+  GitHubAccountContext? _accountContext;
+  List<GitHubIssue> _issues = const <GitHubIssue>[];
+  List<GitHubPullRequest> _pulls = const <GitHubPullRequest>[];
+  GitHubCollaborationFilter _issueFilter = const GitHubCollaborationFilter(
+    state: 'open',
+  );
+  GitHubCollaborationFilter _pullFilter = const GitHubCollaborationFilter(
+    state: 'open',
+  );
+
+  final Map<int, GitHubIssueDetail> _issueDetails = <int, GitHubIssueDetail>{};
+  final Map<int, String> _issueDetailErrors = <int, String>{};
+  final Set<int> _loadingIssueDetails = <int>{};
+  final Set<int> _submittingIssueComments = <int>{};
+  final Map<int, String> _issueSubmitErrors = <int, String>{};
+
+  final Map<int, GitHubPullRequestDetail> _pullDetails =
+      <int, GitHubPullRequestDetail>{};
+  final Map<int, String> _pullDetailErrors = <int, String>{};
+  final Set<int> _loadingPullDetails = <int>{};
+  final Set<int> _submittingPullReviews = <int>{};
+  final Set<int> _submittingPullComments = <int>{};
+  final Map<int, String> _pullSubmitErrors = <int, String>{};
+
+  String get workspacePath => _workspacePath;
+  bool get isLoadingRepo => _isLoadingRepo;
+  bool get isLoadingIssues => _isLoadingIssues;
+  bool get isLoadingPulls => _isLoadingPulls;
+  String? get repoLoadError => _repoLoadError;
+  String? get issuesLoadError => _issuesLoadError;
+  String? get pullsLoadError => _pullsLoadError;
+  GitHubCurrentRepoContext? get repoContext => _repoContext;
+  GitHubAccountContext? get accountContext => _accountContext;
+  List<GitHubIssue> get issues => List<GitHubIssue>.unmodifiable(_issues);
+  List<GitHubPullRequest> get pulls =>
+      List<GitHubPullRequest>.unmodifiable(_pulls);
+  GitHubCollaborationFilter get issueFilter => _issueFilter;
+  GitHubCollaborationFilter get pullFilter => _pullFilter;
+
+  bool get hasRepository => _repoContext?.repository != null;
+  bool get needsAuthAction => _repoContext?.needsAuthAction == true;
+  bool get canLoadCollaboration => _repoContext?.isOk == true;
+  bool get isRepoUnavailable => _repoContext?.isRepoUnavailable == true;
+  String get repoStatusMessage =>
+      _repoContext?.message ?? _repoLoadError ?? 'Repository unavailable.';
+
+  Future<void> initialize() async {
+    if (_initialized) {
+      return;
+    }
+    _initialized = true;
+    await refresh();
+  }
+
+  Future<void> setWorkspacePath(String path) async {
+    final trimmed = path.trim();
+    if (trimmed == _workspacePath) {
+      return;
+    }
+    _workspacePath = trimmed;
+    _resetTransientState();
+    notifyListeners();
+    if (_initialized) {
+      await refresh();
+    }
+  }
+
+  Future<void> refresh() async {
+    await loadCurrentRepo();
+    if (!canLoadCollaboration) {
+      _issues = const <GitHubIssue>[];
+      _pulls = const <GitHubPullRequest>[];
+      _issuesLoadError = null;
+      _pullsLoadError = null;
+      notifyListeners();
+      return;
+    }
+    await Future.wait<void>(<Future<void>>[loadIssues(), loadPullRequests()]);
+  }
+
+  Future<void> loadCurrentRepo() async {
+    _isLoadingRepo = true;
+    _repoLoadError = null;
+    notifyListeners();
+
+    try {
+      _repoContext = await _apiClient.fetchCurrentRepo(
+        workspacePath: _workspacePath,
+      );
+      if (_repoContext!.isOk) {
+        try {
+          _accountContext = await _apiClient.fetchAccount(
+            workspacePath: _workspacePath,
+          );
+        } on GitHubCollaborationException {
+          _accountContext = null;
+        }
+      } else {
+        _accountContext = null;
+      }
+    } on GitHubCollaborationException catch (error) {
+      _repoContext = null;
+      _accountContext = null;
+      _repoLoadError = error.toDisplayMessage();
+    } finally {
+      _isLoadingRepo = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadIssues({bool silent = false}) async {
+    if (!canLoadCollaboration) {
+      return;
+    }
+    if (!silent) {
+      _isLoadingIssues = true;
+      _issuesLoadError = null;
+      notifyListeners();
+    }
+
+    try {
+      _issues = await _apiClient.fetchIssues(
+        filter: _issueFilter,
+        workspacePath: _workspacePath,
+      );
+      _issuesLoadError = null;
+    } on GitHubCollaborationException catch (error) {
+      _issuesLoadError = error.toDisplayMessage();
+      _issues = const <GitHubIssue>[];
+    } finally {
+      _isLoadingIssues = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadPullRequests({bool silent = false}) async {
+    if (!canLoadCollaboration) {
+      return;
+    }
+    if (!silent) {
+      _isLoadingPulls = true;
+      _pullsLoadError = null;
+      notifyListeners();
+    }
+
+    try {
+      _pulls = await _apiClient.fetchPullRequests(
+        filter: _pullFilter,
+        workspacePath: _workspacePath,
+      );
+      _pullsLoadError = null;
+    } on GitHubCollaborationException catch (error) {
+      _pullsLoadError = error.toDisplayMessage();
+      _pulls = const <GitHubPullRequest>[];
+    } finally {
+      _isLoadingPulls = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> updateIssueFilter(GitHubCollaborationFilter filter) async {
+    _issueFilter = filter;
+    await loadIssues();
+  }
+
+  Future<void> updatePullFilter(GitHubCollaborationFilter filter) async {
+    _pullFilter = filter;
+    await loadPullRequests();
+  }
+
+  GitHubIssueDetail? issueDetailFor(int number) => _issueDetails[number];
+
+  String? issueDetailErrorFor(int number) => _issueDetailErrors[number];
+
+  bool isLoadingIssueDetail(int number) =>
+      _loadingIssueDetails.contains(number);
+
+  bool isSubmittingIssueComment(int number) =>
+      _submittingIssueComments.contains(number);
+
+  String? issueSubmitErrorFor(int number) => _issueSubmitErrors[number];
+
+  Future<void> loadIssueDetail(int number, {bool forceRefresh = false}) async {
+    if (!forceRefresh && _issueDetails.containsKey(number)) {
+      return;
+    }
+
+    _loadingIssueDetails.add(number);
+    _issueDetailErrors.remove(number);
+    notifyListeners();
+
+    try {
+      _issueDetails[number] = await _apiClient.fetchIssueDetail(
+        number,
+        workspacePath: _workspacePath,
+      );
+    } on GitHubCollaborationException catch (error) {
+      _issueDetailErrors[number] = error.toDisplayMessage();
+    } finally {
+      _loadingIssueDetails.remove(number);
+      notifyListeners();
+    }
+  }
+
+  Future<bool> submitIssueComment(int number, String body) async {
+    if (body.trim().isEmpty) {
+      _issueSubmitErrors[number] = 'Comment body cannot be empty.';
+      notifyListeners();
+      return false;
+    }
+
+    _submittingIssueComments.add(number);
+    _issueSubmitErrors.remove(number);
+    notifyListeners();
+
+    try {
+      await _apiClient.submitIssueComment(
+        number,
+        GitHubIssueCommentInput(body: body.trim()),
+        workspacePath: _workspacePath,
+      );
+      await loadIssueDetail(number, forceRefresh: true);
+      return true;
+    } on GitHubCollaborationException catch (error) {
+      _issueSubmitErrors[number] = error.toDisplayMessage();
+      notifyListeners();
+      return false;
+    } finally {
+      _submittingIssueComments.remove(number);
+      notifyListeners();
+    }
+  }
+
+  GitHubPullRequestDetail? pullRequestDetailFor(int number) =>
+      _pullDetails[number];
+
+  String? pullRequestDetailErrorFor(int number) => _pullDetailErrors[number];
+
+  bool isLoadingPullRequestDetail(int number) =>
+      _loadingPullDetails.contains(number);
+
+  bool isSubmittingPullRequestReview(int number) =>
+      _submittingPullReviews.contains(number);
+
+  bool isSubmittingPullRequestComment(int number) =>
+      _submittingPullComments.contains(number);
+
+  String? pullSubmitErrorFor(int number) => _pullSubmitErrors[number];
+
+  Future<void> loadPullRequestDetail(
+    int number, {
+    bool forceRefresh = false,
+  }) async {
+    if (!forceRefresh && _pullDetails.containsKey(number)) {
+      return;
+    }
+
+    _loadingPullDetails.add(number);
+    _pullDetailErrors.remove(number);
+    notifyListeners();
+
+    try {
+      _pullDetails[number] = await _apiClient.fetchPullRequestDetail(
+        number,
+        workspacePath: _workspacePath,
+      );
+    } on GitHubCollaborationException catch (error) {
+      _pullDetailErrors[number] = error.toDisplayMessage();
+    } finally {
+      _loadingPullDetails.remove(number);
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadPullRequestConversation(
+    int number, {
+    bool notify = true,
+  }) async {
+    if (notify) {
+      _loadingPullDetails.add(number);
+      _pullDetailErrors.remove(number);
+      notifyListeners();
+    }
+
+    try {
+      final conversation = await _apiClient.fetchPullRequestConversation(
+        number,
+        workspacePath: _workspacePath,
+      );
+      final current = _pullDetails[number];
+      if (current != null) {
+        _pullDetails[number] = GitHubPullRequestDetail(
+          pullRequest: current.pullRequest,
+          files: current.files,
+          comments: conversation.comments,
+          reviews: conversation.reviews,
+        );
+      }
+    } on GitHubCollaborationException catch (error) {
+      _pullDetailErrors[number] = error.toDisplayMessage();
+    } finally {
+      if (notify) {
+        _loadingPullDetails.remove(number);
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<bool> submitPullRequestReview(
+    int number,
+    GitHubPullRequestReviewInput input,
+  ) async {
+    if (input.event.trim().isEmpty) {
+      _pullSubmitErrors[number] = 'Review action is required.';
+      notifyListeners();
+      return false;
+    }
+
+    _submittingPullReviews.add(number);
+    _pullSubmitErrors.remove(number);
+    notifyListeners();
+
+    try {
+      await _apiClient.submitPullRequestReview(
+        number,
+        input,
+        workspacePath: _workspacePath,
+      );
+      await loadPullRequestDetail(number, forceRefresh: true);
+      return true;
+    } on GitHubCollaborationException catch (error) {
+      _pullSubmitErrors[number] = error.toDisplayMessage();
+      notifyListeners();
+      return false;
+    } finally {
+      _submittingPullReviews.remove(number);
+      notifyListeners();
+    }
+  }
+
+  Future<bool> submitPullRequestComment(
+    int number,
+    GitHubPullRequestCommentInput input,
+  ) async {
+    if (input.body.trim().isEmpty) {
+      _pullSubmitErrors[number] = 'Comment body cannot be empty.';
+      notifyListeners();
+      return false;
+    }
+
+    _submittingPullComments.add(number);
+    _pullSubmitErrors.remove(number);
+    notifyListeners();
+
+    try {
+      await _apiClient.submitPullRequestComment(
+        number,
+        input,
+        workspacePath: _workspacePath,
+      );
+      await loadPullRequestDetail(number, forceRefresh: true);
+      return true;
+    } on GitHubCollaborationException catch (error) {
+      _pullSubmitErrors[number] = error.toDisplayMessage();
+      notifyListeners();
+      return false;
+    } finally {
+      _submittingPullComments.remove(number);
+      notifyListeners();
+    }
+  }
+
+  Future<GitHubCollaborationFileAction> resolvePullRequestFileAction(
+    GitHubPullRequestFile file,
+  ) async {
+    try {
+      final result = await _apiClient.resolveLocalFile(
+        workspacePath: _workspacePath,
+        relativePath: file.filename,
+      );
+      if (result.exists) {
+        return GitHubCollaborationFileAction.openLocalFile(
+          localPath: result.localPath,
+          line: firstChangedLineForPatch(file.patch),
+        );
+      }
+    } on GitHubCollaborationException {
+      // Fall through to the patch view when local resolution is unavailable.
+    }
+
+    return GitHubCollaborationFileAction.showPatch(
+      patchPath: file.filename,
+      patch: file.patch.isNotEmpty ? file.patch : 'No patch is available.',
+    );
+  }
+
+  int? firstChangedLineForPatch(String patch) {
+    final match = RegExp(
+      r'@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@',
+    ).firstMatch(patch);
+    if (match == null) {
+      return null;
+    }
+    return int.tryParse(match.group(1)!);
+  }
+
+  void _resetTransientState() {
+    _repoContext = null;
+    _accountContext = null;
+    _repoLoadError = null;
+    _issuesLoadError = null;
+    _pullsLoadError = null;
+    _issues = const <GitHubIssue>[];
+    _pulls = const <GitHubPullRequest>[];
+    _issueDetails.clear();
+    _issueDetailErrors.clear();
+    _loadingIssueDetails.clear();
+    _submittingIssueComments.clear();
+    _issueSubmitErrors.clear();
+    _pullDetails.clear();
+    _pullDetailErrors.clear();
+    _loadingPullDetails.clear();
+    _submittingPullReviews.clear();
+    _submittingPullComments.clear();
+    _pullSubmitErrors.clear();
+  }
+}

--- a/app/lib/screens/code_screen.dart
+++ b/app/lib/screens/code_screen.dart
@@ -157,6 +157,8 @@ class _CodeScreenState extends State<CodeScreen> {
                   ? CodeEditor(
                       content: file.currentContent,
                       fileName: file.name,
+                      revealCursor: editorProvider.cursor,
+                      revealToken: editorProvider.revealNonce,
                       onContentChanged: (content) {
                         editorProvider.updateContent(content);
                       },
@@ -174,6 +176,8 @@ class _CodeScreenState extends State<CodeScreen> {
                   : CodeViewer(
                       content: file.currentContent,
                       fileName: file.name,
+                      revealCursor: editorProvider.cursor,
+                      revealToken: editorProvider.revealNonce,
                       diagnostics: editorProvider.diagnostics,
                       onSelectionChanged: (selection) {
                         editorProvider.updateSelection(

--- a/app/lib/screens/diff_screen.dart
+++ b/app/lib/screens/diff_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../models/git_models.dart';
 import '../providers/git_provider.dart';
+import '../widgets/unified_diff_view.dart';
 
 class DiffScreen extends StatefulWidget {
   final String filePath;
@@ -102,132 +103,14 @@ class _DiffScreenState extends State<DiffScreen> {
           }
 
           final diff = snapshot.data!;
-          final lines = diff.diff.split('\n');
-
-          if (diff.isEmpty) {
-            return Center(
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      widget.isConflict
-                          ? Icons.warning_amber_rounded
-                          : Icons.check_circle_outline,
-                      size: 64,
-                      color: widget.isConflict
-                          ? colorScheme.error
-                          : colorScheme.outline,
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      widget.isConflict
-                          ? 'Open this file in the editor to resolve the conflict.'
-                          : 'No diff available for this file',
-                      textAlign: TextAlign.center,
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                        color: Theme.of(context).colorScheme.outline,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            );
-          }
-
-          return Column(
-            children: [
-              if (widget.isConflict)
-                Container(
-                  width: double.infinity,
-                  color: colorScheme.errorContainer,
-                  padding: const EdgeInsets.all(12),
-                  child: Row(
-                    children: [
-                      Icon(
-                        Icons.warning_amber_rounded,
-                        color: colorScheme.onErrorContainer,
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          'Conflict file: review both sides before staging a resolution.',
-                          style: TextStyle(
-                            color: colorScheme.onErrorContainer,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              Expanded(
-                child: Scrollbar(
-                  child: SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: SingleChildScrollView(
-                      child: Padding(
-                        padding: const EdgeInsets.all(8),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: List.generate(lines.length, (index) {
-                            final line = lines[index];
-                            return _DiffLine(
-                              text: line,
-                              colorScheme: colorScheme,
-                            );
-                          }),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ],
+          return UnifiedDiffView(
+            diff: diff.diff,
+            isConflict: widget.isConflict,
+            emptyLabel: widget.isConflict
+                ? 'Open this file in the editor to resolve the conflict.'
+                : 'No diff available for this file',
           );
         },
-      ),
-    );
-  }
-}
-
-class _DiffLine extends StatelessWidget {
-  final String text;
-  final ColorScheme colorScheme;
-
-  const _DiffLine({required this.text, required this.colorScheme});
-
-  @override
-  Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    Color? backgroundColor;
-    Color textColor = colorScheme.onSurface;
-
-    if (text.startsWith('+')) {
-      backgroundColor = Colors.green.withAlpha(isDark ? 40 : 25);
-      textColor = isDark ? Colors.green.shade300 : Colors.green.shade800;
-    } else if (text.startsWith('-')) {
-      backgroundColor = Colors.red.withAlpha(isDark ? 40 : 25);
-      textColor = isDark ? Colors.red.shade300 : Colors.red.shade800;
-    } else if (text.startsWith('@@')) {
-      backgroundColor = Colors.blue.withAlpha(isDark ? 40 : 25);
-      textColor = isDark ? Colors.blue.shade300 : Colors.blue.shade800;
-    }
-
-    return Container(
-      color: backgroundColor,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            text,
-            style: TextStyle(
-              fontFamily: 'monospace',
-              fontSize: 13,
-              color: textColor,
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/app/lib/screens/github_collaboration_screen.dart
+++ b/app/lib/screens/github_collaboration_screen.dart
@@ -1,0 +1,569 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/github_collaboration_provider.dart';
+import 'github_auth_screen.dart';
+import 'github_issue_detail_screen.dart';
+import 'github_pull_request_detail_screen.dart';
+
+class GitHubCollaborationScreen extends StatefulWidget {
+  const GitHubCollaborationScreen({super.key});
+
+  @override
+  State<GitHubCollaborationScreen> createState() =>
+      _GitHubCollaborationScreenState();
+}
+
+class _GitHubCollaborationScreenState extends State<GitHubCollaborationScreen> {
+  bool _initialized = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initialized) {
+      return;
+    }
+    _initialized = true;
+    Future<void>.microtask(
+      context.read<GitHubCollaborationProvider>().initialize,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<GitHubCollaborationProvider>();
+
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('GitHub Collaboration'),
+          actions: [
+            IconButton(
+              tooltip: 'GitHub auth',
+              onPressed: () => _openGitHubAuth(context),
+              icon: const Icon(Icons.manage_accounts_outlined),
+            ),
+            IconButton(
+              tooltip: 'Refresh',
+              onPressed: provider.isLoadingRepo
+                  ? null
+                  : () => provider.refresh(),
+              icon: const Icon(Icons.refresh),
+            ),
+          ],
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Issues', icon: Icon(Icons.bug_report_outlined)),
+              Tab(text: 'Pull Requests', icon: Icon(Icons.merge_type)),
+            ],
+          ),
+        ),
+        body: Column(
+          children: [
+            _RepoSummaryCard(provider: provider),
+            Expanded(
+              child: TabBarView(
+                children: [
+                  _IssueListTab(provider: provider),
+                  _PullRequestListTab(provider: provider),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _openGitHubAuth(BuildContext context) {
+    Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (_) => const GitHubAuthScreen()));
+  }
+}
+
+class _RepoSummaryCard extends StatelessWidget {
+  final GitHubCollaborationProvider provider;
+
+  const _RepoSummaryCard({required this.provider});
+
+  @override
+  Widget build(BuildContext context) {
+    final repo = provider.repoContext?.repository;
+    final auth = provider.repoContext?.auth;
+    final account = provider.accountContext?.account;
+    final status =
+        provider.repoContext?.status ??
+        (provider.isLoadingRepo ? 'loading' : 'unavailable');
+
+    return Card(
+      margin: const EdgeInsets.fromLTRB(12, 12, 12, 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    repo?.fullName.isNotEmpty == true
+                        ? repo!.fullName
+                        : 'Current workspace repository',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+                _StatusChip(status: status),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              repo?.remoteUrl.isNotEmpty == true
+                  ? repo!.remoteUrl
+                  : provider.workspacePath.isNotEmpty
+                  ? provider.workspacePath
+                  : 'No workspace selected',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              account != null
+                  ? 'Signed in as ${account.login}'
+                  : auth?.accountLogin != null && auth!.accountLogin!.isNotEmpty
+                  ? 'Signed in as ${auth.accountLogin}'
+                  : 'GitHub account unavailable',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            if (provider.repoLoadError != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                provider.repoLoadError!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ] else if ((provider.repoContext?.message ?? '').isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(provider.repoContext!.message!),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IssueListTab extends StatelessWidget {
+  final GitHubCollaborationProvider provider;
+
+  const _IssueListTab({required this.provider});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _IssueFilterBar(provider: provider),
+        Expanded(child: _IssueListBody(provider: provider)),
+      ],
+    );
+  }
+}
+
+class _IssueFilterBar extends StatelessWidget {
+  final GitHubCollaborationProvider provider;
+
+  const _IssueFilterBar({required this.provider});
+
+  @override
+  Widget build(BuildContext context) {
+    final filter = provider.issueFilter;
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          _StateChip(
+            label: 'All',
+            selected: filter.state.isEmpty,
+            onSelected: (_) =>
+                provider.updateIssueFilter(filter.copyWith(state: '')),
+          ),
+          _StateChip(
+            label: 'Open',
+            selected: filter.state == 'open',
+            onSelected: (_) =>
+                provider.updateIssueFilter(filter.copyWith(state: 'open')),
+          ),
+          _StateChip(
+            label: 'Closed',
+            selected: filter.state == 'closed',
+            onSelected: (_) =>
+                provider.updateIssueFilter(filter.copyWith(state: 'closed')),
+          ),
+          const SizedBox(width: 8),
+          FilterChip(
+            label: const Text('Assigned to me'),
+            selected: filter.assignedToMe,
+            onSelected: (value) => provider.updateIssueFilter(
+              filter.copyWith(assignedToMe: value),
+            ),
+          ),
+          const SizedBox(width: 8),
+          FilterChip(
+            label: const Text('Created by me'),
+            selected: filter.createdByMe,
+            onSelected: (value) =>
+                provider.updateIssueFilter(filter.copyWith(createdByMe: value)),
+          ),
+          const SizedBox(width: 8),
+          FilterChip(
+            label: const Text('Mentioned'),
+            selected: filter.mentioned,
+            onSelected: (value) =>
+                provider.updateIssueFilter(filter.copyWith(mentioned: value)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _IssueListBody extends StatelessWidget {
+  final GitHubCollaborationProvider provider;
+
+  const _IssueListBody({required this.provider});
+
+  @override
+  Widget build(BuildContext context) {
+    if (provider.needsAuthAction) {
+      return _AuthRequiredView(
+        label: provider.repoStatusMessage,
+        onOpenAuth: () => Navigator.of(
+          context,
+        ).push(MaterialPageRoute(builder: (_) => const GitHubAuthScreen())),
+      );
+    }
+    if (provider.isRepoUnavailable && !provider.canLoadCollaboration) {
+      return _EmptyState(
+        icon: Icons.link_off,
+        title: 'GitHub collaboration unavailable',
+        message: provider.repoStatusMessage,
+      );
+    }
+    if (provider.isLoadingIssues && provider.issues.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (provider.issuesLoadError != null) {
+      return _EmptyState(
+        icon: Icons.error_outline,
+        title: 'Failed to load issues',
+        message: provider.issuesLoadError!,
+      );
+    }
+    if (provider.issues.isEmpty) {
+      return const _EmptyState(
+        icon: Icons.bug_report_outlined,
+        title: 'No issues match these filters',
+        message: 'Pull to refresh or change the filters.',
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: () => provider.loadIssues(),
+      child: ListView.separated(
+        itemCount: provider.issues.length,
+        separatorBuilder: (_, _) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final issue = provider.issues[index];
+          return ListTile(
+            leading: Icon(
+              issue.state == 'open'
+                  ? Icons.radio_button_checked
+                  : Icons.check_circle_outline,
+            ),
+            title: Text('#${issue.number} ${issue.title}'),
+            subtitle: Text(
+              issue.author?.login.isNotEmpty == true
+                  ? 'by ${issue.author!.login} · ${issue.commentsCount} comments'
+                  : '${issue.commentsCount} comments',
+            ),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) =>
+                      GitHubIssueDetailScreen(issueNumber: issue.number),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _PullRequestListTab extends StatelessWidget {
+  final GitHubCollaborationProvider provider;
+
+  const _PullRequestListTab({required this.provider});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _PullRequestFilterBar(provider: provider),
+        Expanded(child: _PullRequestListBody(provider: provider)),
+      ],
+    );
+  }
+}
+
+class _PullRequestFilterBar extends StatelessWidget {
+  final GitHubCollaborationProvider provider;
+
+  const _PullRequestFilterBar({required this.provider});
+
+  @override
+  Widget build(BuildContext context) {
+    final filter = provider.pullFilter;
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          _StateChip(
+            label: 'All',
+            selected: filter.state.isEmpty,
+            onSelected: (_) =>
+                provider.updatePullFilter(filter.copyWith(state: '')),
+          ),
+          _StateChip(
+            label: 'Open',
+            selected: filter.state == 'open',
+            onSelected: (_) =>
+                provider.updatePullFilter(filter.copyWith(state: 'open')),
+          ),
+          _StateChip(
+            label: 'Closed',
+            selected: filter.state == 'closed',
+            onSelected: (_) =>
+                provider.updatePullFilter(filter.copyWith(state: 'closed')),
+          ),
+          const SizedBox(width: 8),
+          FilterChip(
+            label: const Text('Assigned to me'),
+            selected: filter.assignedToMe,
+            onSelected: (value) =>
+                provider.updatePullFilter(filter.copyWith(assignedToMe: value)),
+          ),
+          const SizedBox(width: 8),
+          FilterChip(
+            label: const Text('Created by me'),
+            selected: filter.createdByMe,
+            onSelected: (value) =>
+                provider.updatePullFilter(filter.copyWith(createdByMe: value)),
+          ),
+          const SizedBox(width: 8),
+          FilterChip(
+            label: const Text('Mentioned'),
+            selected: filter.mentioned,
+            onSelected: (value) =>
+                provider.updatePullFilter(filter.copyWith(mentioned: value)),
+          ),
+          const SizedBox(width: 8),
+          FilterChip(
+            label: const Text('Needs review'),
+            selected: filter.needsReview,
+            onSelected: (value) =>
+                provider.updatePullFilter(filter.copyWith(needsReview: value)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PullRequestListBody extends StatelessWidget {
+  final GitHubCollaborationProvider provider;
+
+  const _PullRequestListBody({required this.provider});
+
+  @override
+  Widget build(BuildContext context) {
+    if (provider.needsAuthAction) {
+      return _AuthRequiredView(
+        label: provider.repoStatusMessage,
+        onOpenAuth: () => Navigator.of(
+          context,
+        ).push(MaterialPageRoute(builder: (_) => const GitHubAuthScreen())),
+      );
+    }
+    if (provider.isRepoUnavailable && !provider.canLoadCollaboration) {
+      return _EmptyState(
+        icon: Icons.link_off,
+        title: 'GitHub collaboration unavailable',
+        message: provider.repoStatusMessage,
+      );
+    }
+    if (provider.isLoadingPulls && provider.pulls.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (provider.pullsLoadError != null) {
+      return _EmptyState(
+        icon: Icons.error_outline,
+        title: 'Failed to load pull requests',
+        message: provider.pullsLoadError!,
+      );
+    }
+    if (provider.pulls.isEmpty) {
+      return const _EmptyState(
+        icon: Icons.merge_type,
+        title: 'No pull requests match these filters',
+        message: 'Pull to refresh or change the filters.',
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: () => provider.loadPullRequests(),
+      child: ListView.separated(
+        itemCount: provider.pulls.length,
+        separatorBuilder: (_, _) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final pull = provider.pulls[index];
+          return ListTile(
+            leading: Icon(
+              pull.merged
+                  ? Icons.done_all
+                  : pull.state == 'open'
+                  ? Icons.merge_type
+                  : Icons.inventory_2_outlined,
+            ),
+            title: Text('#${pull.number} ${pull.title}'),
+            subtitle: Text(
+              '${pull.headRef.ref} -> ${pull.baseRef.ref} · ${pull.changedFiles} files',
+            ),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => GitHubPullRequestDetailScreen(
+                    pullRequestNumber: pull.number,
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _AuthRequiredView extends StatelessWidget {
+  final String label;
+  final VoidCallback onOpenAuth;
+
+  const _AuthRequiredView({required this.label, required this.onOpenAuth});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.lock_outline,
+              size: 48,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'GitHub authentication required',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(label, textAlign: TextAlign.center),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: onOpenAuth,
+              icon: const Icon(Icons.manage_accounts_outlined),
+              label: const Text('Open GitHub auth'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String message;
+
+  const _EmptyState({
+    required this.icon,
+    required this.title,
+    required this.message,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 48, color: Theme.of(context).colorScheme.outline),
+            const SizedBox(height: 16),
+            Text(title, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(message, textAlign: TextAlign.center),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  final String status;
+
+  const _StatusChip({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      label: Text(status.replaceAll('_', ' ')),
+      visualDensity: VisualDensity.compact,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    );
+  }
+}
+
+class _StateChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final ValueChanged<bool> onSelected;
+
+  const _StateChip({
+    required this.label,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 8),
+      child: ChoiceChip(
+        label: Text(label),
+        selected: selected,
+        onSelected: onSelected,
+      ),
+    );
+  }
+}

--- a/app/lib/screens/github_issue_detail_screen.dart
+++ b/app/lib/screens/github_issue_detail_screen.dart
@@ -1,0 +1,322 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../models/github_collaboration_models.dart';
+import '../providers/github_collaboration_provider.dart';
+
+class GitHubIssueDetailScreen extends StatefulWidget {
+  final int issueNumber;
+
+  const GitHubIssueDetailScreen({super.key, required this.issueNumber});
+
+  @override
+  State<GitHubIssueDetailScreen> createState() =>
+      _GitHubIssueDetailScreenState();
+}
+
+class _GitHubIssueDetailScreenState extends State<GitHubIssueDetailScreen> {
+  final TextEditingController _commentController = TextEditingController();
+  bool _initialized = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initialized) {
+      return;
+    }
+    _initialized = true;
+    final provider = context.read<GitHubCollaborationProvider>();
+    Future<void>.microtask(
+      () => provider.loadIssueDetail(widget.issueNumber, forceRefresh: true),
+    );
+  }
+
+  @override
+  void dispose() {
+    _commentController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<GitHubCollaborationProvider>();
+    final detail = provider.issueDetailFor(widget.issueNumber);
+    final isLoading = provider.isLoadingIssueDetail(widget.issueNumber);
+    final error = provider.issueDetailErrorFor(widget.issueNumber);
+    final submitError = provider.issueSubmitErrorFor(widget.issueNumber);
+    final isSubmitting = provider.isSubmittingIssueComment(widget.issueNumber);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Issue #${widget.issueNumber}'),
+        actions: [
+          IconButton(
+            tooltip: 'Refresh issue',
+            onPressed: isLoading
+                ? null
+                : () => provider.loadIssueDetail(
+                    widget.issueNumber,
+                    forceRefresh: true,
+                  ),
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: Builder(
+        builder: (context) {
+          if (isLoading && detail == null) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (error != null && detail == null) {
+            return _IssueErrorView(message: error);
+          }
+          if (detail == null) {
+            return const _IssueErrorView(
+              message: 'Issue details are unavailable right now.',
+            );
+          }
+
+          return Column(
+            children: [
+              if (submitError != null)
+                Card(
+                  color: Theme.of(context).colorScheme.errorContainer,
+                  margin: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Text(submitError),
+                  ),
+                ),
+              Expanded(
+                child: ListView(
+                  padding: const EdgeInsets.all(16),
+                  children: [
+                    _IssueHeader(issue: detail.issue),
+                    const SizedBox(height: 16),
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: MarkdownBody(
+                          data: detail.issue.body.isNotEmpty
+                              ? detail.issue.body
+                              : '_No description provided._',
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'Comments',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    if (detail.comments.isEmpty)
+                      const Card(
+                        child: Padding(
+                          padding: EdgeInsets.all(16),
+                          child: Text('No comments yet.'),
+                        ),
+                      )
+                    else
+                      ...detail.comments.map(
+                        (comment) => _IssueCommentCard(comment: comment),
+                      ),
+                  ],
+                ),
+              ),
+              _IssueCommentComposer(
+                controller: _commentController,
+                isSubmitting: isSubmitting,
+                onSubmit: () async {
+                  final success = await provider.submitIssueComment(
+                    widget.issueNumber,
+                    _commentController.text,
+                  );
+                  if (!mounted) {
+                    return;
+                  }
+                  final messenger = ScaffoldMessenger.of(this.context);
+                  if (success) {
+                    _commentController.clear();
+                    messenger.showSnackBar(
+                      const SnackBar(content: Text('Issue comment posted')),
+                    );
+                  } else {
+                    messenger.showSnackBar(
+                      SnackBar(
+                        content: Text(
+                          provider.issueSubmitErrorFor(widget.issueNumber) ??
+                              'Failed to post issue comment.',
+                        ),
+                      ),
+                    );
+                  }
+                },
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _IssueHeader extends StatelessWidget {
+  final GitHubIssue issue;
+
+  const _IssueHeader({required this.issue});
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat.yMd().add_Hm();
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '#${issue.number} ${issue.title}',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                Chip(label: Text(issue.state)),
+                if (issue.author != null)
+                  Chip(label: Text('Author: ${issue.author!.login}')),
+                Chip(label: Text('${issue.commentsCount} comments')),
+                if (issue.updatedAt != null)
+                  Chip(
+                    label: Text(
+                      'Updated ${dateFormat.format(issue.updatedAt!.toLocal())}',
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IssueCommentCard extends StatelessWidget {
+  final GitHubIssueComment comment;
+
+  const _IssueCommentCard({required this.comment});
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat.yMd().add_Hm();
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              comment.author?.login.isNotEmpty == true
+                  ? comment.author!.login
+                  : 'Unknown author',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            if (comment.createdAt != null)
+              Text(
+                dateFormat.format(comment.createdAt!.toLocal()),
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            const SizedBox(height: 8),
+            MarkdownBody(
+              data: comment.body.isNotEmpty ? comment.body : '_Empty comment._',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IssueCommentComposer extends StatelessWidget {
+  final TextEditingController controller;
+  final bool isSubmitting;
+  final Future<void> Function() onSubmit;
+
+  const _IssueCommentComposer({
+    required this.controller,
+    required this.isSubmitting,
+    required this.onSubmit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
+        child: Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: controller,
+                minLines: 1,
+                maxLines: 4,
+                decoration: const InputDecoration(
+                  labelText: 'Add a comment',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            FilledButton(
+              onPressed: isSubmitting ? null : () => onSubmit(),
+              child: isSubmitting
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Post'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IssueErrorView extends StatelessWidget {
+  final String message;
+
+  const _IssueErrorView({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 48,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Failed to load issue',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(message, textAlign: TextAlign.center),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/screens/github_patch_screen.dart
+++ b/app/lib/screens/github_patch_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/unified_diff_view.dart';
+
+class GitHubPatchScreen extends StatelessWidget {
+  final String path;
+  final String patch;
+
+  const GitHubPatchScreen({super.key, required this.path, required this.patch});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(path, overflow: TextOverflow.ellipsis)),
+      body: UnifiedDiffView(
+        diff: patch,
+        emptyLabel: 'No patch is available for this file.',
+      ),
+    );
+  }
+}

--- a/app/lib/screens/github_pull_request_detail_screen.dart
+++ b/app/lib/screens/github_pull_request_detail_screen.dart
@@ -1,0 +1,589 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../models/editor_context.dart';
+import '../models/github_collaboration_models.dart';
+import '../providers/editor_provider.dart';
+import '../providers/github_collaboration_provider.dart';
+import 'code_screen.dart';
+import 'github_patch_screen.dart';
+
+class GitHubPullRequestDetailScreen extends StatefulWidget {
+  final int pullRequestNumber;
+
+  const GitHubPullRequestDetailScreen({
+    super.key,
+    required this.pullRequestNumber,
+  });
+
+  @override
+  State<GitHubPullRequestDetailScreen> createState() =>
+      _GitHubPullRequestDetailScreenState();
+}
+
+class _GitHubPullRequestDetailScreenState
+    extends State<GitHubPullRequestDetailScreen> {
+  final TextEditingController _reviewController = TextEditingController();
+  bool _initialized = false;
+  String _selectedReviewEvent = 'COMMENT';
+  bool _isResolvingFile = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initialized) {
+      return;
+    }
+    _initialized = true;
+    final provider = context.read<GitHubCollaborationProvider>();
+    Future<void>.microtask(
+      () => provider.loadPullRequestDetail(
+        widget.pullRequestNumber,
+        forceRefresh: true,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _reviewController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<GitHubCollaborationProvider>();
+    final detail = provider.pullRequestDetailFor(widget.pullRequestNumber);
+    final isLoading = provider.isLoadingPullRequestDetail(
+      widget.pullRequestNumber,
+    );
+    final error = provider.pullRequestDetailErrorFor(widget.pullRequestNumber);
+    final isSubmittingReview = provider.isSubmittingPullRequestReview(
+      widget.pullRequestNumber,
+    );
+    final submitError = provider.pullSubmitErrorFor(widget.pullRequestNumber);
+
+    return DefaultTabController(
+      length: 4,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text('PR #${widget.pullRequestNumber}'),
+          bottom: const TabBar(
+            isScrollable: true,
+            tabs: [
+              Tab(text: 'Overview'),
+              Tab(text: 'Files'),
+              Tab(text: 'Conversation'),
+              Tab(text: 'Checks'),
+            ],
+          ),
+          actions: [
+            IconButton(
+              tooltip: 'Refresh pull request',
+              onPressed: isLoading
+                  ? null
+                  : () => provider.loadPullRequestDetail(
+                      widget.pullRequestNumber,
+                      forceRefresh: true,
+                    ),
+              icon: const Icon(Icons.refresh),
+            ),
+          ],
+        ),
+        body: Builder(
+          builder: (context) {
+            if (isLoading && detail == null) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (error != null && detail == null) {
+              return _PullRequestErrorView(message: error);
+            }
+            if (detail == null) {
+              return const _PullRequestErrorView(
+                message: 'Pull request details are unavailable right now.',
+              );
+            }
+
+            return Column(
+              children: [
+                if (submitError != null)
+                  Card(
+                    color: Theme.of(context).colorScheme.errorContainer,
+                    margin: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+                    child: Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Text(submitError),
+                    ),
+                  ),
+                Expanded(
+                  child: TabBarView(
+                    children: [
+                      _PullRequestOverviewTab(detail: detail),
+                      _PullRequestFilesTab(
+                        files: detail.files,
+                        isResolvingFile: _isResolvingFile,
+                        onOpenFile: (file) => _openFile(provider, file),
+                      ),
+                      _PullRequestConversationTab(
+                        detail: detail,
+                        selectedReviewEvent: _selectedReviewEvent,
+                        reviewController: _reviewController,
+                        isSubmitting: isSubmittingReview,
+                        onEventChanged: (value) {
+                          setState(() {
+                            _selectedReviewEvent = value;
+                          });
+                        },
+                        onSubmit: () => _submitReview(provider),
+                      ),
+                      _PullRequestChecksTab(detail: detail),
+                    ],
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openFile(
+    GitHubCollaborationProvider provider,
+    GitHubPullRequestFile file,
+  ) async {
+    setState(() {
+      _isResolvingFile = true;
+    });
+
+    try {
+      final action = await provider.resolvePullRequestFileAction(file);
+      if (!mounted) {
+        return;
+      }
+      if (action.shouldOpenLocalFile) {
+        final editorProvider = context.read<EditorProvider>();
+        await editorProvider.openFile(
+          action.localPath,
+          cursor: EditorCursor(line: action.line ?? 1, column: 1),
+        );
+        if (!mounted) {
+          return;
+        }
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => ChangeNotifierProvider.value(
+              value: editorProvider,
+              child: const CodeScreen(),
+            ),
+          ),
+        );
+      } else {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) =>
+                GitHubPatchScreen(path: action.patchPath, patch: action.patch),
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isResolvingFile = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _submitReview(GitHubCollaborationProvider provider) async {
+    final success = await provider.submitPullRequestReview(
+      widget.pullRequestNumber,
+      GitHubPullRequestReviewInput(
+        event: _selectedReviewEvent,
+        body: _reviewController.text.trim(),
+      ),
+    );
+    if (!mounted) {
+      return;
+    }
+    final messenger = ScaffoldMessenger.of(context);
+    if (success) {
+      _reviewController.clear();
+      messenger.showSnackBar(
+        SnackBar(content: Text('Review $_selectedReviewEvent submitted')),
+      );
+    } else {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            provider.pullSubmitErrorFor(widget.pullRequestNumber) ??
+                'Failed to submit the pull request review.',
+          ),
+        ),
+      );
+    }
+  }
+}
+
+class _PullRequestOverviewTab extends StatelessWidget {
+  final GitHubPullRequestDetail detail;
+
+  const _PullRequestOverviewTab({required this.detail});
+
+  @override
+  Widget build(BuildContext context) {
+    final pull = detail.pullRequest;
+    final dateFormat = DateFormat.yMd().add_Hm();
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '#${pull.number} ${pull.title}',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    Chip(label: Text(pull.state)),
+                    if (pull.draft) const Chip(label: Text('Draft')),
+                    if (pull.merged) const Chip(label: Text('Merged')),
+                    Chip(label: Text('${pull.changedFiles} files changed')),
+                    Chip(label: Text('${pull.additions} additions')),
+                    Chip(label: Text('${pull.deletions} deletions')),
+                    if (pull.updatedAt != null)
+                      Chip(
+                        label: Text(
+                          'Updated ${dateFormat.format(pull.updatedAt!.toLocal())}',
+                        ),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Text('Base: ${pull.baseRef.ref}'),
+                Text('Head: ${pull.headRef.ref}'),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: MarkdownBody(
+              data: pull.body.isNotEmpty
+                  ? pull.body
+                  : '_No pull request description provided._',
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PullRequestFilesTab extends StatelessWidget {
+  final List<GitHubPullRequestFile> files;
+  final bool isResolvingFile;
+  final ValueChanged<GitHubPullRequestFile> onOpenFile;
+
+  const _PullRequestFilesTab({
+    required this.files,
+    required this.isResolvingFile,
+    required this.onOpenFile,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (files.isEmpty) {
+      return const Center(child: Text('No changed files reported.'));
+    }
+
+    return Stack(
+      children: [
+        ListView.separated(
+          itemCount: files.length,
+          separatorBuilder: (_, _) => const Divider(height: 1),
+          itemBuilder: (context, index) {
+            final file = files[index];
+            return ListTile(
+              title: Text(file.filename),
+              subtitle: Text(
+                '${file.status} · +${file.additions} / -${file.deletions}',
+              ),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => onOpenFile(file),
+            );
+          },
+        ),
+        if (isResolvingFile)
+          const Positioned.fill(
+            child: IgnorePointer(
+              child: ColoredBox(
+                color: Color(0x33000000),
+                child: Center(child: CircularProgressIndicator()),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _PullRequestConversationTab extends StatelessWidget {
+  final GitHubPullRequestDetail detail;
+  final String selectedReviewEvent;
+  final TextEditingController reviewController;
+  final bool isSubmitting;
+  final ValueChanged<String> onEventChanged;
+  final Future<void> Function() onSubmit;
+
+  const _PullRequestConversationTab({
+    required this.detail,
+    required this.selectedReviewEvent,
+    required this.reviewController,
+    required this.isSubmitting,
+    required this.onEventChanged,
+    required this.onSubmit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat.yMd().add_Hm();
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Text('Reviews', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        if (detail.reviews.isEmpty)
+          const Card(
+            child: Padding(
+              padding: EdgeInsets.all(16),
+              child: Text('No reviews yet.'),
+            ),
+          )
+        else
+          ...detail.reviews.map(
+            (review) => Card(
+              margin: const EdgeInsets.only(bottom: 8),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      review.author?.login.isNotEmpty == true
+                          ? review.author!.login
+                          : 'Unknown reviewer',
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                    Text(review.state),
+                    if (review.submittedAt != null)
+                      Text(
+                        dateFormat.format(review.submittedAt!.toLocal()),
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    if (review.body.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      MarkdownBody(data: review.body),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        const SizedBox(height: 16),
+        Text('Comments', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        if (detail.comments.isEmpty)
+          const Card(
+            child: Padding(
+              padding: EdgeInsets.all(16),
+              child: Text('No review comments yet.'),
+            ),
+          )
+        else
+          ...detail.comments.map(
+            (comment) => Card(
+              margin: const EdgeInsets.only(bottom: 8),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      comment.author?.login.isNotEmpty == true
+                          ? comment.author!.login
+                          : 'Unknown author',
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                    if (comment.path.isNotEmpty)
+                      Text(
+                        comment.path,
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    if (comment.updatedAt != null)
+                      Text(
+                        dateFormat.format(comment.updatedAt!.toLocal()),
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    const SizedBox(height: 8),
+                    MarkdownBody(
+                      data: comment.body.isNotEmpty
+                          ? comment.body
+                          : '_Empty comment._',
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        const SizedBox(height: 16),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Submit review',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 12),
+                SegmentedButton<String>(
+                  segments: const [
+                    ButtonSegment(value: 'COMMENT', label: Text('Comment')),
+                    ButtonSegment(value: 'APPROVE', label: Text('Approve')),
+                    ButtonSegment(
+                      value: 'REQUEST_CHANGES',
+                      label: Text('Request changes'),
+                    ),
+                  ],
+                  selected: <String>{selectedReviewEvent},
+                  onSelectionChanged: (values) => onEventChanged(values.first),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: reviewController,
+                  minLines: 2,
+                  maxLines: 6,
+                  decoration: const InputDecoration(
+                    labelText: 'Review comment',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: FilledButton(
+                    onPressed: isSubmitting ? null : () => onSubmit(),
+                    child: isSubmitting
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Submit review'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PullRequestChecksTab extends StatelessWidget {
+  final GitHubPullRequestDetail detail;
+
+  const _PullRequestChecksTab({required this.detail});
+
+  @override
+  Widget build(BuildContext context) {
+    final checks = detail.pullRequest.checks;
+    if (checks == null) {
+      return const Center(child: Text('No checks were reported.'));
+    }
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                Chip(label: Text('State: ${checks.state}')),
+                Chip(label: Text('Total: ${checks.totalCount}')),
+                Chip(label: Text('Success: ${checks.successCount}')),
+                Chip(label: Text('Pending: ${checks.pendingCount}')),
+                Chip(label: Text('Failure: ${checks.failureCount}')),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        ...checks.checks.map(
+          (check) => ListTile(
+            leading: Icon(
+              check.conclusion == 'success'
+                  ? Icons.check_circle_outline
+                  : check.status == 'pending'
+                  ? Icons.schedule
+                  : Icons.error_outline,
+            ),
+            title: Text(check.name),
+            subtitle: Text(
+              check.conclusion.isNotEmpty ? check.conclusion : check.status,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PullRequestErrorView extends StatelessWidget {
+  final String message;
+
+  const _PullRequestErrorView({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 48,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Failed to load pull request',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(message, textAlign: TextAlign.center),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/screens/more_screen.dart
+++ b/app/lib/screens/more_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'git_screen.dart';
+import 'github_collaboration_screen.dart';
 import 'github_auth_screen.dart';
 import 'settings_screen.dart';
 
@@ -28,7 +29,21 @@ class MoreScreen extends StatelessWidget {
           ListTile(
             leading: const Icon(Icons.code),
             title: const Text('GitHub'),
-            subtitle: const Text('Connect GitHub and inspect auth status'),
+            subtitle: const Text('Browse issues, pull requests, and reviews'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const GitHubCollaborationScreen(),
+                ),
+              );
+            },
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.manage_accounts_outlined),
+            title: const Text('GitHub Connection'),
+            subtitle: const Text('Inspect auth status and reconnect if needed'),
             trailing: const Icon(Icons.chevron_right),
             onTap: () {
               Navigator.of(context).push(

--- a/app/lib/services/github_collaboration_api_client.dart
+++ b/app/lib/services/github_collaboration_api_client.dart
@@ -1,0 +1,285 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../models/github_collaboration_models.dart';
+import 'settings_service.dart';
+
+class GitHubCollaborationApiClient {
+  final SettingsService _settings;
+  final http.Client _client;
+
+  GitHubCollaborationApiClient({
+    required SettingsService settings,
+    http.Client? client,
+  }) : _settings = settings,
+       _client = client ?? http.Client();
+
+  String get baseUrl => _settings.serverUrl;
+  String get token => _settings.authToken;
+
+  Map<String, String> get _headers => <String, String>{
+    'Authorization': 'Bearer $token',
+    'Content-Type': 'application/json',
+  };
+
+  Uri _buildUri(String path, {Map<String, String>? queryParams}) {
+    final normalizedBase = baseUrl.endsWith('/')
+        ? baseUrl.substring(0, baseUrl.length - 1)
+        : baseUrl;
+    final uri = Uri.parse('$normalizedBase$path');
+    if (queryParams == null || queryParams.isEmpty) {
+      return uri;
+    }
+    return uri.replace(queryParameters: queryParams);
+  }
+
+  Future<GitHubCurrentRepoContext> fetchCurrentRepo({
+    String workspacePath = '',
+  }) async {
+    final response = await _client.get(
+      _buildUri(
+        '/api/github/repos/current',
+        queryParams: _workspaceQuery(workspacePath),
+      ),
+      headers: _headers,
+    );
+    return _parseResponse(response, GitHubCurrentRepoContext.fromJson);
+  }
+
+  Future<GitHubAccountContext> fetchAccount({String workspacePath = ''}) async {
+    final response = await _client.get(
+      _buildUri(
+        '/api/github/account',
+        queryParams: _workspaceQuery(workspacePath),
+      ),
+      headers: _headers,
+    );
+    return _parseResponse(response, GitHubAccountContext.fromJson);
+  }
+
+  Future<List<GitHubIssue>> fetchIssues({
+    required GitHubCollaborationFilter filter,
+    String workspacePath = '',
+  }) async {
+    final response = await _client.get(
+      _buildUri(
+        '/api/github/issues',
+        queryParams: {
+          ..._workspaceQuery(workspacePath),
+          ...filter.toQueryParameters(includeNeedsReview: false),
+        },
+      ),
+      headers: _headers,
+    );
+    final payload = _parseJsonEnvelope(response);
+    return _mapList(payload['issues'], (item) => GitHubIssue.fromJson(item));
+  }
+
+  Future<GitHubIssueDetail> fetchIssueDetail(
+    int number, {
+    String workspacePath = '',
+  }) async {
+    final response = await _client.get(
+      _buildUri(
+        '/api/github/issues/$number',
+        queryParams: _workspaceQuery(workspacePath),
+      ),
+      headers: _headers,
+    );
+    return _parseResponse(response, GitHubIssueDetail.fromJson);
+  }
+
+  Future<GitHubIssueComment> submitIssueComment(
+    int number,
+    GitHubIssueCommentInput input, {
+    String workspacePath = '',
+  }) async {
+    final response = await _client.post(
+      _buildUri('/api/github/issues/$number/comments'),
+      headers: _headers,
+      body: jsonEncode(<String, dynamic>{
+        'workspace_path': workspacePath,
+        'body': input.body,
+      }),
+    );
+    final payload = _parseJsonEnvelope(response);
+    return GitHubIssueComment.fromJson(
+      payload['comment'] as Map<String, dynamic>? ?? const <String, dynamic>{},
+    );
+  }
+
+  Future<List<GitHubPullRequest>> fetchPullRequests({
+    required GitHubCollaborationFilter filter,
+    String workspacePath = '',
+  }) async {
+    final response = await _client.get(
+      _buildUri(
+        '/api/github/pulls',
+        queryParams: {
+          ..._workspaceQuery(workspacePath),
+          ...filter.toQueryParameters(),
+        },
+      ),
+      headers: _headers,
+    );
+    final payload = _parseJsonEnvelope(response);
+    return _mapList(
+      payload['pulls'],
+      (item) => GitHubPullRequest.fromJson(item),
+    );
+  }
+
+  Future<GitHubPullRequestDetail> fetchPullRequestDetail(
+    int number, {
+    String workspacePath = '',
+  }) async {
+    final response = await _client.get(
+      _buildUri(
+        '/api/github/pulls/$number',
+        queryParams: _workspaceQuery(workspacePath),
+      ),
+      headers: _headers,
+    );
+    return _parseResponse(response, GitHubPullRequestDetail.fromJson);
+  }
+
+  Future<GitHubPullRequestConversation> fetchPullRequestConversation(
+    int number, {
+    String workspacePath = '',
+  }) async {
+    final response = await _client.get(
+      _buildUri(
+        '/api/github/pulls/$number/comments',
+        queryParams: _workspaceQuery(workspacePath),
+      ),
+      headers: _headers,
+    );
+    return _parseResponse(response, GitHubPullRequestConversation.fromJson);
+  }
+
+  Future<GitHubPullRequestComment> submitPullRequestComment(
+    int number,
+    GitHubPullRequestCommentInput input, {
+    String workspacePath = '',
+  }) async {
+    final response = await _client.post(
+      _buildUri('/api/github/pulls/$number/comments'),
+      headers: _headers,
+      body: jsonEncode(input.toJson(workspacePath)),
+    );
+    final payload = _parseJsonEnvelope(response);
+    return GitHubPullRequestComment.fromJson(
+      payload['comment'] as Map<String, dynamic>? ?? const <String, dynamic>{},
+    );
+  }
+
+  Future<GitHubPullRequestReview> submitPullRequestReview(
+    int number,
+    GitHubPullRequestReviewInput input, {
+    String workspacePath = '',
+  }) async {
+    final response = await _client.post(
+      _buildUri('/api/github/pulls/$number/reviews'),
+      headers: _headers,
+      body: jsonEncode(input.toJson(workspacePath)),
+    );
+    final payload = _parseJsonEnvelope(response);
+    return GitHubPullRequestReview.fromJson(
+      payload['review'] as Map<String, dynamic>? ?? const <String, dynamic>{},
+    );
+  }
+
+  Future<GitHubResolveLocalFileResult> resolveLocalFile({
+    required String workspacePath,
+    required String relativePath,
+  }) async {
+    final response = await _client.post(
+      _buildUri('/api/github/resolve-local-file'),
+      headers: _headers,
+      body: jsonEncode(<String, dynamic>{
+        'workspace_path': workspacePath,
+        'path': relativePath,
+      }),
+    );
+    return _parseResponse(response, GitHubResolveLocalFileResult.fromJson);
+  }
+
+  Map<String, dynamic> _parseJsonEnvelope(http.Response response) {
+    final payload = _decodeBody(response.body);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw GitHubCollaborationException(
+        statusCode: response.statusCode,
+        errorCode:
+            (payload['error_code'] as String?)?.trim() ??
+            _defaultErrorCodeForStatus(response.statusCode),
+        message:
+            (payload['message'] as String?)?.trim() ??
+            'GitHub collaboration request failed (HTTP ${response.statusCode}).',
+      );
+    }
+    return payload;
+  }
+
+  T _parseResponse<T>(
+    http.Response response,
+    T Function(Map<String, dynamic> json) fromJson,
+  ) {
+    final payload = _parseJsonEnvelope(response);
+    return fromJson(payload);
+  }
+
+  Map<String, dynamic> _decodeBody(String body) {
+    final trimmed = body.trim();
+    if (trimmed.isEmpty) {
+      return const <String, dynamic>{};
+    }
+    final decoded = jsonDecode(trimmed);
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+    return const <String, dynamic>{};
+  }
+
+  Map<String, String> _workspaceQuery(String workspacePath) {
+    final trimmed = workspacePath.trim();
+    if (trimmed.isEmpty) {
+      return const <String, String>{};
+    }
+    return <String, String>{'path': trimmed};
+  }
+
+  String _defaultErrorCodeForStatus(int statusCode) {
+    switch (statusCode) {
+      case 400:
+        return 'invalid_request';
+      case 401:
+        return 'not_authenticated';
+      case 403:
+        return 'repo_access_unavailable';
+      case 404:
+        return 'not_found';
+      case 503:
+        return 'github_auth_disabled';
+      default:
+        return 'github_auth_error';
+    }
+  }
+
+  void dispose() {
+    _client.close();
+  }
+}
+
+List<T> _mapList<T>(
+  Object? value,
+  T Function(Map<String, dynamic> item) builder,
+) {
+  if (value is! List) {
+    return List<T>.empty(growable: false);
+  }
+  return value
+      .whereType<Map<String, dynamic>>()
+      .map(builder)
+      .toList(growable: false);
+}

--- a/app/lib/widgets/code_editor.dart
+++ b/app/lib/widgets/code_editor.dart
@@ -5,6 +5,8 @@ import '../models/editor_context.dart';
 class CodeEditor extends StatefulWidget {
   final String content;
   final String fileName;
+  final EditorCursor? revealCursor;
+  final int revealToken;
   final void Function(String content) onContentChanged;
   final void Function(EditorCursor cursor)? onCursorChanged;
   final void Function(EditorSelection? selection, EditorCursor cursor)?
@@ -15,6 +17,8 @@ class CodeEditor extends StatefulWidget {
     super.key,
     required this.content,
     required this.fileName,
+    this.revealCursor,
+    this.revealToken = 0,
     required this.onContentChanged,
     this.onCursorChanged,
     this.onSelectionChanged,
@@ -45,6 +49,9 @@ class _CodeEditorState extends State<CodeEditor> {
     _controller.addListener(_onSelectionChanged);
     _editorScrollController.addListener(_syncLineNumbersFromEditor);
     _lineNumberScrollController.addListener(_syncEditorFromLineNumbers);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _revealCursorIfNeeded();
+    });
   }
 
   @override
@@ -57,6 +64,11 @@ class _CodeEditorState extends State<CodeEditor> {
       _controller.text = widget.content;
       _controller.addListener(_onTextChanged);
       _controller.addListener(_onSelectionChanged);
+    }
+    if (oldWidget.revealToken != widget.revealToken) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _revealCursorIfNeeded();
+      });
     }
   }
 
@@ -125,6 +137,21 @@ class _CodeEditorState extends State<CodeEditor> {
     }
 
     return EditorCursor(line: line, column: column);
+  }
+
+  void _revealCursorIfNeeded() {
+    final cursor = widget.revealCursor;
+    if (cursor == null || !_editorScrollController.hasClients) {
+      return;
+    }
+    final targetOffset =
+        ((cursor.line - 1) * _fontSize * 1.5) - (_fontSize * 3);
+    final position = _editorScrollController.position;
+    final clamped = targetOffset.clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+    _editorScrollController.jumpTo(clamped.toDouble());
   }
 
   @override

--- a/app/lib/widgets/code_viewer.dart
+++ b/app/lib/widgets/code_viewer.dart
@@ -82,6 +82,8 @@ class _SyntaxTheme {
 class CodeViewer extends StatefulWidget {
   final String content;
   final String fileName;
+  final EditorCursor? revealCursor;
+  final int revealToken;
   final VoidCallback? onAskAi;
   final void Function(EditorSelection? selection)? onSelectionChanged;
   final VoidCallback? onEditRequested;
@@ -91,6 +93,8 @@ class CodeViewer extends StatefulWidget {
     super.key,
     required this.content,
     required this.fileName,
+    this.revealCursor,
+    this.revealToken = 0,
     this.onAskAi,
     this.onSelectionChanged,
     this.onEditRequested,
@@ -115,6 +119,32 @@ class _CodeViewerState extends State<CodeViewer> {
   String? _cachedContent;
   String? _cachedFileName;
   Brightness? _cachedBrightness;
+  late final ScrollController _verticalScrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _verticalScrollController = ScrollController();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _revealCursorIfNeeded();
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant CodeViewer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.revealToken != widget.revealToken) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _revealCursorIfNeeded();
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _verticalScrollController.dispose();
+    super.dispose();
+  }
 
   Map<int, Diagnostic> get _diagnosticsByLine {
     if (_cachedDiagnosticsSource != widget.diagnostics) {
@@ -300,6 +330,21 @@ class _CodeViewerState extends State<CodeViewer> {
     return EditorCursor(line: line, column: column);
   }
 
+  void _revealCursorIfNeeded() {
+    final cursor = widget.revealCursor;
+    if (cursor == null || !_verticalScrollController.hasClients) {
+      return;
+    }
+    final targetOffset =
+        ((cursor.line - 1) * _fontSize * 1.5) - (_fontSize * 3);
+    final position = _verticalScrollController.position;
+    final clamped = targetOffset.clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+    _verticalScrollController.jumpTo(clamped.toDouble());
+  }
+
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
@@ -350,6 +395,7 @@ class _CodeViewerState extends State<CodeViewer> {
                   }
                 },
                 child: SingleChildScrollView(
+                  controller: _verticalScrollController,
                   child: SingleChildScrollView(
                     scrollDirection: Axis.horizontal,
                     child: Row(

--- a/app/lib/widgets/unified_diff_view.dart
+++ b/app/lib/widgets/unified_diff_view.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+
+class UnifiedDiffView extends StatelessWidget {
+  final String diff;
+  final bool isConflict;
+  final String emptyLabel;
+
+  const UnifiedDiffView({
+    super.key,
+    required this.diff,
+    this.isConflict = false,
+    this.emptyLabel = 'No diff available for this file',
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final lines = diff.split('\n');
+
+    if (diff.trim().isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                isConflict
+                    ? Icons.warning_amber_rounded
+                    : Icons.check_circle_outline,
+                size: 64,
+                color: isConflict ? colorScheme.error : colorScheme.outline,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                emptyLabel,
+                textAlign: TextAlign.center,
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyLarge?.copyWith(color: colorScheme.outline),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        if (isConflict)
+          Container(
+            width: double.infinity,
+            color: colorScheme.errorContainer,
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.warning_amber_rounded,
+                  color: colorScheme.onErrorContainer,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Conflict file: review both sides before staging a resolution.',
+                    style: TextStyle(color: colorScheme.onErrorContainer),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        Expanded(
+          child: Scrollbar(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: SingleChildScrollView(
+                child: Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: lines
+                        .map(
+                          (line) =>
+                              _DiffLine(text: line, colorScheme: colorScheme),
+                        )
+                        .toList(growable: false),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DiffLine extends StatelessWidget {
+  final String text;
+  final ColorScheme colorScheme;
+
+  const _DiffLine({required this.text, required this.colorScheme});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    Color? backgroundColor;
+    Color textColor = colorScheme.onSurface;
+
+    if (text.startsWith('+')) {
+      backgroundColor = Colors.green.withAlpha(isDark ? 40 : 25);
+      textColor = isDark ? Colors.green.shade300 : Colors.green.shade800;
+    } else if (text.startsWith('-')) {
+      backgroundColor = Colors.red.withAlpha(isDark ? 40 : 25);
+      textColor = isDark ? Colors.red.shade300 : Colors.red.shade800;
+    } else if (text.startsWith('@@')) {
+      backgroundColor = Colors.blue.withAlpha(isDark ? 40 : 25);
+      textColor = isDark ? Colors.blue.shade300 : Colors.blue.shade800;
+    }
+
+    return Container(
+      color: backgroundColor,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            text,
+            style: TextStyle(
+              fontFamily: 'monospace',
+              fontSize: 13,
+              color: textColor,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/test/providers/github_collaboration_provider_test.dart
+++ b/app/test/providers/github_collaboration_provider_test.dart
@@ -1,0 +1,380 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:vscode_mobile/models/github_collaboration_models.dart';
+import 'package:vscode_mobile/providers/github_collaboration_provider.dart';
+import 'package:vscode_mobile/services/github_collaboration_api_client.dart';
+import 'package:vscode_mobile/services/settings_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SettingsService settings;
+  late _FakeGitHubCollaborationApiClient apiClient;
+  late GitHubCollaborationProvider provider;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    settings = SettingsService();
+    await settings.save('http://server.test', 'secret-token');
+    apiClient = _FakeGitHubCollaborationApiClient(settings)
+      ..repoContext = GitHubCurrentRepoContext.fromJson(<String, dynamic>{
+        'status': 'ok',
+        'repository': <String, dynamic>{
+          'github_host': 'github.com',
+          'owner': 'octo-org',
+          'name': 'mobile-app',
+          'full_name': 'octo-org/mobile-app',
+          'remote_name': 'origin',
+          'remote_url': 'git@github.com:octo-org/mobile-app.git',
+          'repo_root': '/workspace/repo',
+        },
+        'auth': <String, dynamic>{
+          'authenticated': true,
+          'github_host': 'github.com',
+          'account_login': 'octocat',
+          'account_id': 9,
+          'needs_refresh': false,
+          'needs_reauth': false,
+        },
+      })
+      ..accountContext = GitHubAccountContext.fromJson(<String, dynamic>{
+        'repository': <String, dynamic>{'full_name': 'octo-org/mobile-app'},
+        'account': <String, dynamic>{'login': 'octocat', 'id': 9},
+      })
+      ..issues = <GitHubIssue>[
+        GitHubIssue.fromJson(<String, dynamic>{
+          'number': 7,
+          'title': 'Fix reconnect',
+          'state': 'open',
+          'comments_count': 1,
+        }),
+      ]
+      ..pulls = <GitHubPullRequest>[
+        GitHubPullRequest.fromJson(<String, dynamic>{
+          'number': 12,
+          'title': 'Add collaboration UI',
+          'state': 'open',
+          'changed_files': 1,
+          'base_ref': <String, dynamic>{'ref': 'main'},
+          'head_ref': <String, dynamic>{'ref': 'feature'},
+        }),
+      ]
+      ..issueDetail = GitHubIssueDetail.fromJson(<String, dynamic>{
+        'issue': <String, dynamic>{
+          'number': 7,
+          'title': 'Fix reconnect',
+          'state': 'open',
+          'comments_count': 1,
+        },
+        'comments': [
+          <String, dynamic>{'id': 1, 'body': 'first'},
+        ],
+      })
+      ..pullDetail = GitHubPullRequestDetail.fromJson(<String, dynamic>{
+        'pull_request': <String, dynamic>{
+          'number': 12,
+          'title': 'Add collaboration UI',
+          'state': 'open',
+          'changed_files': 1,
+          'base_ref': <String, dynamic>{'ref': 'main'},
+          'head_ref': <String, dynamic>{'ref': 'feature'},
+        },
+        'files': [
+          <String, dynamic>{
+            'filename': 'app/lib/main.dart',
+            'status': 'modified',
+            'additions': 10,
+            'deletions': 2,
+            'changes': 12,
+            'patch': '@@ -10,1 +42,2 @@\n-old\n+new',
+          },
+        ],
+        'comments': [
+          <String, dynamic>{'id': 2, 'body': 'nit'},
+        ],
+        'reviews': [
+          <String, dynamic>{'id': 3, 'state': 'COMMENTED'},
+        ],
+      })
+      ..conversation = GitHubPullRequestConversation.fromJson(<String, dynamic>{
+        'comments': [
+          <String, dynamic>{'id': 2, 'body': 'nit'},
+        ],
+        'reviews': [
+          <String, dynamic>{'id': 3, 'state': 'COMMENTED'},
+        ],
+      })
+      ..resolveResult = GitHubResolveLocalFileResult.fromJson(<String, dynamic>{
+        'repo_root': '/workspace/repo',
+        'relative_path': 'app/lib/main.dart',
+        'local_path': '/workspace/repo/app/lib/main.dart',
+        'exists': true,
+      });
+    provider = GitHubCollaborationProvider(apiClient: apiClient);
+  });
+
+  test(
+    'initialize loads repo context issues and pulls for the workspace',
+    () async {
+      await provider.setWorkspacePath('/workspace/repo');
+      await provider.initialize();
+
+      expect(provider.repoContext?.repository?.fullName, 'octo-org/mobile-app');
+      expect(provider.accountContext?.account.login, 'octocat');
+      expect(provider.issues.single.number, 7);
+      expect(provider.pulls.single.number, 12);
+      expect(apiClient.lastWorkspacePath, '/workspace/repo');
+    },
+  );
+
+  test(
+    'workspace changes trigger a fresh reload and filter updates refetch',
+    () async {
+      await provider.setWorkspacePath('/workspace/repo');
+      await provider.initialize();
+
+      apiClient.issues = <GitHubIssue>[];
+      await provider.updateIssueFilter(
+        provider.issueFilter.copyWith(mentioned: true),
+      );
+      expect(provider.issueFilter.mentioned, isTrue);
+      expect(apiClient.lastIssueFilter?.mentioned, isTrue);
+
+      apiClient.pulls = <GitHubPullRequest>[];
+      await provider.updatePullFilter(
+        provider.pullFilter.copyWith(needsReview: true),
+      );
+      expect(provider.pullFilter.needsReview, isTrue);
+      expect(apiClient.lastPullFilter?.needsReview, isTrue);
+
+      await provider.setWorkspacePath('/workspace/other');
+      expect(apiClient.lastWorkspacePath, '/workspace/other');
+    },
+  );
+
+  test(
+    'submitIssueComment exposes in-flight state and refreshes detail',
+    () async {
+      final completer = Completer<GitHubIssueComment>();
+      apiClient.issueCommentCompleter = completer;
+
+      await provider.setWorkspacePath('/workspace/repo');
+      await provider.initialize();
+      await provider.loadIssueDetail(7, forceRefresh: true);
+
+      final future = provider.submitIssueComment(7, 'hello world');
+      expect(provider.isSubmittingIssueComment(7), isTrue);
+
+      completer.complete(
+        GitHubIssueComment.fromJson(<String, dynamic>{
+          'id': 99,
+          'body': 'hello world',
+        }),
+      );
+      final success = await future;
+
+      expect(success, isTrue);
+      expect(provider.isSubmittingIssueComment(7), isFalse);
+      expect(apiClient.issueCommentBodies, ['hello world']);
+    },
+  );
+
+  test(
+    'submitPullRequestReview and loadPullRequestConversation refresh detail state',
+    () async {
+      final completer = Completer<GitHubPullRequestReview>();
+      apiClient.pullReviewCompleter = completer;
+
+      await provider.setWorkspacePath('/workspace/repo');
+      await provider.initialize();
+      await provider.loadPullRequestDetail(12, forceRefresh: true);
+
+      final future = provider.submitPullRequestReview(
+        12,
+        const GitHubPullRequestReviewInput(
+          event: 'APPROVE',
+          body: 'looks good',
+        ),
+      );
+      expect(provider.isSubmittingPullRequestReview(12), isTrue);
+
+      completer.complete(
+        GitHubPullRequestReview.fromJson(<String, dynamic>{
+          'id': 55,
+          'state': 'APPROVED',
+        }),
+      );
+      final success = await future;
+
+      expect(success, isTrue);
+      expect(provider.isSubmittingPullRequestReview(12), isFalse);
+      expect(apiClient.lastReviewInput?.event, 'APPROVE');
+      expect(
+        provider.pullRequestDetailFor(12)?.reviews.single.state,
+        'COMMENTED',
+      );
+    },
+  );
+
+  test(
+    'resolvePullRequestFileAction prefers local file and falls back to patch',
+    () async {
+      await provider.setWorkspacePath('/workspace/repo');
+      await provider.initialize();
+      final file = apiClient.pullDetail.files.single;
+
+      final openLocal = await provider.resolvePullRequestFileAction(file);
+      expect(openLocal.shouldOpenLocalFile, isTrue);
+      expect(openLocal.localPath, '/workspace/repo/app/lib/main.dart');
+      expect(openLocal.line, 42);
+
+      apiClient.resolveResult =
+          GitHubResolveLocalFileResult.fromJson(<String, dynamic>{
+            'repo_root': '/workspace/repo',
+            'relative_path': 'missing.dart',
+            'local_path': '/workspace/repo/missing.dart',
+            'exists': false,
+          });
+      final showPatch = await provider.resolvePullRequestFileAction(
+        GitHubPullRequestFile.fromJson(<String, dynamic>{
+          'filename': 'missing.dart',
+          'status': 'removed',
+          'additions': 0,
+          'deletions': 4,
+          'changes': 4,
+          'patch': '@@ -1,4 +0,0 @@\n-old',
+        }),
+      );
+      expect(showPatch.shouldOpenLocalFile, isFalse);
+      expect(showPatch.patchPath, 'missing.dart');
+      expect(showPatch.patch, contains('@@ -1,4 +0,0 @@'));
+    },
+  );
+}
+
+class _FakeGitHubCollaborationApiClient extends GitHubCollaborationApiClient {
+  _FakeGitHubCollaborationApiClient(SettingsService settings)
+    : super(settings: settings);
+
+  late GitHubCurrentRepoContext repoContext;
+  late GitHubAccountContext accountContext;
+  List<GitHubIssue> issues = <GitHubIssue>[];
+  List<GitHubPullRequest> pulls = <GitHubPullRequest>[];
+  late GitHubIssueDetail issueDetail;
+  late GitHubPullRequestDetail pullDetail;
+  late GitHubPullRequestConversation conversation;
+  late GitHubResolveLocalFileResult resolveResult;
+  String lastWorkspacePath = '';
+  GitHubCollaborationFilter? lastIssueFilter;
+  GitHubCollaborationFilter? lastPullFilter;
+  final List<String> issueCommentBodies = <String>[];
+  Completer<GitHubIssueComment>? issueCommentCompleter;
+  Completer<GitHubPullRequestReview>? pullReviewCompleter;
+  GitHubPullRequestReviewInput? lastReviewInput;
+
+  @override
+  Future<GitHubCurrentRepoContext> fetchCurrentRepo({
+    String workspacePath = '',
+  }) async {
+    lastWorkspacePath = workspacePath;
+    return repoContext;
+  }
+
+  @override
+  Future<GitHubAccountContext> fetchAccount({String workspacePath = ''}) async {
+    lastWorkspacePath = workspacePath;
+    return accountContext;
+  }
+
+  @override
+  Future<List<GitHubIssue>> fetchIssues({
+    required GitHubCollaborationFilter filter,
+    String workspacePath = '',
+  }) async {
+    lastWorkspacePath = workspacePath;
+    lastIssueFilter = filter;
+    return issues;
+  }
+
+  @override
+  Future<GitHubIssueDetail> fetchIssueDetail(
+    int number, {
+    String workspacePath = '',
+  }) async {
+    lastWorkspacePath = workspacePath;
+    return issueDetail;
+  }
+
+  @override
+  Future<GitHubIssueComment> submitIssueComment(
+    int number,
+    GitHubIssueCommentInput input, {
+    String workspacePath = '',
+  }) async {
+    lastWorkspacePath = workspacePath;
+    issueCommentBodies.add(input.body);
+    if (issueCommentCompleter != null) {
+      return issueCommentCompleter!.future;
+    }
+    return GitHubIssueComment.fromJson(<String, dynamic>{
+      'id': 99,
+      'body': input.body,
+    });
+  }
+
+  @override
+  Future<List<GitHubPullRequest>> fetchPullRequests({
+    required GitHubCollaborationFilter filter,
+    String workspacePath = '',
+  }) async {
+    lastWorkspacePath = workspacePath;
+    lastPullFilter = filter;
+    return pulls;
+  }
+
+  @override
+  Future<GitHubPullRequestDetail> fetchPullRequestDetail(
+    int number, {
+    String workspacePath = '',
+  }) async {
+    lastWorkspacePath = workspacePath;
+    return pullDetail;
+  }
+
+  @override
+  Future<GitHubPullRequestConversation> fetchPullRequestConversation(
+    int number, {
+    String workspacePath = '',
+  }) async {
+    lastWorkspacePath = workspacePath;
+    return conversation;
+  }
+
+  @override
+  Future<GitHubPullRequestReview> submitPullRequestReview(
+    int number,
+    GitHubPullRequestReviewInput input, {
+    String workspacePath = '',
+  }) async {
+    lastWorkspacePath = workspacePath;
+    lastReviewInput = input;
+    if (pullReviewCompleter != null) {
+      return pullReviewCompleter!.future;
+    }
+    return GitHubPullRequestReview.fromJson(<String, dynamic>{
+      'id': 55,
+      'state': input.event,
+    });
+  }
+
+  @override
+  Future<GitHubResolveLocalFileResult> resolveLocalFile({
+    required String workspacePath,
+    required String relativePath,
+  }) async {
+    lastWorkspacePath = workspacePath;
+    return resolveResult;
+  }
+}

--- a/app/test/services/github_collaboration_api_client_test.dart
+++ b/app/test/services/github_collaboration_api_client_test.dart
@@ -1,0 +1,383 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:vscode_mobile/models/github_collaboration_models.dart';
+import 'package:vscode_mobile/services/github_collaboration_api_client.dart';
+import 'package:vscode_mobile/services/settings_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SettingsService settings;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    settings = SettingsService();
+    await settings.save('http://server.test', 'secret-token');
+  });
+
+  test(
+    'fetchCurrentRepo includes workspace query and decodes repo context',
+    () async {
+      final client = MockClient((http.Request request) async {
+        expect(request.method, 'GET');
+        expect(request.url.path, '/api/github/repos/current');
+        expect(request.url.queryParameters['path'], '/workspace/repo');
+        return http.Response(
+          jsonEncode(<String, dynamic>{
+            'status': 'ok',
+            'repository': <String, dynamic>{
+              'github_host': 'github.com',
+              'owner': 'octo-org',
+              'name': 'mobile-app',
+              'full_name': 'octo-org/mobile-app',
+              'remote_name': 'origin',
+              'remote_url': 'git@github.com:octo-org/mobile-app.git',
+              'repo_root': '/workspace/repo',
+              'private': true,
+            },
+            'auth': <String, dynamic>{
+              'authenticated': true,
+              'github_host': 'github.com',
+              'account_login': 'octocat',
+              'account_id': 9,
+              'needs_refresh': false,
+              'needs_reauth': false,
+            },
+          }),
+          200,
+        );
+      });
+
+      final apiClient = GitHubCollaborationApiClient(
+        settings: settings,
+        client: client,
+      );
+      final context = await apiClient.fetchCurrentRepo(
+        workspacePath: '/workspace/repo',
+      );
+
+      expect(context.isOk, isTrue);
+      expect(context.repository?.fullName, 'octo-org/mobile-app');
+      expect(context.auth?.accountLogin, 'octocat');
+    },
+  );
+
+  test('fetchIssues and fetchIssueDetail decode issue payloads', () async {
+    final client = MockClient((http.Request request) async {
+      if (request.url.path == '/api/github/issues') {
+        expect(request.url.queryParameters['state'], 'open');
+        expect(request.url.queryParameters['assigned_to_me'], 'true');
+        return http.Response(
+          jsonEncode(<String, dynamic>{
+            'issues': [
+              <String, dynamic>{
+                'number': 7,
+                'title': 'Fix reconnect',
+                'state': 'open',
+                'body': 'Reconnect stalls after sleep.',
+                'comments_count': 3,
+                'author': <String, dynamic>{'login': 'octocat', 'id': 9},
+              },
+            ],
+          }),
+          200,
+        );
+      }
+
+      expect(request.url.path, '/api/github/issues/7');
+      return http.Response(
+        jsonEncode(<String, dynamic>{
+          'issue': <String, dynamic>{
+            'number': 7,
+            'title': 'Fix reconnect',
+            'state': 'open',
+            'body': 'Reconnect stalls after sleep.',
+            'comments_count': 3,
+          },
+          'comments': [
+            <String, dynamic>{
+              'id': 11,
+              'body': 'I can take this.',
+              'author': <String, dynamic>{'login': 'octocat', 'id': 9},
+            },
+          ],
+        }),
+        200,
+      );
+    });
+
+    final apiClient = GitHubCollaborationApiClient(
+      settings: settings,
+      client: client,
+    );
+
+    final issues = await apiClient.fetchIssues(
+      filter: const GitHubCollaborationFilter(
+        state: 'open',
+        assignedToMe: true,
+      ),
+      workspacePath: '/workspace/repo',
+    );
+    final detail = await apiClient.fetchIssueDetail(
+      7,
+      workspacePath: '/workspace/repo',
+    );
+
+    expect(issues.single.number, 7);
+    expect(issues.single.author?.login, 'octocat');
+    expect(detail.issue.title, 'Fix reconnect');
+    expect(detail.comments.single.body, 'I can take this.');
+  });
+
+  test(
+    'fetchPullRequestDetail decodes files comments reviews and checks',
+    () async {
+      final client = MockClient((http.Request request) async {
+        expect(request.url.path, '/api/github/pulls/12');
+        return http.Response(
+          jsonEncode(<String, dynamic>{
+            'pull_request': <String, dynamic>{
+              'number': 12,
+              'title': 'Add collaboration UI',
+              'state': 'open',
+              'body': 'Implements the GitHub collaboration flow.',
+              'changed_files': 2,
+              'base_ref': <String, dynamic>{'ref': 'main'},
+              'head_ref': <String, dynamic>{'ref': 'feature/github-collab'},
+              'checks': <String, dynamic>{
+                'state': 'pending',
+                'total_count': 2,
+                'success_count': 1,
+                'pending_count': 1,
+                'failure_count': 0,
+                'checks': [
+                  <String, dynamic>{
+                    'name': 'ci / unit-tests',
+                    'status': 'completed',
+                    'conclusion': 'success',
+                  },
+                ],
+              },
+            },
+            'files': [
+              <String, dynamic>{
+                'filename': 'app/lib/main.dart',
+                'status': 'modified',
+                'additions': 10,
+                'deletions': 0,
+                'changes': 10,
+                'patch': '@@ -1,1 +1,10 @@\n+new',
+              },
+            ],
+            'comments': [
+              <String, dynamic>{
+                'id': 21,
+                'body': 'Looks good',
+                'path': 'app/lib/main.dart',
+              },
+            ],
+            'reviews': [
+              <String, dynamic>{
+                'id': 31,
+                'state': 'COMMENTED',
+                'body': 'Ship it',
+              },
+            ],
+          }),
+          200,
+        );
+      });
+
+      final apiClient = GitHubCollaborationApiClient(
+        settings: settings,
+        client: client,
+      );
+      final detail = await apiClient.fetchPullRequestDetail(
+        12,
+        workspacePath: '/workspace/repo',
+      );
+
+      expect(detail.pullRequest.number, 12);
+      expect(detail.files.single.filename, 'app/lib/main.dart');
+      expect(detail.comments.single.path, 'app/lib/main.dart');
+      expect(detail.reviews.single.state, 'COMMENTED');
+      expect(detail.pullRequest.checks?.checks.single.name, 'ci / unit-tests');
+    },
+  );
+
+  test(
+    'resolveLocalFile and submit endpoints send expected request bodies',
+    () async {
+      final requests = <Map<String, dynamic>>[];
+      final client = MockClient((http.Request request) async {
+        if (request.method == 'POST') {
+          requests.add(jsonDecode(request.body) as Map<String, dynamic>);
+        }
+        if (request.url.path == '/api/github/resolve-local-file') {
+          return http.Response(
+            jsonEncode(<String, dynamic>{
+              'repo_root': '/workspace/repo',
+              'relative_path': 'app/lib/main.dart',
+              'local_path': '/workspace/repo/app/lib/main.dart',
+              'exists': true,
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/github/issues/7/comments') {
+          return http.Response(
+            jsonEncode(<String, dynamic>{
+              'comment': <String, dynamic>{'id': 1, 'body': 'hello'},
+            }),
+            201,
+          );
+        }
+        if (request.url.path == '/api/github/pulls/12/comments') {
+          return http.Response(
+            jsonEncode(<String, dynamic>{
+              'comment': <String, dynamic>{'id': 2, 'body': 'inline'},
+            }),
+            201,
+          );
+        }
+        return http.Response(
+          jsonEncode(<String, dynamic>{
+            'review': <String, dynamic>{'id': 3, 'state': 'APPROVED'},
+          }),
+          201,
+        );
+      });
+
+      final apiClient = GitHubCollaborationApiClient(
+        settings: settings,
+        client: client,
+      );
+
+      await apiClient.resolveLocalFile(
+        workspacePath: '/workspace/repo',
+        relativePath: 'app/lib/main.dart',
+      );
+      await apiClient.submitIssueComment(
+        7,
+        const GitHubIssueCommentInput(body: 'hello'),
+        workspacePath: '/workspace/repo',
+      );
+      await apiClient.submitPullRequestComment(
+        12,
+        const GitHubPullRequestCommentInput(
+          body: 'inline',
+          path: 'app/lib/main.dart',
+          commitId: 'deadbeef',
+          line: 10,
+          side: 'RIGHT',
+        ),
+        workspacePath: '/workspace/repo',
+      );
+      await apiClient.submitPullRequestReview(
+        12,
+        const GitHubPullRequestReviewInput(
+          event: 'APPROVE',
+          body: 'Looks good',
+          comments: <GitHubPullRequestReviewDraftComment>[
+            GitHubPullRequestReviewDraftComment(
+              body: 'nit',
+              path: 'app/lib/main.dart',
+              line: 12,
+              side: 'RIGHT',
+            ),
+          ],
+        ),
+        workspacePath: '/workspace/repo',
+      );
+
+      expect(
+        requests.any(
+          (request) =>
+              request['workspace_path'] == '/workspace/repo' &&
+              request['path'] == 'app/lib/main.dart' &&
+              request.length == 2,
+        ),
+        isTrue,
+      );
+      expect(
+        requests.any(
+          (request) =>
+              request['workspace_path'] == '/workspace/repo' &&
+              request['body'] == 'hello' &&
+              request.length == 2,
+        ),
+        isTrue,
+      );
+      expect(
+        requests.any(
+          (request) =>
+              request['workspace_path'] == '/workspace/repo' &&
+              request['body'] == 'inline' &&
+              request['path'] == 'app/lib/main.dart' &&
+              request['commit_id'] == 'deadbeef' &&
+              request['side'] == 'RIGHT' &&
+              request['line'] == 10,
+        ),
+        isTrue,
+      );
+      expect(
+        requests.any((request) {
+          final comments = request['comments'] as List<dynamic>?;
+          if (comments == null || comments.isEmpty) {
+            return false;
+          }
+          final firstComment = comments.first as Map<String, dynamic>;
+          return request['workspace_path'] == '/workspace/repo' &&
+              request['event'] == 'APPROVE' &&
+              request['body'] == 'Looks good' &&
+              firstComment['body'] == 'nit' &&
+              firstComment['path'] == 'app/lib/main.dart' &&
+              firstComment['side'] == 'RIGHT' &&
+              firstComment['line'] == 12;
+        }),
+        isTrue,
+      );
+    },
+  );
+
+  test('maps structured errors to collaboration exceptions', () async {
+    final client = MockClient((_) async {
+      return http.Response(
+        jsonEncode(<String, dynamic>{
+          'error_code': 'app_not_installed_for_repo',
+          'message': 'install the GitHub app first',
+        }),
+        403,
+      );
+    });
+
+    final apiClient = GitHubCollaborationApiClient(
+      settings: settings,
+      client: client,
+    );
+
+    await expectLater(
+      () => apiClient.fetchPullRequests(
+        filter: const GitHubCollaborationFilter(),
+        workspacePath: '/workspace/repo',
+      ),
+      throwsA(
+        isA<GitHubCollaborationException>()
+            .having(
+              (error) => error.errorCode,
+              'errorCode',
+              'app_not_installed_for_repo',
+            )
+            .having(
+              (error) => error.toDisplayMessage(),
+              'display message',
+              contains('GitHub App'),
+            ),
+      ),
+    );
+  });
+}

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:vscode_mobile/models/github_collaboration_models.dart';
+import 'package:vscode_mobile/providers/github_collaboration_provider.dart';
 import 'package:vscode_mobile/providers/github_auth_provider.dart';
-import 'package:vscode_mobile/models/github_auth_models.dart';
+import 'package:vscode_mobile/screens/github_collaboration_screen.dart';
 import 'package:vscode_mobile/screens/more_screen.dart';
 import 'package:vscode_mobile/services/git_api_client.dart';
+import 'package:vscode_mobile/services/github_collaboration_api_client.dart';
 import 'package:vscode_mobile/services/github_auth_api_client.dart';
 import 'package:vscode_mobile/services/settings_service.dart';
 
@@ -14,6 +17,10 @@ Future<Widget> buildTestApp() async {
 
   final settings = SettingsService();
   await settings.save('http://localhost:8080', 'server-token');
+  final collaborationProvider = GitHubCollaborationProvider(
+    apiClient: _FakeGitHubCollaborationApiClient(settings),
+  );
+  await collaborationProvider.setWorkspacePath('/workspaces/openvsmobile');
 
   return MultiProvider(
     providers: [
@@ -24,36 +31,109 @@ Future<Widget> buildTestApp() async {
           gitApiClient: _FakeGitApiClient(settings),
         )..setWorkspacePath('/workspaces/openvsmobile'),
       ),
+      ChangeNotifierProvider<GitHubCollaborationProvider>.value(
+        value: collaborationProvider,
+      ),
     ],
     child: const MaterialApp(home: MoreScreen()),
   );
 }
 
 void main() {
-  testWidgets('More screen renders the GitHub entry', (tester) async {
+  testWidgets('More screen routes the GitHub entry to collaboration', (
+    tester,
+  ) async {
     await tester.pumpWidget(await buildTestApp());
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text('GitHub'), findsOneWidget);
-    expect(find.text('Connect GitHub and inspect auth status'), findsOneWidget);
-    expect(find.text('Settings'), findsOneWidget);
+    expect(
+      find.text('Browse issues, pull requests, and reviews'),
+      findsOneWidget,
+    );
+    expect(find.text('GitHub Connection'), findsOneWidget);
+
+    await tester.tap(find.text('GitHub'));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(GitHubCollaborationScreen), findsOneWidget);
+    expect(find.text('octo-org/mobile-app'), findsOneWidget);
   });
 }
 
 class _FakeGitHubAuthApiClient extends GitHubAuthApiClient {
   _FakeGitHubAuthApiClient(SettingsService settings)
     : super(settings: settings);
-
-  @override
-  Future<GitHubAuthStatus> getStatus({String githubHost = 'github.com'}) async {
-    throw const GitHubAuthApiException(
-      statusCode: 401,
-      errorCode: 'not_authenticated',
-      message: 'github not authenticated',
-    );
-  }
 }
 
 class _FakeGitApiClient extends GitApiClient {
   _FakeGitApiClient(SettingsService settings) : super(settings: settings);
+}
+
+class _FakeGitHubCollaborationApiClient extends GitHubCollaborationApiClient {
+  _FakeGitHubCollaborationApiClient(SettingsService settings)
+    : super(settings: settings);
+
+  @override
+  Future<GitHubCurrentRepoContext> fetchCurrentRepo({
+    String workspacePath = '',
+  }) async {
+    return GitHubCurrentRepoContext.fromJson(<String, dynamic>{
+      'status': 'ok',
+      'repository': <String, dynamic>{
+        'full_name': 'octo-org/mobile-app',
+        'remote_url': 'git@github.com:octo-org/mobile-app.git',
+        'repo_root': workspacePath,
+      },
+      'auth': <String, dynamic>{
+        'authenticated': true,
+        'github_host': 'github.com',
+        'account_login': 'octocat',
+        'account_id': 9,
+        'needs_refresh': false,
+        'needs_reauth': false,
+      },
+    });
+  }
+
+  @override
+  Future<GitHubAccountContext> fetchAccount({String workspacePath = ''}) async {
+    return GitHubAccountContext.fromJson(<String, dynamic>{
+      'repository': <String, dynamic>{'full_name': 'octo-org/mobile-app'},
+      'account': <String, dynamic>{'login': 'octocat', 'id': 9},
+    });
+  }
+
+  @override
+  Future<List<GitHubIssue>> fetchIssues({
+    required GitHubCollaborationFilter filter,
+    String workspacePath = '',
+  }) async {
+    return <GitHubIssue>[
+      GitHubIssue.fromJson(<String, dynamic>{
+        'number': 7,
+        'title': 'Fix reconnect',
+        'state': 'open',
+        'comments_count': 1,
+      }),
+    ];
+  }
+
+  @override
+  Future<List<GitHubPullRequest>> fetchPullRequests({
+    required GitHubCollaborationFilter filter,
+    String workspacePath = '',
+  }) async {
+    return <GitHubPullRequest>[
+      GitHubPullRequest.fromJson(<String, dynamic>{
+        'number': 12,
+        'title': 'Add collaboration UI',
+        'state': 'open',
+        'changed_files': 1,
+        'base_ref': <String, dynamic>{'ref': 'main'},
+        'head_ref': <String, dynamic>{'ref': 'feature'},
+      }),
+    ];
+  }
 }

--- a/app/test/widgets/github_collaboration_screen_test.dart
+++ b/app/test/widgets/github_collaboration_screen_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:vscode_mobile/models/github_collaboration_models.dart';
+import 'package:vscode_mobile/providers/github_collaboration_provider.dart';
+import 'package:vscode_mobile/screens/github_collaboration_screen.dart';
+import 'package:vscode_mobile/services/github_collaboration_api_client.dart';
+import 'package:vscode_mobile/services/settings_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets(
+    'renders repo header and switches between issues and pull requests',
+    (tester) async {
+      final provider = await _buildProvider(
+        repoContext: GitHubCurrentRepoContext.fromJson(<String, dynamic>{
+          'status': 'ok',
+          'repository': <String, dynamic>{
+            'full_name': 'octo-org/mobile-app',
+            'remote_url': 'git@github.com:octo-org/mobile-app.git',
+            'repo_root': '/workspace/repo',
+          },
+          'auth': <String, dynamic>{
+            'authenticated': true,
+            'github_host': 'github.com',
+            'account_login': 'octocat',
+            'account_id': 9,
+            'needs_refresh': false,
+            'needs_reauth': false,
+          },
+        }),
+        issues: <GitHubIssue>[
+          GitHubIssue.fromJson(<String, dynamic>{
+            'number': 7,
+            'title': 'Fix reconnect',
+            'state': 'open',
+            'comments_count': 1,
+            'author': <String, dynamic>{'login': 'octocat', 'id': 9},
+          }),
+        ],
+        pulls: <GitHubPullRequest>[
+          GitHubPullRequest.fromJson(<String, dynamic>{
+            'number': 12,
+            'title': 'Add collaboration UI',
+            'state': 'open',
+            'changed_files': 1,
+            'base_ref': <String, dynamic>{'ref': 'main'},
+            'head_ref': <String, dynamic>{'ref': 'feature'},
+          }),
+        ],
+      );
+
+      await tester.pumpWidget(_buildApp(provider));
+      await tester.pumpAndSettle();
+
+      expect(find.text('octo-org/mobile-app'), findsOneWidget);
+      expect(find.text('Issues'), findsOneWidget);
+      expect(find.text('Pull Requests'), findsOneWidget);
+      expect(find.text('#7 Fix reconnect'), findsOneWidget);
+
+      await tester.tap(find.text('Pull Requests'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('#12 Add collaboration UI'), findsOneWidget);
+    },
+  );
+
+  testWidgets('renders auth-needed state with auth action', (tester) async {
+    final provider = await _buildProvider(
+      repoContext: GitHubCurrentRepoContext.fromJson(<String, dynamic>{
+        'status': 'not_authenticated',
+        'repository': <String, dynamic>{
+          'full_name': 'octo-org/mobile-app',
+          'remote_url': 'git@github.com:octo-org/mobile-app.git',
+          'repo_root': '/workspace/repo',
+        },
+        'message': 'GitHub is not connected on this server yet.',
+      }),
+      issues: const <GitHubIssue>[],
+      pulls: const <GitHubPullRequest>[],
+    );
+
+    await tester.pumpWidget(_buildApp(provider));
+    await tester.pumpAndSettle();
+
+    expect(find.text('GitHub authentication required'), findsOneWidget);
+    expect(
+      find.widgetWithText(FilledButton, 'Open GitHub auth'),
+      findsOneWidget,
+    );
+  });
+}
+
+Widget _buildApp(GitHubCollaborationProvider provider) {
+  return ChangeNotifierProvider<GitHubCollaborationProvider>.value(
+    value: provider,
+    child: const MaterialApp(home: GitHubCollaborationScreen()),
+  );
+}
+
+Future<GitHubCollaborationProvider> _buildProvider({
+  required GitHubCurrentRepoContext repoContext,
+  required List<GitHubIssue> issues,
+  required List<GitHubPullRequest> pulls,
+}) async {
+  final settings = SettingsService();
+  await settings.save('http://server.test', 'secret-token');
+  final apiClient = _FakeGitHubCollaborationApiClient(settings)
+    ..repoContext = repoContext
+    ..issues = issues
+    ..pulls = pulls;
+  final provider = GitHubCollaborationProvider(apiClient: apiClient);
+  await provider.setWorkspacePath('/workspace/repo');
+  return provider;
+}
+
+class _FakeGitHubCollaborationApiClient extends GitHubCollaborationApiClient {
+  _FakeGitHubCollaborationApiClient(SettingsService settings)
+    : super(settings: settings);
+
+  late GitHubCurrentRepoContext repoContext;
+  List<GitHubIssue> issues = <GitHubIssue>[];
+  List<GitHubPullRequest> pulls = <GitHubPullRequest>[];
+
+  @override
+  Future<GitHubCurrentRepoContext> fetchCurrentRepo({
+    String workspacePath = '',
+  }) async {
+    return repoContext;
+  }
+
+  @override
+  Future<GitHubAccountContext> fetchAccount({String workspacePath = ''}) async {
+    return GitHubAccountContext.fromJson(<String, dynamic>{
+      'repository': <String, dynamic>{'full_name': 'octo-org/mobile-app'},
+      'account': <String, dynamic>{'login': 'octocat', 'id': 9},
+    });
+  }
+
+  @override
+  Future<List<GitHubIssue>> fetchIssues({
+    required GitHubCollaborationFilter filter,
+    String workspacePath = '',
+  }) async {
+    return issues;
+  }
+
+  @override
+  Future<List<GitHubPullRequest>> fetchPullRequests({
+    required GitHubCollaborationFilter filter,
+    String workspacePath = '',
+  }) async {
+    return pulls;
+  }
+}

--- a/app/test/widgets/github_issue_detail_screen_test.dart
+++ b/app/test/widgets/github_issue_detail_screen_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:vscode_mobile/models/github_collaboration_models.dart';
+import 'package:vscode_mobile/providers/github_collaboration_provider.dart';
+import 'package:vscode_mobile/screens/github_issue_detail_screen.dart';
+import 'package:vscode_mobile/services/github_collaboration_api_client.dart';
+import 'package:vscode_mobile/services/settings_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('renders issue detail and posts a new comment', (tester) async {
+    final settings = SettingsService();
+    await settings.save('http://server.test', 'secret-token');
+    final apiClient = _FakeGitHubCollaborationApiClient(settings);
+    final provider = GitHubCollaborationProvider(apiClient: apiClient);
+    await provider.setWorkspacePath('/workspace/repo');
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<GitHubCollaborationProvider>.value(
+        value: provider,
+        child: const MaterialApp(home: GitHubIssueDetailScreen(issueNumber: 7)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('#7 Fix reconnect'), findsOneWidget);
+    expect(find.text('No comments yet.'), findsNothing);
+    expect(find.text('Existing comment'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'New issue comment');
+    await tester.tap(find.widgetWithText(FilledButton, 'Post'));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(apiClient.submittedComments, ['New issue comment']);
+    expect(find.text('Issue comment posted'), findsOneWidget);
+  });
+}
+
+class _FakeGitHubCollaborationApiClient extends GitHubCollaborationApiClient {
+  _FakeGitHubCollaborationApiClient(SettingsService settings)
+    : super(settings: settings);
+
+  final List<String> submittedComments = <String>[];
+
+  @override
+  Future<GitHubIssueDetail> fetchIssueDetail(
+    int number, {
+    String workspacePath = '',
+  }) async {
+    return GitHubIssueDetail.fromJson(<String, dynamic>{
+      'issue': <String, dynamic>{
+        'number': 7,
+        'title': 'Fix reconnect',
+        'state': 'open',
+        'body': 'Reconnect stalls after sleep.',
+        'comments_count': 1,
+      },
+      'comments': [
+        <String, dynamic>{
+          'id': 1,
+          'body': 'Existing comment',
+          'author': <String, dynamic>{'login': 'octocat', 'id': 9},
+        },
+      ],
+    });
+  }
+
+  @override
+  Future<GitHubIssueComment> submitIssueComment(
+    int number,
+    GitHubIssueCommentInput input, {
+    String workspacePath = '',
+  }) async {
+    submittedComments.add(input.body);
+    return GitHubIssueComment.fromJson(<String, dynamic>{
+      'id': 2,
+      'body': input.body,
+    });
+  }
+}

--- a/app/test/widgets/github_pull_request_detail_screen_test.dart
+++ b/app/test/widgets/github_pull_request_detail_screen_test.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:vscode_mobile/models/diagnostic.dart';
+import 'package:vscode_mobile/models/github_collaboration_models.dart';
+import 'package:vscode_mobile/providers/editor_provider.dart';
+import 'package:vscode_mobile/providers/github_collaboration_provider.dart';
+import 'package:vscode_mobile/screens/code_screen.dart';
+import 'package:vscode_mobile/screens/github_pull_request_detail_screen.dart';
+import 'package:vscode_mobile/services/api_client.dart';
+import 'package:vscode_mobile/services/github_collaboration_api_client.dart';
+import 'package:vscode_mobile/services/settings_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('renders checks and submits a review action', (tester) async {
+    final harness = await _buildHarness();
+
+    await tester.pumpWidget(harness.widget);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Conversation'));
+    await tester.pumpAndSettle();
+    expect(find.text('Comment'), findsOneWidget);
+    expect(find.text('Approve'), findsOneWidget);
+    expect(find.text('Request changes'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'Ship it');
+    final submitReviewButton = find.widgetWithText(
+      FilledButton,
+      'Submit review',
+    );
+    await tester.scrollUntilVisible(
+      submitReviewButton,
+      200,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(submitReviewButton);
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(harness.collabApi.reviewInputs.single.event, 'COMMENT');
+    expect(find.text('Review COMMENT submitted'), findsOneWidget);
+
+    await tester.tap(find.text('Checks'));
+    await tester.pumpAndSettle();
+    expect(find.text('State: pending'), findsOneWidget);
+    expect(find.text('ci / unit-tests'), findsOneWidget);
+  });
+
+  testWidgets('tapping a file opens the editor when the local file exists', (
+    tester,
+  ) async {
+    final harness = await _buildHarness();
+    harness.collabApi.resolveResult =
+        GitHubResolveLocalFileResult.fromJson(<String, dynamic>{
+          'repo_root': '/workspace/repo',
+          'relative_path': 'app/lib/main.dart',
+          'local_path': '/workspace/repo/app/lib/main.dart',
+          'exists': true,
+        });
+
+    await tester.pumpWidget(harness.widget);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Files'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('app/lib/main.dart'));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CodeScreen), findsOneWidget);
+    expect(harness.editorProvider.currentFile?.path, '/workspace/repo/app/lib/main.dart');
+    expect(harness.editorProvider.cursor?.line, 42);
+  });
+
+  testWidgets('tapping a file falls back to the patch screen when missing', (
+    tester,
+  ) async {
+    final harness = await _buildHarness();
+    harness.collabApi.resolveResult =
+        GitHubResolveLocalFileResult.fromJson(<String, dynamic>{
+          'repo_root': '/workspace/repo',
+          'relative_path': 'app/lib/main.dart',
+          'local_path': '/workspace/repo/app/lib/main.dart',
+          'exists': false,
+        });
+
+    await tester.pumpWidget(harness.widget);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Files'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('app/lib/main.dart'));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.text('app/lib/main.dart'), findsWidgets);
+    expect(find.textContaining('@@ -10,1 +42,2 @@'), findsOneWidget);
+  });
+}
+
+class _Harness {
+  final Widget widget;
+  final _FakeGitHubCollaborationApiClient collabApi;
+  final EditorProvider editorProvider;
+
+  const _Harness({
+    required this.widget,
+    required this.collabApi,
+    required this.editorProvider,
+  });
+}
+
+Future<_Harness> _buildHarness() async {
+  final settings = SettingsService();
+  await settings.save('http://server.test', 'secret-token');
+  final collabApi = _FakeGitHubCollaborationApiClient(settings);
+  final editorApi = _FakeApiClient(settings);
+  final collabProvider = GitHubCollaborationProvider(apiClient: collabApi);
+  await collabProvider.setWorkspacePath('/workspace/repo');
+  final editorProvider = EditorProvider(apiClient: editorApi);
+
+  return _Harness(
+    collabApi: collabApi,
+    editorProvider: editorProvider,
+    widget: MultiProvider(
+      providers: [
+        ChangeNotifierProvider<GitHubCollaborationProvider>.value(
+          value: collabProvider,
+        ),
+        ChangeNotifierProvider<EditorProvider>.value(value: editorProvider),
+      ],
+      child: const MaterialApp(
+        home: GitHubPullRequestDetailScreen(pullRequestNumber: 12),
+      ),
+    ),
+  );
+}
+
+class _FakeGitHubCollaborationApiClient extends GitHubCollaborationApiClient {
+  _FakeGitHubCollaborationApiClient(SettingsService settings)
+    : super(settings: settings);
+
+  GitHubResolveLocalFileResult resolveResult =
+      GitHubResolveLocalFileResult.fromJson(<String, dynamic>{
+        'repo_root': '/workspace/repo',
+        'relative_path': 'app/lib/main.dart',
+        'local_path': '/workspace/repo/app/lib/main.dart',
+        'exists': true,
+      });
+  final List<GitHubPullRequestReviewInput> reviewInputs =
+      <GitHubPullRequestReviewInput>[];
+
+  @override
+  Future<GitHubPullRequestDetail> fetchPullRequestDetail(
+    int number, {
+    String workspacePath = '',
+  }) async {
+    return GitHubPullRequestDetail.fromJson(<String, dynamic>{
+      'pull_request': <String, dynamic>{
+        'number': 12,
+        'title': 'Add collaboration UI',
+        'state': 'open',
+        'body': 'Implements the GitHub collaboration flow.',
+        'changed_files': 1,
+        'base_ref': <String, dynamic>{'ref': 'main'},
+        'head_ref': <String, dynamic>{'ref': 'feature'},
+        'checks': <String, dynamic>{
+          'state': 'pending',
+          'total_count': 1,
+          'success_count': 0,
+          'pending_count': 1,
+          'failure_count': 0,
+          'checks': [
+            <String, dynamic>{'name': 'ci / unit-tests', 'status': 'pending'},
+          ],
+        },
+      },
+      'files': [
+        <String, dynamic>{
+          'filename': 'app/lib/main.dart',
+          'status': 'modified',
+          'additions': 2,
+          'deletions': 1,
+          'changes': 3,
+          'patch': '@@ -10,1 +42,2 @@\n-old\n+new',
+        },
+      ],
+      'comments': [
+        <String, dynamic>{
+          'id': 2,
+          'body': 'Inline note',
+          'path': 'app/lib/main.dart',
+        },
+      ],
+      'reviews': [
+        <String, dynamic>{'id': 3, 'state': 'COMMENTED', 'body': 'Looks good'},
+      ],
+    });
+  }
+
+  @override
+  Future<GitHubPullRequestReview> submitPullRequestReview(
+    int number,
+    GitHubPullRequestReviewInput input, {
+    String workspacePath = '',
+  }) async {
+    reviewInputs.add(input);
+    return GitHubPullRequestReview.fromJson(<String, dynamic>{
+      'id': 99,
+      'state': input.event,
+      'body': input.body,
+    });
+  }
+
+  @override
+  Future<GitHubResolveLocalFileResult> resolveLocalFile({
+    required String workspacePath,
+    required String relativePath,
+  }) async {
+    return resolveResult;
+  }
+}
+
+class _FakeApiClient extends ApiClient {
+  _FakeApiClient(SettingsService settings) : super(settings: settings);
+
+  @override
+  Future<String> readFile(String path) async => 'void main() {}';
+
+  @override
+  Future<List<Diagnostic>> getDiagnostics({
+    String? filePath,
+    String workDir = '/',
+  }) async {
+    return const <Diagnostic>[];
+  }
+}


### PR DESCRIPTION
## Summary
- add a workspace-scoped GitHub collaboration surface reachable from the app's GitHub entry
- support repo-bound issue and pull request browsing, detail views, issue comments, and PR reviews
- add PR file navigation that opens local files in the editor when present and falls back to a patch viewer otherwise

## Why
- completes ASE-54 by mirroring GitHub issue and PR collaboration inside OpenASE instead of sending users to a read-only remote browser flow

## Issue
- Closes #15

## Validation
- `cd app && /home/ddq/flutter/bin/flutter analyze lib test`
- `cd app && /home/ddq/flutter/bin/flutter test`
