### PR TITLE
ASE-44: ship Flutter editor experience

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -12,6 +12,7 @@ import 'providers/workspace_provider.dart';
 import 'services/api_client.dart';
 import 'services/browser_launcher.dart';
 import 'services/chat_api_client.dart';
+import 'services/editor_api_client.dart';
 import 'services/git_api_client.dart';
 import 'services/github_auth_api_client.dart';
 import 'services/settings_service.dart';
@@ -24,6 +25,7 @@ void main() async {
 
   final apiClient = ApiClient(settings: settings);
   final chatApiClient = ChatApiClient(settings: settings);
+  final editorApiClient = EditorApiClient(settings: settings);
   final gitApiClient = GitApiClient(settings: settings);
   final githubAuthApiClient = GitHubAuthApiClient(settings: settings);
   final browserLauncher = BrowserLauncher();
@@ -43,7 +45,10 @@ void main() async {
                 ..setProject(workspaceProvider.currentPath),
         ),
         ChangeNotifierProvider(
-          create: (_) => EditorProvider(apiClient: apiClient),
+          create: (_) => EditorProvider(
+            apiClient: apiClient,
+            editorApiClient: editorApiClient,
+          ),
         ),
         ChangeNotifierProxyProvider<EditorProvider, ChatProvider>(
           create: (_) =>

--- a/app/lib/models/diagnostic.dart
+++ b/app/lib/models/diagnostic.dart
@@ -1,33 +1,99 @@
-/// Model for diagnostic findings from the server.
+import 'editor_models.dart';
+
+/// Model for diagnostic findings from either the legacy diagnostics endpoint or
+/// the newer bridge-backed editor diagnostics report.
 class Diagnostic {
   final String filePath;
-  final int line;
-  final int column;
+  final DocumentRange range;
   final String severity;
   final String message;
   final String source;
 
   const Diagnostic({
     required this.filePath,
-    required this.line,
-    required this.column,
+    required this.range,
     required this.severity,
     required this.message,
     required this.source,
   });
 
-  factory Diagnostic.fromJson(Map<String, dynamic> json) {
+  factory Diagnostic.fromJson(
+    Map<String, dynamic> json, {
+    String? defaultPath,
+  }) {
+    final rawRange = json['range'];
+    final filePath =
+        json['filePath'] as String? ??
+        json['path'] as String? ??
+        defaultPath ??
+        '';
+
+    if (rawRange is Map) {
+      return Diagnostic(
+        filePath: filePath,
+        range: DocumentRange.fromJson(Map<String, dynamic>.from(rawRange)),
+        severity: _severityToString(json['severity']),
+        message: json['message'] as String? ?? '',
+        source: json['source'] as String? ?? '',
+      );
+    }
+
+    final line = (json['line'] as int? ?? 1).clamp(1, 1 << 20);
+    final column = (json['column'] as int? ?? 1).clamp(1, 1 << 20);
     return Diagnostic(
-      filePath: json['filePath'] as String? ?? '',
-      line: json['line'] as int? ?? 0,
-      column: json['column'] as int? ?? 0,
-      severity: json['severity'] as String? ?? 'info',
+      filePath: filePath,
+      range: DocumentRange(
+        start: DocumentPosition(line: line - 1, character: column - 1),
+        end: DocumentPosition(line: line - 1, character: column),
+      ),
+      severity: _severityToString(json['severity']),
       message: json['message'] as String? ?? '',
       source: json['source'] as String? ?? '',
     );
   }
 
+  static List<Diagnostic> listFromReportJson(Map<String, dynamic> json) {
+    final path = json['path'] as String? ?? '';
+    final rawDiagnostics = json['diagnostics'];
+    if (rawDiagnostics is! List) {
+      return const <Diagnostic>[];
+    }
+    return rawDiagnostics
+        .whereType<Map>()
+        .map(
+          (entry) => Diagnostic.fromJson(
+            Map<String, dynamic>.from(entry),
+            defaultPath: path,
+          ),
+        )
+        .toList();
+  }
+
+  int get line => range.startLineOneBased;
+  int get column => range.start.character + 1;
+  int get endLine => range.endLineOneBased;
+  int get endColumn => range.end.character + 1;
+
   bool get isError => severity == 'error';
   bool get isWarning => severity == 'warning';
   bool get isInfo => severity == 'info';
+}
+
+String _severityToString(dynamic severity) {
+  if (severity is String) {
+    return severity.toLowerCase();
+  }
+  if (severity is num) {
+    switch (severity.toInt()) {
+      case 1:
+        return 'error';
+      case 2:
+        return 'warning';
+      case 3:
+        return 'info';
+      default:
+        return 'hint';
+    }
+  }
+  return 'info';
 }

--- a/app/lib/models/editor_models.dart
+++ b/app/lib/models/editor_models.dart
@@ -1,0 +1,533 @@
+import 'dart:convert';
+
+import 'editor_context.dart';
+
+class BridgeEventEnvelope {
+  final String type;
+  final dynamic payload;
+
+  const BridgeEventEnvelope({required this.type, required this.payload});
+
+  factory BridgeEventEnvelope.fromJson(Map<String, dynamic> json) {
+    return BridgeEventEnvelope(
+      type: json['type'] as String? ?? '',
+      payload: json['payload'],
+    );
+  }
+}
+
+class BridgeCapability {
+  final bool enabled;
+  final String? reason;
+  final Map<String, dynamic> raw;
+
+  const BridgeCapability({
+    required this.enabled,
+    required this.raw,
+    this.reason,
+  });
+
+  factory BridgeCapability.fromJson(dynamic json) {
+    if (json is bool) {
+      return BridgeCapability(enabled: json, raw: <String, dynamic>{});
+    }
+    if (json is Map<String, dynamic>) {
+      return BridgeCapability(
+        enabled: json['enabled'] as bool? ?? false,
+        reason: json['reason'] as String?,
+        raw: Map<String, dynamic>.from(json),
+      );
+    }
+    if (json is Map) {
+      return BridgeCapability.fromJson(Map<String, dynamic>.from(json));
+    }
+    return const BridgeCapability(enabled: false, raw: <String, dynamic>{});
+  }
+}
+
+class BridgeCapabilitiesDocument {
+  final String state;
+  final String protocolVersion;
+  final String bridgeVersion;
+  final String generation;
+  final Map<String, BridgeCapability> capabilities;
+
+  const BridgeCapabilitiesDocument({
+    required this.state,
+    required this.protocolVersion,
+    required this.bridgeVersion,
+    required this.generation,
+    required this.capabilities,
+  });
+
+  factory BridgeCapabilitiesDocument.fromJson(Map<String, dynamic> json) {
+    final rawCapabilities = json['capabilities'];
+    final capabilities = <String, BridgeCapability>{};
+    if (rawCapabilities is Map) {
+      for (final entry in rawCapabilities.entries) {
+        capabilities[entry.key.toString()] = BridgeCapability.fromJson(
+          entry.value,
+        );
+      }
+    }
+    return BridgeCapabilitiesDocument(
+      state: json['state'] as String? ?? '',
+      protocolVersion: json['protocolVersion'] as String? ?? '',
+      bridgeVersion: json['bridgeVersion'] as String? ?? '',
+      generation: json['generation'] as String? ?? '',
+      capabilities: capabilities,
+    );
+  }
+
+  bool isEnabled(String name, [Iterable<String> aliases = const <String>[]]) {
+    final candidates = <String>[name, ...aliases];
+    for (final candidate in candidates) {
+      final capability = capabilities[candidate];
+      if (capability != null) {
+        return capability.enabled;
+      }
+    }
+    return false;
+  }
+}
+
+class DocumentPosition {
+  final int line;
+  final int character;
+
+  const DocumentPosition({required this.line, required this.character});
+
+  factory DocumentPosition.fromJson(Map<String, dynamic> json) {
+    return DocumentPosition(
+      line: json['line'] as int? ?? 0,
+      character: json['character'] as int? ?? 0,
+    );
+  }
+
+  factory DocumentPosition.fromCursor(EditorCursor cursor) {
+    return DocumentPosition(
+      line: cursor.line > 0 ? cursor.line - 1 : 0,
+      character: cursor.column > 0 ? cursor.column - 1 : 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {'line': line, 'character': character};
+
+  EditorCursor toCursor() =>
+      EditorCursor(line: line + 1, column: character + 1);
+}
+
+class DocumentRange {
+  final DocumentPosition start;
+  final DocumentPosition end;
+
+  const DocumentRange({required this.start, required this.end});
+
+  factory DocumentRange.fromJson(Map<String, dynamic> json) {
+    return DocumentRange(
+      start: DocumentPosition.fromJson(
+        Map<String, dynamic>.from(
+          json['start'] as Map? ?? const <String, dynamic>{},
+        ),
+      ),
+      end: DocumentPosition.fromJson(
+        Map<String, dynamic>.from(
+          json['end'] as Map? ?? const <String, dynamic>{},
+        ),
+      ),
+    );
+  }
+
+  factory DocumentRange.fromSelection(EditorSelection selection) {
+    return DocumentRange(
+      start: DocumentPosition.fromCursor(selection.start),
+      end: DocumentPosition.fromCursor(selection.end),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'start': start.toJson(),
+    'end': end.toJson(),
+  };
+
+  EditorSelection toSelection() =>
+      EditorSelection(start: start.toCursor(), end: end.toCursor());
+
+  bool containsLine(int oneBasedLine) {
+    final zeroBased = oneBasedLine > 0 ? oneBasedLine - 1 : 0;
+    return zeroBased >= start.line && zeroBased <= end.line;
+  }
+
+  int get startLineOneBased => start.line + 1;
+  int get endLineOneBased => end.line + 1;
+}
+
+class DocumentChange {
+  final DocumentRange? range;
+  final String text;
+
+  const DocumentChange({required this.text, this.range});
+
+  const DocumentChange.fullReplacement(String content)
+    : text = content,
+      range = null;
+
+  Map<String, dynamic> toJson() => {
+    if (range != null) 'range': range!.toJson(),
+    'text': text,
+  };
+}
+
+class DocumentSnapshot {
+  final String path;
+  final int version;
+  final String content;
+
+  const DocumentSnapshot({
+    required this.path,
+    required this.version,
+    required this.content,
+  });
+
+  factory DocumentSnapshot.fromJson(Map<String, dynamic> json) {
+    return DocumentSnapshot(
+      path: json['path'] as String? ?? '',
+      version: json['version'] as int? ?? 0,
+      content: json['content'] as String? ?? '',
+    );
+  }
+}
+
+class EditorLocation {
+  final String uri;
+  final String path;
+  final DocumentRange range;
+
+  const EditorLocation({
+    required this.uri,
+    required this.path,
+    required this.range,
+  });
+
+  factory EditorLocation.fromJson(Map<String, dynamic> json) {
+    final uri = json['uri'] as String? ?? '';
+    final path = (json['path'] as String?) ?? _pathFromUri(uri);
+    return EditorLocation(
+      uri: uri,
+      path: path,
+      range: DocumentRange.fromJson(
+        Map<String, dynamic>.from(
+          json['range'] as Map? ?? const <String, dynamic>{},
+        ),
+      ),
+    );
+  }
+
+  String get label => '$path:${range.startLineOneBased}';
+}
+
+class EditorTextEdit {
+  final DocumentRange range;
+  final String newText;
+
+  const EditorTextEdit({required this.range, required this.newText});
+
+  factory EditorTextEdit.fromJson(Map<String, dynamic> json) {
+    final explicitRange = json['range'];
+    if (explicitRange is Map) {
+      return EditorTextEdit(
+        range: DocumentRange.fromJson(Map<String, dynamic>.from(explicitRange)),
+        newText: json['newText'] as String? ?? '',
+      );
+    }
+
+    final replace = json['replace'];
+    if (replace is Map) {
+      return EditorTextEdit(
+        range: DocumentRange.fromJson(Map<String, dynamic>.from(replace)),
+        newText: json['newText'] as String? ?? '',
+      );
+    }
+
+    final insert = json['insert'];
+    if (insert is Map) {
+      return EditorTextEdit(
+        range: DocumentRange.fromJson(Map<String, dynamic>.from(insert)),
+        newText: json['newText'] as String? ?? '',
+      );
+    }
+
+    return const EditorTextEdit(
+      range: DocumentRange(
+        start: DocumentPosition(line: 0, character: 0),
+        end: DocumentPosition(line: 0, character: 0),
+      ),
+      newText: '',
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'range': range.toJson(),
+    'newText': newText,
+  };
+}
+
+class EditorWorkspaceEdit {
+  final Map<String, List<EditorTextEdit>> changes;
+
+  const EditorWorkspaceEdit({required this.changes});
+
+  factory EditorWorkspaceEdit.fromJson(Map<String, dynamic> json) {
+    final changes = <String, List<EditorTextEdit>>{};
+    final rawChanges = json['changes'];
+    if (rawChanges is Map) {
+      for (final entry in rawChanges.entries) {
+        final edits = <EditorTextEdit>[];
+        if (entry.value is List) {
+          for (final edit in entry.value as List) {
+            if (edit is Map) {
+              edits.add(
+                EditorTextEdit.fromJson(Map<String, dynamic>.from(edit)),
+              );
+            }
+          }
+        }
+        changes[entry.key.toString()] = edits;
+      }
+    }
+
+    final rawDocumentChanges = json['documentChanges'];
+    if (rawDocumentChanges is List) {
+      for (final change in rawDocumentChanges) {
+        if (change is! Map) {
+          continue;
+        }
+        final map = Map<String, dynamic>.from(change);
+        final textDocument = map['textDocument'];
+        final edits = map['edits'];
+        final uri = textDocument is Map
+            ? (textDocument['uri'] as String? ?? '')
+            : '';
+        final path = _pathFromUri(uri);
+        if (path.isEmpty || edits is! List) {
+          continue;
+        }
+        final parsedEdits = changes.putIfAbsent(path, () => <EditorTextEdit>[]);
+        for (final edit in edits) {
+          if (edit is Map) {
+            parsedEdits.add(
+              EditorTextEdit.fromJson(Map<String, dynamic>.from(edit)),
+            );
+          }
+        }
+      }
+    }
+
+    return EditorWorkspaceEdit(changes: changes);
+  }
+
+  bool get isEmpty => changes.values.every((edits) => edits.isEmpty);
+}
+
+class EditorHover {
+  final dynamic contents;
+  final DocumentRange? range;
+
+  const EditorHover({required this.contents, this.range});
+
+  factory EditorHover.fromJson(Map<String, dynamic> json) {
+    final rawRange = json['range'];
+    return EditorHover(
+      contents: json['contents'],
+      range: rawRange is Map
+          ? DocumentRange.fromJson(Map<String, dynamic>.from(rawRange))
+          : null,
+    );
+  }
+
+  String get plainText => _stringifyMarkup(contents).trim();
+}
+
+class EditorCompletionList {
+  final bool isIncomplete;
+  final List<EditorCompletionItem> items;
+
+  const EditorCompletionList({required this.isIncomplete, required this.items});
+
+  factory EditorCompletionList.fromJson(Map<String, dynamic> json) {
+    final items = <EditorCompletionItem>[];
+    final rawItems = json['items'];
+    if (rawItems is List) {
+      for (final item in rawItems) {
+        if (item is Map) {
+          items.add(
+            EditorCompletionItem.fromJson(Map<String, dynamic>.from(item)),
+          );
+        }
+      }
+    }
+    return EditorCompletionList(
+      isIncomplete: json['isIncomplete'] as bool? ?? false,
+      items: items,
+    );
+  }
+}
+
+class EditorCompletionItem {
+  final String label;
+  final String detail;
+  final String? insertText;
+  final EditorTextEdit? textEdit;
+  final List<EditorTextEdit> additionalTextEdits;
+  final dynamic documentation;
+  final Map<String, dynamic> raw;
+
+  const EditorCompletionItem({
+    required this.label,
+    required this.detail,
+    required this.insertText,
+    required this.textEdit,
+    required this.additionalTextEdits,
+    required this.documentation,
+    required this.raw,
+  });
+
+  factory EditorCompletionItem.fromJson(Map<String, dynamic> json) {
+    final rawAdditional = json['additionalTextEdits'];
+    final additionalTextEdits = <EditorTextEdit>[];
+    if (rawAdditional is List) {
+      for (final edit in rawAdditional) {
+        if (edit is Map) {
+          additionalTextEdits.add(
+            EditorTextEdit.fromJson(Map<String, dynamic>.from(edit)),
+          );
+        }
+      }
+    }
+
+    EditorTextEdit? textEdit;
+    final rawTextEdit = json['textEdit'];
+    if (rawTextEdit is Map) {
+      textEdit = EditorTextEdit.fromJson(
+        Map<String, dynamic>.from(rawTextEdit),
+      );
+    }
+
+    final label = json['label'];
+    return EditorCompletionItem(
+      label: label is String ? label : jsonEncode(label),
+      detail: json['detail'] as String? ?? '',
+      insertText: json['insertText'] as String?,
+      textEdit: textEdit,
+      additionalTextEdits: additionalTextEdits,
+      documentation: json['documentation'],
+      raw: Map<String, dynamic>.from(json),
+    );
+  }
+
+  String get documentationText => _stringifyMarkup(documentation).trim();
+}
+
+class EditorCodeAction {
+  final String title;
+  final String kind;
+  final EditorWorkspaceEdit? edit;
+  final Map<String, dynamic> raw;
+
+  const EditorCodeAction({
+    required this.title,
+    required this.kind,
+    required this.raw,
+    this.edit,
+  });
+
+  factory EditorCodeAction.fromJson(Map<String, dynamic> json) {
+    final rawEdit = json['edit'];
+    return EditorCodeAction(
+      title: json['title'] as String? ?? 'Untitled action',
+      kind: json['kind'] as String? ?? '',
+      edit: rawEdit is Map
+          ? EditorWorkspaceEdit.fromJson(Map<String, dynamic>.from(rawEdit))
+          : null,
+      raw: Map<String, dynamic>.from(json),
+    );
+  }
+
+  bool get isQuickFix => kind == 'quickfix' || kind.startsWith('quickfix.');
+}
+
+class EditorSignatureHelp {
+  final List<String> signatures;
+  final int activeSignature;
+  final int activeParameter;
+
+  const EditorSignatureHelp({
+    required this.signatures,
+    required this.activeSignature,
+    required this.activeParameter,
+  });
+
+  factory EditorSignatureHelp.fromJson(Map<String, dynamic> json) {
+    final signatures = <String>[];
+    final rawSignatures = json['signatures'];
+    if (rawSignatures is List) {
+      for (final signature in rawSignatures) {
+        if (signature is Map) {
+          final label = signature['label'] as String?;
+          if (label != null && label.isNotEmpty) {
+            signatures.add(label);
+          }
+        } else if (signature is String && signature.isNotEmpty) {
+          signatures.add(signature);
+        }
+      }
+    }
+    return EditorSignatureHelp(
+      signatures: signatures,
+      activeSignature: json['activeSignature'] as int? ?? 0,
+      activeParameter: json['activeParameter'] as int? ?? 0,
+    );
+  }
+
+  String? get activeLabel {
+    if (signatures.isEmpty) {
+      return null;
+    }
+    final index = activeSignature.clamp(0, signatures.length - 1);
+    return signatures[index];
+  }
+}
+
+String _pathFromUri(String uri) {
+  if (uri.isEmpty) {
+    return '';
+  }
+  try {
+    return Uri.parse(uri).path;
+  } catch (_) {
+    return uri;
+  }
+}
+
+String _stringifyMarkup(dynamic value) {
+  if (value == null) {
+    return '';
+  }
+  if (value is String) {
+    return value;
+  }
+  if (value is List) {
+    return value
+        .map(_stringifyMarkup)
+        .where((part) => part.isNotEmpty)
+        .join('\n\n');
+  }
+  if (value is Map) {
+    final map = Map<String, dynamic>.from(value);
+    final preferred = map['value'] ?? map['language'] ?? map['kind'];
+    if (preferred is String && preferred.isNotEmpty) {
+      return preferred;
+    }
+  }
+  return value.toString();
+}

--- a/app/lib/navigation/editor_navigation.dart
+++ b/app/lib/navigation/editor_navigation.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/chat_message.dart';
+import '../models/editor_context.dart';
+import '../models/editor_models.dart';
+import '../providers/editor_provider.dart';
+import '../screens/code_screen.dart';
+
+Future<void> openCodePath(
+  BuildContext context, {
+  required String path,
+  EditorSelection? selection,
+  EditorCursor? cursor,
+  int? line,
+  int? offset,
+  int? limit,
+}) async {
+  final editorProvider = context.read<EditorProvider>();
+  await editorProvider.openFileAt(
+    path,
+    selection: selection,
+    cursor: cursor,
+    line: line,
+    offset: offset,
+    limit: limit,
+  );
+
+  if (!context.mounted) {
+    return;
+  }
+
+  await Navigator.of(context).push(
+    MaterialPageRoute<void>(
+      builder: (_) => ChangeNotifierProvider.value(
+        value: editorProvider,
+        child: const CodeScreen(),
+      ),
+    ),
+  );
+}
+
+Future<void> openCodeLocation(BuildContext context, EditorLocation location) {
+  return openCodePath(
+    context,
+    path: location.path,
+    selection: location.range.toSelection(),
+    cursor: location.range.start.toCursor(),
+  );
+}
+
+Future<void> openCodeAnnotation(
+  BuildContext context, {
+  required String path,
+  FileAnnotation? annotation,
+}) {
+  return openCodePath(
+    context,
+    path: path,
+    offset: annotation?.offset,
+    limit: annotation?.limit,
+  );
+}

--- a/app/lib/providers/editor_provider.dart
+++ b/app/lib/providers/editor_provider.dart
@@ -1,44 +1,88 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
 import '../models/diagnostic.dart';
 import '../models/editor_context.dart';
+import '../models/editor_models.dart';
+import '../models/chat_message.dart';
 import '../services/api_client.dart';
+import '../services/editor_api_client.dart';
 
-/// Represents an open file with its content and edit state.
 class OpenFile {
   final String path;
   final String name;
   String originalContent;
   String currentContent;
+  int version;
   bool isEditing;
+  bool bridgeTracking;
+  EditorCursor cursor;
+  EditorSelection? selection;
+  EditorSelection? revealSelection;
+  int revealNonce;
+  List<Diagnostic> diagnostics;
 
   OpenFile({
     required this.path,
     required this.name,
     required this.originalContent,
-    String? currentContent,
+    required this.currentContent,
+    required this.version,
     this.isEditing = false,
-  }) : currentContent = currentContent ?? originalContent;
+    this.bridgeTracking = false,
+    EditorCursor? cursor,
+    this.selection,
+    this.revealSelection,
+    this.revealNonce = 0,
+    List<Diagnostic>? diagnostics,
+  }) : cursor = cursor ?? const EditorCursor(line: 1, column: 1),
+       diagnostics = diagnostics ?? <Diagnostic>[];
 
   bool get hasUnsavedChanges => currentContent != originalContent;
 }
 
-class EditorProvider extends ChangeNotifier {
-  final ApiClient apiClient;
+class EditorJumpLocation {
+  final String path;
+  final EditorSelection? selection;
+  final EditorCursor? cursor;
 
-  final List<OpenFile> _openFiles = [];
+  const EditorJumpLocation({required this.path, this.selection, this.cursor});
+}
+
+class EditorProvider extends ChangeNotifier {
+  EditorProvider({required this.apiClient, required this.editorApiClient}) {
+    unawaited(refreshCapabilities());
+    _connectEvents();
+  }
+
+  final ApiClient apiClient;
+  final EditorApiClient editorApiClient;
+
+  final List<OpenFile> _openFiles = <OpenFile>[];
+  final List<EditorJumpLocation> _jumpHistory = <EditorJumpLocation>[];
+  final Set<String> _syncingPaths = <String>{};
+  final Map<String, String> _pendingContentSync = <String, String>{};
+  final Map<String, Completer<void>> _syncCompleters =
+      <String, Completer<void>>{};
+
+  WebSocketChannel? _eventsChannel;
+  StreamSubscription<dynamic>? _eventsSubscription;
+  Future<void> _eventsTeardown = Future<void>.value();
+  BridgeCapabilitiesDocument? _capabilities;
   int _currentFileIndex = -1;
-  EditorCursor? _cursor;
-  EditorSelection? _selection;
   bool _isLoading = false;
   String? _error;
-
-  // Diagnostics for the current file.
-  List<Diagnostic> _diagnostics = [];
-  List<Diagnostic> get diagnostics => List.unmodifiable(_diagnostics);
   bool _isLoadingDiagnostics = false;
-  bool get isLoadingDiagnostics => _isLoadingDiagnostics;
-
-  EditorProvider({required this.apiClient});
+  bool _isLoadingCompletions = false;
+  EditorHover? _hover;
+  EditorSignatureHelp? _signatureHelp;
+  List<EditorCompletionItem> _completionItems = <EditorCompletionItem>[];
+  List<EditorLocation> _lastLocations = <EditorLocation>[];
+  String _lastLocationLabel = 'Locations';
+  bool _isDisposed = false;
 
   List<OpenFile> get openFiles => List.unmodifiable(_openFiles);
   OpenFile? get currentFile =>
@@ -46,23 +90,127 @@ class EditorProvider extends ChangeNotifier {
       ? _openFiles[_currentFileIndex]
       : null;
   int get currentFileIndex => _currentFileIndex;
-  EditorCursor? get cursor => _cursor;
-  EditorSelection? get selection => _selection;
   bool get isLoading => _isLoading;
   String? get error => _error;
+  bool get isLoadingDiagnostics => _isLoadingDiagnostics;
+  bool get isLoadingCompletions => _isLoadingCompletions;
+  List<Diagnostic> get diagnostics =>
+      List.unmodifiable(currentFile?.diagnostics ?? const <Diagnostic>[]);
+  List<Diagnostic> get allDiagnostics =>
+      _openFiles.expand((file) => file.diagnostics).toList(growable: false);
+  EditorCursor? get cursor => currentFile?.cursor;
+  EditorSelection? get selection => currentFile?.selection;
+  EditorSelection? get revealSelection => currentFile?.revealSelection;
+  int get revealNonce => currentFile?.revealNonce ?? 0;
+  BridgeCapabilitiesDocument? get capabilities => _capabilities;
+  EditorHover? get hover => _hover;
+  EditorSignatureHelp? get signatureHelp => _signatureHelp;
+  List<EditorCompletionItem> get completionItems =>
+      List.unmodifiable(_completionItems);
+  List<EditorLocation> get lastLocations => List.unmodifiable(_lastLocations);
+  String get lastLocationLabel => _lastLocationLabel;
+  bool get canJumpBack => _jumpHistory.isNotEmpty;
+  bool get hasUnsavedChanges =>
+      _openFiles.any((file) => file.hasUnsavedChanges);
+
   EditorChatContext get chatContext => EditorChatContext(
     activeFile: currentFile?.path,
-    cursor: _cursor,
-    selection: _selection,
+    cursor: currentFile?.cursor,
+    selection: currentFile?.selection,
   );
 
-  /// Open a file by path. If already open, switch to it.
-  Future<void> openFile(String path) async {
-    final existingIndex = _openFiles.indexWhere((f) => f.path == path);
+  bool capabilityEnabled(
+    String name, [
+    Iterable<String> aliases = const <String>[],
+  ]) {
+    final capabilities = _capabilities;
+    if (capabilities == null) {
+      return false;
+    }
+    return capabilities.isEnabled(name, aliases);
+  }
+
+  String? capabilityReason(
+    String name, [
+    Iterable<String> aliases = const <String>[],
+  ]) {
+    final capabilities = _capabilities;
+    if (capabilities == null) {
+      return null;
+    }
+    for (final candidate in <String>[name, ...aliases]) {
+      final capability = capabilities.capabilities[candidate];
+      if (capability != null &&
+          capability.reason != null &&
+          capability.reason!.isNotEmpty) {
+        return capability.reason;
+      }
+    }
+    return null;
+  }
+
+  String unavailableMessage(String feature) {
+    final capabilities = _capabilities;
+    if (capabilities == null) {
+      return 'Editor bridge is not ready for $feature.';
+    }
+    final normalized = feature
+        .toLowerCase()
+        .replaceAll(' ', '')
+        .replaceAll('-', '');
+    return capabilityReason(normalized) ??
+        '$feature is unavailable for the current bridge session.';
+  }
+
+  void clearError() {
+    if (_error == null) {
+      return;
+    }
+    _error = null;
+    notifyListeners();
+  }
+
+  Future<void> refreshCapabilities() async {
+    try {
+      _capabilities = await editorApiClient.getCapabilities();
+      _error = null;
+    } catch (error) {
+      _capabilities = null;
+      _error = error.toString();
+    }
+    notifyListeners();
+  }
+
+  Future<void> openFile(String path) => openFileAt(path);
+
+  Future<void> openFileAt(
+    String path, {
+    EditorSelection? selection,
+    EditorCursor? cursor,
+    int? line,
+    int? offset,
+    int? limit,
+    bool recordJump = true,
+  }) async {
+    if (recordJump) {
+      _recordCurrentLocation();
+    }
+
+    final existingIndex = _openFiles.indexWhere((file) => file.path == path);
     if (existingIndex >= 0) {
       _currentFileIndex = existingIndex;
-      _resetContextForCurrentFile();
+      final file = _openFiles[existingIndex];
+      _applyReveal(
+        file,
+        selection: selection,
+        cursor: cursor,
+        line: line,
+        offset: offset,
+        limit: limit,
+      );
+      _clearTransientUi();
       notifyListeners();
+      unawaited(loadDiagnostics());
       return;
     }
 
@@ -72,135 +220,226 @@ class EditorProvider extends ChangeNotifier {
 
     try {
       final content = await apiClient.readFile(path);
-      final name = path.split('/').last;
-      final file = OpenFile(path: path, name: name, originalContent: content);
+      var version = 1;
+      var bridgeTracking = false;
+      try {
+        final snapshot = await editorApiClient.openDocument(
+          path: path,
+          version: 1,
+          content: content,
+        );
+        version = snapshot.version;
+        bridgeTracking = true;
+      } catch (_) {
+        // Keep local editing available even when the bridge is not ready.
+      }
+
+      final file = OpenFile(
+        path: path,
+        name: path.split('/').last,
+        originalContent: content,
+        currentContent: content,
+        version: version,
+        bridgeTracking: bridgeTracking,
+      );
       _openFiles.add(file);
       _currentFileIndex = _openFiles.length - 1;
-      _resetContextForCurrentFile();
-      loadDiagnostics();
-    } catch (e) {
-      _error = e.toString();
+      _applyReveal(
+        file,
+        selection: selection,
+        cursor: cursor,
+        line: line,
+        offset: offset,
+        limit: limit,
+      );
+      _clearTransientUi();
+      unawaited(loadDiagnostics());
+    } catch (error) {
+      _error = error.toString();
     } finally {
       _isLoading = false;
       notifyListeners();
     }
   }
 
-  void closeFile(int index) {
-    if (index < 0 || index >= _openFiles.length) return;
+  Future<bool> closeFile(int index) async {
+    if (index < 0 || index >= _openFiles.length) {
+      return false;
+    }
+
+    final file = _openFiles[index];
+    _pendingContentSync.remove(file.path);
+    await _flushDocument(file.path);
+    if (file.bridgeTracking) {
+      try {
+        await editorApiClient.closeDocument(file.path);
+      } catch (_) {
+        // Closing the local UI should still succeed if the bridge session vanished.
+      }
+    }
+
     _openFiles.removeAt(index);
     if (_currentFileIndex >= _openFiles.length) {
       _currentFileIndex = _openFiles.length - 1;
+    } else if (_currentFileIndex > index) {
+      _currentFileIndex -= 1;
     }
-    _resetContextForCurrentFile();
+    _clearTransientUi();
     notifyListeners();
+    return true;
   }
 
   void switchToFile(int index) {
-    if (index >= 0 && index < _openFiles.length) {
-      _currentFileIndex = index;
-      _resetContextForCurrentFile();
-      notifyListeners();
+    if (index < 0 || index >= _openFiles.length) {
+      return;
     }
+    _currentFileIndex = index;
+    _clearTransientUi();
+    notifyListeners();
+    unawaited(loadDiagnostics());
   }
 
   void toggleEditMode() {
     final file = currentFile;
-    if (file == null) return;
+    if (file == null) {
+      return;
+    }
     file.isEditing = !file.isEditing;
     notifyListeners();
   }
 
   void enterEditMode() {
     final file = currentFile;
-    if (file == null) return;
+    if (file == null) {
+      return;
+    }
     file.isEditing = true;
     notifyListeners();
   }
 
   void exitEditMode() {
     final file = currentFile;
-    if (file == null) return;
+    if (file == null) {
+      return;
+    }
     file.isEditing = false;
     notifyListeners();
   }
 
   void updateContent(String content) {
     final file = currentFile;
-    if (file == null) return;
+    if (file == null || content == file.currentContent) {
+      return;
+    }
+
+    final previousContent = file.currentContent;
     file.currentContent = content;
+    _queueDocumentSync(file.path, content);
     notifyListeners();
+
+    final insertedCharacter = _detectSingleInsertedCharacter(
+      previousContent,
+      content,
+    );
+    if (insertedCharacter == '.') {
+      unawaited(requestCompletion());
+    }
+    if (insertedCharacter == '(' || insertedCharacter == ',') {
+      unawaited(requestSignatureHelp());
+    }
   }
 
   void updateCursor(EditorCursor? cursor) {
-    _cursor = cursor;
-    if (cursor == null) {
-      _selection = null;
+    final file = currentFile;
+    if (file == null || cursor == null) {
+      return;
+    }
+    file.cursor = cursor;
+    if (file.selection?.isCollapsed ?? false) {
+      file.selection = null;
     }
     notifyListeners();
   }
 
   void updateSelection(EditorSelection? selection, {EditorCursor? cursor}) {
-    _selection = selection;
+    final file = currentFile;
+    if (file == null) {
+      return;
+    }
+    file.selection = selection;
     if (cursor != null) {
-      _cursor = cursor;
+      file.cursor = cursor;
     }
     notifyListeners();
   }
 
   void clearSelection() {
-    _selection = null;
+    final file = currentFile;
+    if (file == null) {
+      return;
+    }
+    file.selection = null;
     notifyListeners();
   }
 
-  /// Save the current file to the server.
   Future<bool> saveCurrentFile() async {
     final file = currentFile;
-    if (file == null) return false;
+    if (file == null) {
+      return false;
+    }
 
     _isLoading = true;
     _error = null;
     notifyListeners();
 
     try {
-      await apiClient.writeFile(file.path, file.currentContent);
+      await _flushDocument(file.path);
+      if (file.bridgeTracking) {
+        final snapshot = await editorApiClient.saveDocument(file.path);
+        file.version = snapshot.version;
+      } else {
+        await apiClient.writeFile(file.path, file.currentContent);
+      }
       file.originalContent = file.currentContent;
-      _isLoading = false;
-      notifyListeners();
-      loadDiagnostics(); // Refresh diagnostics after save.
+      await loadDiagnostics();
       return true;
-    } catch (e) {
-      _error = e.toString();
+    } catch (error) {
+      _error = error.toString();
+      return false;
+    } finally {
       _isLoading = false;
       notifyListeners();
-      return false;
     }
   }
 
-  bool get hasUnsavedChanges => _openFiles.any((f) => f.hasUnsavedChanges);
-
-  /// Load diagnostics for the current file.
   Future<void> loadDiagnostics() async {
     final file = currentFile;
-    if (file == null) return;
+    if (file == null) {
+      return;
+    }
 
     _isLoadingDiagnostics = true;
     notifyListeners();
 
     try {
-      final workDir = _extractWorkDir(file.path);
-      final allDiags = await apiClient.getDiagnostics(
-        filePath: file.path,
-        workDir: workDir,
-      );
-      // Filter to only diagnostics for the current file.
-      _diagnostics = allDiags
-          .where(
-            (d) => file.path.endsWith(d.filePath) || d.filePath == file.path,
-          )
-          .toList();
-    } catch (_) {
-      _diagnostics = [];
+      if (file.bridgeTracking && capabilityEnabled('diagnostics')) {
+        await _flushDocument(file.path);
+        file.diagnostics = await editorApiClient.diagnostics(
+          path: file.path,
+          version: file.version,
+          workDir: _extractWorkDir(file.path),
+        );
+      } else {
+        final legacy = await apiClient.getDiagnostics(
+          filePath: file.path,
+          workDir: _extractWorkDir(file.path),
+        );
+        file.diagnostics = legacy;
+      }
+      _error = null;
+    } catch (error) {
+      _error = error.toString();
+      file.diagnostics = <Diagnostic>[];
     } finally {
       _isLoadingDiagnostics = false;
       notifyListeners();
@@ -208,25 +447,768 @@ class EditorProvider extends ChangeNotifier {
   }
 
   List<Diagnostic> diagnosticsForLine(int line) {
-    return _diagnostics.where((d) => d.line == line).toList();
+    return diagnostics
+        .where((diagnostic) => diagnostic.range.containsLine(line))
+        .toList();
+  }
+
+  Future<List<EditorCompletionItem>> requestCompletion() async {
+    final file = currentFile;
+    if (file == null) {
+      return const <EditorCompletionItem>[];
+    }
+    if (!file.bridgeTracking || !capabilityEnabled('completion')) {
+      _error = unavailableMessage('Completion');
+      _completionItems = <EditorCompletionItem>[];
+      notifyListeners();
+      return const <EditorCompletionItem>[];
+    }
+
+    _isLoadingCompletions = true;
+    notifyListeners();
+    try {
+      await _flushDocument(file.path);
+      final result = await editorApiClient.completion(
+        path: file.path,
+        version: file.version,
+        position: DocumentPosition.fromCursor(file.cursor),
+        workDir: _extractWorkDir(file.path),
+      );
+      _completionItems = result.items;
+      return _completionItems;
+    } catch (error) {
+      _error = error.toString();
+      _completionItems = <EditorCompletionItem>[];
+      return const <EditorCompletionItem>[];
+    } finally {
+      _isLoadingCompletions = false;
+      notifyListeners();
+    }
+  }
+
+  void clearCompletionItems() {
+    if (_completionItems.isEmpty) {
+      return;
+    }
+    _completionItems = <EditorCompletionItem>[];
+    notifyListeners();
+  }
+
+  Future<bool> applyCompletionItem(EditorCompletionItem item) async {
+    final file = currentFile;
+    if (file == null) {
+      return false;
+    }
+
+    final edits = <EditorTextEdit>[
+      if (item.textEdit != null) item.textEdit!,
+      ...item.additionalTextEdits,
+    ];
+
+    if (edits.isEmpty) {
+      edits.add(
+        EditorTextEdit(
+          range: DocumentRange(
+            start: DocumentPosition.fromCursor(file.cursor),
+            end: DocumentPosition.fromCursor(file.cursor),
+          ),
+          newText: item.insertText ?? item.label,
+        ),
+      );
+    }
+
+    final applied = await applyTextEdits(file.path, edits, recordJump: false);
+    if (applied) {
+      _completionItems = <EditorCompletionItem>[];
+      await requestSignatureHelp();
+      notifyListeners();
+    }
+    return applied;
+  }
+
+  Future<EditorHover?> requestHover() async {
+    final file = currentFile;
+    if (file == null) {
+      return null;
+    }
+    if (!file.bridgeTracking || !capabilityEnabled('hover')) {
+      _error = unavailableMessage('Hover');
+      notifyListeners();
+      return null;
+    }
+
+    try {
+      await _flushDocument(file.path);
+      _hover = await editorApiClient.hover(
+        path: file.path,
+        version: file.version,
+        position: DocumentPosition.fromCursor(file.cursor),
+        workDir: _extractWorkDir(file.path),
+      );
+      notifyListeners();
+      return _hover;
+    } catch (error) {
+      _error = error.toString();
+      notifyListeners();
+      return null;
+    }
+  }
+
+  void clearHover() {
+    if (_hover == null) {
+      return;
+    }
+    _hover = null;
+    notifyListeners();
+  }
+
+  Future<EditorSignatureHelp?> requestSignatureHelp() async {
+    final file = currentFile;
+    if (file == null) {
+      return null;
+    }
+    if (!file.bridgeTracking ||
+        !capabilityEnabled('signatureHelp', <String>['signature-help'])) {
+      _signatureHelp = null;
+      notifyListeners();
+      return null;
+    }
+
+    try {
+      await _flushDocument(file.path);
+      _signatureHelp = await editorApiClient.signatureHelp(
+        path: file.path,
+        version: file.version,
+        position: DocumentPosition.fromCursor(file.cursor),
+        workDir: _extractWorkDir(file.path),
+      );
+    } catch (error) {
+      _error = error.toString();
+      _signatureHelp = null;
+    }
+    notifyListeners();
+    return _signatureHelp;
+  }
+
+  Future<List<EditorLocation>> requestDefinition() async {
+    return _requestLocations(
+      label: 'Definitions',
+      capability: 'definition',
+      request: (file) => editorApiClient.definition(
+        path: file.path,
+        version: file.version,
+        position: DocumentPosition.fromCursor(file.cursor),
+        workDir: _extractWorkDir(file.path),
+      ),
+    );
+  }
+
+  Future<List<EditorLocation>> requestReferences() async {
+    return _requestLocations(
+      label: 'References',
+      capability: 'references',
+      request: (file) => editorApiClient.references(
+        path: file.path,
+        version: file.version,
+        position: DocumentPosition.fromCursor(file.cursor),
+        workDir: _extractWorkDir(file.path),
+      ),
+    );
+  }
+
+  Future<bool> jumpBack() async {
+    if (_jumpHistory.isEmpty) {
+      return false;
+    }
+    final target = _jumpHistory.removeLast();
+    await openFileAt(
+      target.path,
+      selection: target.selection,
+      cursor: target.cursor,
+      recordJump: false,
+    );
+    return true;
+  }
+
+  Future<bool> formatCurrentFile() async {
+    final file = currentFile;
+    if (file == null) {
+      return false;
+    }
+    if (!file.bridgeTracking || !capabilityEnabled('formatting')) {
+      _error = unavailableMessage('Formatting');
+      notifyListeners();
+      return false;
+    }
+    try {
+      await _flushDocument(file.path);
+      final edits = await editorApiClient.formatting(
+        path: file.path,
+        version: file.version,
+        workDir: _extractWorkDir(file.path),
+      );
+      return applyTextEdits(file.path, edits, recordJump: false);
+    } catch (error) {
+      _error = error.toString();
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<List<EditorCodeAction>> loadCodeActions({
+    bool quickFixOnly = false,
+  }) async {
+    final file = currentFile;
+    if (file == null) {
+      return const <EditorCodeAction>[];
+    }
+    if (!file.bridgeTracking ||
+        !capabilityEnabled('codeActions', <String>['code-actions'])) {
+      _error = unavailableMessage('Code actions');
+      notifyListeners();
+      return const <EditorCodeAction>[];
+    }
+
+    final effectiveSelection =
+        file.selection ?? EditorSelection(start: file.cursor, end: file.cursor);
+
+    try {
+      await _flushDocument(file.path);
+      final actions = await editorApiClient.codeActions(
+        path: file.path,
+        version: file.version,
+        range: DocumentRange.fromSelection(effectiveSelection),
+        workDir: _extractWorkDir(file.path),
+      );
+      if (quickFixOnly) {
+        return actions.where((action) => action.isQuickFix).toList();
+      }
+      return actions;
+    } catch (error) {
+      _error = error.toString();
+      notifyListeners();
+      return const <EditorCodeAction>[];
+    }
+  }
+
+  Future<bool> applyCodeAction(EditorCodeAction action) async {
+    final edit = action.edit;
+    if (edit == null || edit.isEmpty) {
+      return false;
+    }
+    return applyWorkspaceEdit(edit, recordJump: false);
+  }
+
+  Future<bool> renameSymbol(String newName) async {
+    final file = currentFile;
+    if (file == null) {
+      return false;
+    }
+    if (!file.bridgeTracking || !capabilityEnabled('rename')) {
+      _error = unavailableMessage('Rename');
+      notifyListeners();
+      return false;
+    }
+    try {
+      await _flushDocument(file.path);
+      final edit = await editorApiClient.rename(
+        path: file.path,
+        version: file.version,
+        position: DocumentPosition.fromCursor(file.cursor),
+        workDir: _extractWorkDir(file.path),
+        newName: newName,
+      );
+      return applyWorkspaceEdit(edit, recordJump: false);
+    } catch (error) {
+      _error = error.toString();
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<bool> applyWorkspaceEdit(
+    EditorWorkspaceEdit edit, {
+    bool recordJump = true,
+  }) async {
+    var success = true;
+    for (final entry in edit.changes.entries) {
+      final applied = await applyTextEdits(
+        entry.key,
+        entry.value,
+        recordJump: recordJump,
+      );
+      success = success && applied;
+    }
+    return success;
+  }
+
+  Future<bool> applyTextEdits(
+    String path,
+    List<EditorTextEdit> edits, {
+    bool recordJump = true,
+  }) async {
+    if (edits.isEmpty) {
+      return true;
+    }
+
+    await openFileAt(path, recordJump: recordJump);
+    final file = currentFile;
+    if (file == null || file.path != path) {
+      return false;
+    }
+
+    try {
+      final updated = _applyTextEditsToContent(file.currentContent, edits);
+      updateContent(updated);
+      final focusSelection = edits.last.range.toSelection();
+      updateSelection(focusSelection, cursor: focusSelection.end);
+      file.revealSelection = focusSelection;
+      file.revealNonce += 1;
+      notifyListeners();
+      return true;
+    } catch (error) {
+      _error = error.toString();
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<void> openAnnotation(String path, FileAnnotation? annotation) async {
+    await openFileAt(
+      path,
+      offset: annotation?.offset,
+      limit: annotation?.limit,
+      recordJump: true,
+    );
+  }
+
+  Future<void> openLocation(EditorLocation location, {bool recordJump = true}) {
+    return openFileAt(
+      location.path,
+      selection: location.range.toSelection(),
+      cursor: location.range.start.toCursor(),
+      recordJump: recordJump,
+    );
+  }
+
+  Future<void> openDiagnostic(Diagnostic diagnostic, {bool recordJump = true}) {
+    return openFileAt(
+      diagnostic.filePath,
+      selection: diagnostic.range.toSelection(),
+      cursor: diagnostic.range.start.toCursor(),
+      recordJump: recordJump,
+    );
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    unawaited(_disconnectEvents());
+    super.dispose();
+  }
+
+  Future<List<EditorLocation>> _requestLocations({
+    required String label,
+    required String capability,
+    required Future<List<EditorLocation>> Function(OpenFile file) request,
+  }) async {
+    final file = currentFile;
+    if (file == null) {
+      return const <EditorLocation>[];
+    }
+    if (!file.bridgeTracking || !capabilityEnabled(capability)) {
+      _error = unavailableMessage(label);
+      notifyListeners();
+      return const <EditorLocation>[];
+    }
+
+    try {
+      await _flushDocument(file.path);
+      _lastLocations = await request(file);
+      _lastLocationLabel = label;
+    } catch (error) {
+      _error = error.toString();
+      _lastLocations = <EditorLocation>[];
+    }
+    notifyListeners();
+    return _lastLocations;
+  }
+
+  void _recordCurrentLocation() {
+    final file = currentFile;
+    if (file == null) {
+      return;
+    }
+    _jumpHistory.add(
+      EditorJumpLocation(
+        path: file.path,
+        selection: file.selection,
+        cursor: file.cursor,
+      ),
+    );
+  }
+
+  void _clearTransientUi() {
+    _completionItems = <EditorCompletionItem>[];
+    _hover = null;
+    _signatureHelp = null;
+    _lastLocations = <EditorLocation>[];
+    _lastLocationLabel = 'Locations';
+  }
+
+  void _connectEvents() {
+    unawaited(_reconnectEvents());
+  }
+
+  void _onBridgeEvent(dynamic raw) {
+    if (_isDisposed || raw is! String) {
+      return;
+    }
+    unawaited(_handleBridgeEvent(raw));
+  }
+
+  Future<void> _handleBridgeEvent(String raw) async {
+    if (_isDisposed) {
+      return;
+    }
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) {
+        return;
+      }
+      final event = BridgeEventEnvelope.fromJson(decoded);
+      if (event.type == 'bridge/ready' || event.type == 'bridge/restarted') {
+        await refreshCapabilities();
+        await _reopenBridgeDocuments();
+        return;
+      }
+      if (event.type != 'bridge/editor/diagnosticsChanged' &&
+          event.type != 'bridge/diagnosticsChanged') {
+        return;
+      }
+      final payload = event.payload;
+      if (payload is! Map) {
+        return;
+      }
+      final report = Map<String, dynamic>.from(payload);
+      final path = report['path'] as String? ?? '';
+      OpenFile? file;
+      for (final candidate in _openFiles) {
+        if (candidate.path == path) {
+          file = candidate;
+          break;
+        }
+      }
+      if (file == null) {
+        return;
+      }
+      file.diagnostics = Diagnostic.listFromReportJson(report);
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    } catch (_) {
+      // Ignore malformed bridge events.
+    }
+  }
+
+  Future<void> _reconnectEvents() async {
+    await _disconnectEvents();
+    if (_isDisposed) {
+      return;
+    }
+    try {
+      final channel = editorApiClient.connectEventsWebSocket();
+      if (_isDisposed) {
+        await channel.sink.close();
+        return;
+      }
+      _eventsChannel = channel;
+      _eventsSubscription = channel.stream.listen(
+        _onBridgeEvent,
+        onError: (_) {},
+        onDone: () {},
+      );
+    } catch (_) {
+      _eventsChannel = null;
+      _eventsSubscription = null;
+    }
+  }
+
+  Future<void> _disconnectEvents() {
+    _eventsTeardown = _eventsTeardown.then((_) async {
+      final subscription = _eventsSubscription;
+      final channel = _eventsChannel;
+      _eventsSubscription = null;
+      _eventsChannel = null;
+
+      if (subscription != null) {
+        try {
+          await subscription.cancel();
+        } catch (_) {
+          // Best-effort teardown; reconnection will self-heal.
+        }
+      }
+      if (channel != null) {
+        try {
+          await channel.sink.close();
+        } catch (_) {
+          // The socket may already be closing; ignore teardown races.
+        }
+      }
+    });
+    return _eventsTeardown;
+  }
+
+  Future<void> _reopenBridgeDocuments() async {
+    for (final file in _openFiles) {
+      try {
+        final snapshot = await editorApiClient.openDocument(
+          path: file.path,
+          version: 1,
+          content: file.currentContent,
+        );
+        file.version = snapshot.version;
+        file.bridgeTracking = true;
+      } catch (_) {
+        file.bridgeTracking = false;
+      }
+    }
+    if (currentFile != null) {
+      await loadDiagnostics();
+    } else {
+      notifyListeners();
+    }
+  }
+
+  void _queueDocumentSync(String path, String content) {
+    final file = _fileForPath(path);
+    if (file == null || !file.bridgeTracking) {
+      return;
+    }
+    _pendingContentSync[path] = content;
+    _syncCompleters.putIfAbsent(path, Completer<void>.new);
+    if (_syncingPaths.contains(path)) {
+      return;
+    }
+    unawaited(_drainDocumentSync(path));
+  }
+
+  Future<void> _drainDocumentSync(String path) async {
+    final file = _fileForPath(path);
+    if (file == null) {
+      _completeSync(path);
+      return;
+    }
+
+    _syncingPaths.add(path);
+    try {
+      while (true) {
+        final pending = _pendingContentSync.remove(path);
+        if (pending == null) {
+          break;
+        }
+        final nextVersion = file.version + 1;
+        try {
+          final snapshot = await editorApiClient.changeDocument(
+            path: path,
+            version: nextVersion,
+            changes: <DocumentChange>[DocumentChange.fullReplacement(pending)],
+          );
+          file.version = snapshot.version;
+        } catch (error) {
+          _error = error.toString();
+          break;
+        }
+      }
+    } finally {
+      _syncingPaths.remove(path);
+      _completeSync(path);
+      notifyListeners();
+    }
+  }
+
+  Future<void> _flushDocument(String path) async {
+    final pending = _syncCompleters[path];
+    if (pending == null) {
+      return;
+    }
+    if (!_pendingContentSync.containsKey(path) &&
+        !_syncingPaths.contains(path)) {
+      _completeSync(path);
+      return;
+    }
+    await pending.future;
+  }
+
+  void _completeSync(String path) {
+    final completer = _syncCompleters.remove(path);
+    if (completer != null && !completer.isCompleted) {
+      completer.complete();
+    }
+  }
+
+  OpenFile? _fileForPath(String path) {
+    for (final file in _openFiles) {
+      if (file.path == path) {
+        return file;
+      }
+    }
+    return null;
+  }
+
+  void _applyReveal(
+    OpenFile file, {
+    EditorSelection? selection,
+    EditorCursor? cursor,
+    int? line,
+    int? offset,
+    int? limit,
+  }) {
+    var effectiveSelection = selection;
+    var effectiveCursor = cursor;
+
+    if (effectiveSelection == null && line != null) {
+      final collapsed = EditorCursor(line: line, column: 1);
+      effectiveSelection = EditorSelection(start: collapsed, end: collapsed);
+      effectiveCursor = collapsed;
+    }
+
+    if (effectiveSelection == null && offset != null) {
+      effectiveSelection = _selectionFromOffset(
+        file.currentContent,
+        offset,
+        limit: limit,
+      );
+      effectiveCursor = effectiveSelection?.start;
+    }
+
+    if (effectiveSelection != null) {
+      file.selection = effectiveSelection;
+      file.cursor = effectiveCursor ?? effectiveSelection.end;
+      file.revealSelection = effectiveSelection;
+      file.revealNonce += 1;
+      return;
+    }
+
+    if (effectiveCursor != null) {
+      file.cursor = effectiveCursor;
+      file.selection = null;
+      file.revealSelection = EditorSelection(
+        start: effectiveCursor,
+        end: effectiveCursor,
+      );
+      file.revealNonce += 1;
+      return;
+    }
+
+    file.cursor = const EditorCursor(line: 1, column: 1);
+    file.selection = null;
+    file.revealSelection = null;
+  }
+
+  EditorSelection? _selectionFromOffset(
+    String content,
+    int offset, {
+    int? limit,
+  }) {
+    if (content.isEmpty) {
+      return null;
+    }
+    final startOffset = offset.clamp(0, content.length);
+    final endOffset = (offset + (limit ?? 0)).clamp(
+      startOffset,
+      content.length,
+    );
+    final start = _offsetToCursor(content, startOffset);
+    final end = _offsetToCursor(content, endOffset);
+    return EditorSelection(start: start, end: end);
+  }
+
+  EditorCursor _offsetToCursor(String content, int rawOffset) {
+    final clampedOffset = rawOffset.clamp(0, content.length);
+    var line = 1;
+    var column = 1;
+    for (var index = 0; index < clampedOffset; index += 1) {
+      if (content.codeUnitAt(index) == 10) {
+        line += 1;
+        column = 1;
+      } else {
+        column += 1;
+      }
+    }
+    return EditorCursor(line: line, column: column);
   }
 
   String _extractWorkDir(String filePath) {
     final parts = filePath.split('/');
-    // Return everything except the last component (the filename).
     if (parts.length > 1) {
       return parts.sublist(0, parts.length - 1).join('/');
     }
     return '/';
   }
 
-  void _resetContextForCurrentFile() {
-    if (currentFile == null) {
-      _cursor = null;
-      _selection = null;
-      return;
+  String? _detectSingleInsertedCharacter(String previous, String current) {
+    if (current.length != previous.length + 1) {
+      return null;
     }
-    _cursor = const EditorCursor(line: 1, column: 1);
-    _selection = null;
+    final cursor = this.cursor;
+    if (cursor == null) {
+      return current.substring(current.length - 1);
+    }
+    final offset = _cursorToOffset(current, cursor).clamp(1, current.length);
+    return current.substring(offset - 1, offset);
+  }
+
+  int _cursorToOffset(String content, EditorCursor cursor) {
+    final targetLine = cursor.line > 0 ? cursor.line : 1;
+    final targetColumn = cursor.column > 0 ? cursor.column : 1;
+    var line = 1;
+    var column = 1;
+    for (var index = 0; index < content.length; index += 1) {
+      if (line == targetLine && column == targetColumn) {
+        return index;
+      }
+      if (content.codeUnitAt(index) == 10) {
+        line += 1;
+        column = 1;
+      } else {
+        column += 1;
+      }
+    }
+    return content.length;
+  }
+
+  String _applyTextEditsToContent(String content, List<EditorTextEdit> edits) {
+    final sorted = List<EditorTextEdit>.from(edits)
+      ..sort((left, right) {
+        final leftOffset = _positionToOffset(content, left.range.start);
+        final rightOffset = _positionToOffset(content, right.range.start);
+        return rightOffset.compareTo(leftOffset);
+      });
+
+    var updated = content;
+    for (final edit in sorted) {
+      final startOffset = _positionToOffset(updated, edit.range.start);
+      final endOffset = _positionToOffset(updated, edit.range.end);
+      updated = updated.replaceRange(startOffset, endOffset, edit.newText);
+    }
+    return updated;
+  }
+
+  int _positionToOffset(String content, DocumentPosition position) {
+    final lines = content.split('\n');
+    if (position.line < 0 || position.line > lines.length) {
+      throw RangeError('line ${position.line} is out of range');
+    }
+    if (position.line == lines.length) {
+      return content.length;
+    }
+    var offset = 0;
+    for (var index = 0; index < position.line; index += 1) {
+      offset += lines[index].length + 1;
+    }
+    final line = lines[position.line];
+    final clampedCharacter = position.character.clamp(0, line.length);
+    return offset + clampedCharacter;
   }
 }

--- a/app/lib/screens/chat_screen.dart
+++ b/app/lib/screens/chat_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../navigation/editor_navigation.dart';
 import '../providers/chat_provider.dart';
 import '../providers/editor_provider.dart';
 import '../providers/workspace_provider.dart';
 import '../widgets/chat_bubble.dart';
-import 'code_screen.dart';
 import 'session_list_screen.dart';
 
 /// Full-screen AI chat view (tab 2 in bottom navigation).
@@ -69,9 +69,7 @@ class _ChatScreenState extends State<ChatScreen> {
                     Text(
                       ws.displayName,
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Theme.of(context)
-                            .colorScheme
-                            .onSurfaceVariant,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
                       ),
                     ),
                   ],
@@ -99,7 +97,7 @@ class _ChatScreenState extends State<ChatScreen> {
               ),
             ],
           ),
-              body: Column(
+          body: Column(
             children: [
               if (provider.error != null) _buildErrorBanner(context, provider),
               if (provider.editorContext?.hasContext ?? false)
@@ -157,10 +155,7 @@ class _ChatScreenState extends State<ChatScreen> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text('Workspace: ${workspace.displayName}'),
-                  Text(
-                    'File: $fileName',
-                    overflow: TextOverflow.ellipsis,
-                  ),
+                  Text('File: $fileName', overflow: TextOverflow.ellipsis),
                   Text('Selection: $selectionLabel'),
                 ],
               ),
@@ -206,20 +201,8 @@ class _ChatScreenState extends State<ChatScreen> {
           message: msg,
           nextMessage: nextMsg,
           sessionId: provider.conversationId,
-          onFileTap: (filePath) {
-            final editorProvider = context.read<EditorProvider>();
-            editorProvider.openFile(filePath).then((_) {
-              if (context.mounted) {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => ChangeNotifierProvider.value(
-                      value: editorProvider,
-                      child: const CodeScreen(),
-                    ),
-                  ),
-                );
-              }
-            });
+          onFileTap: (filePath, annotation) {
+            openCodeAnnotation(context, path: filePath, annotation: annotation);
           },
         );
       },

--- a/app/lib/screens/code_screen.dart
+++ b/app/lib/screens/code_screen.dart
@@ -1,10 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
+import '../models/editor_models.dart';
 import '../providers/editor_provider.dart';
-import 'chat_screen.dart';
-import '../widgets/code_viewer.dart';
 import '../widgets/code_editor.dart';
+import '../widgets/code_viewer.dart';
 import '../widgets/contextual_chat.dart';
+import 'chat_screen.dart';
+
+enum _EditorMenuAction {
+  requestCompletion,
+  hover,
+  definition,
+  references,
+  rename,
+  format,
+  quickFixes,
+  problems,
+  close,
+}
+
+enum _CloseChoice { save, discard, cancel }
 
 class CodeScreen extends StatefulWidget {
   const CodeScreen({super.key});
@@ -16,44 +32,499 @@ class CodeScreen extends StatefulWidget {
 class _CodeScreenState extends State<CodeScreen> {
   bool _showChat = false;
 
-  Future<void> _confirmClose(
+  Future<void> _showFeedback(BuildContext context, String message) async {
+    if (!context.mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message), duration: const Duration(seconds: 2)),
+    );
+  }
+
+  Future<void> _closeCurrentFile(
     BuildContext context,
     EditorProvider editorProvider,
   ) async {
     final file = editorProvider.currentFile;
-    if (file == null) return;
-
-    if (file.hasUnsavedChanges) {
-      final result = await showDialog<bool>(
-        context: context,
-        builder: (ctx) => AlertDialog(
-          title: const Text('Unsaved Changes'),
-          content: Text('${file.name} has unsaved changes. Close anyway?'),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: const Text('Cancel'),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(ctx, true),
-              child: const Text('Discard'),
-            ),
-          ],
-        ),
-      );
-      if (result != true) return;
+    if (file == null) {
+      return;
     }
 
-    editorProvider.closeFile(editorProvider.currentFileIndex);
+    if (!file.hasUnsavedChanges) {
+      await editorProvider.closeFile(editorProvider.currentFileIndex);
+      if (context.mounted) {
+        Navigator.of(context).pop();
+      }
+      return;
+    }
+
+    final choice = await showDialog<_CloseChoice>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Unsaved changes'),
+        content: Text('Save changes to ${file.name} before closing?'),
+        actions: [
+          TextButton(
+            onPressed: () =>
+                Navigator.of(dialogContext).pop(_CloseChoice.cancel),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () =>
+                Navigator.of(dialogContext).pop(_CloseChoice.discard),
+            child: const Text('Discard'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(_CloseChoice.save),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+
+    if (choice == null || choice == _CloseChoice.cancel) {
+      return;
+    }
+
+    if (choice == _CloseChoice.save) {
+      final saved = await editorProvider.saveCurrentFile();
+      if (!saved) {
+        if (!context.mounted) {
+          return;
+        }
+        await _showFeedback(context, 'Failed to save file before closing.');
+        return;
+      }
+    }
+
+    await editorProvider.closeFile(editorProvider.currentFileIndex);
     if (context.mounted) {
       Navigator.of(context).pop();
     }
   }
 
+  Future<void> _showLocations(
+    BuildContext context,
+    EditorProvider editorProvider,
+    String title,
+    Future<List<EditorLocation>> Function() loader,
+  ) async {
+    final locations = await loader();
+    if (!context.mounted) {
+      return;
+    }
+    if (locations.isEmpty) {
+      await _showFeedback(context, 'No $title found.');
+      return;
+    }
+    if (locations.length == 1) {
+      await editorProvider.openLocation(locations.first);
+      return;
+    }
+
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: ListView.builder(
+            itemCount: locations.length,
+            itemBuilder: (context, index) {
+              final location = locations[index];
+              return ListTile(
+                leading: const Icon(Icons.place_outlined),
+                title: Text(location.path.split('/').last),
+                subtitle: Text(location.label),
+                onTap: () async {
+                  Navigator.of(sheetContext).pop();
+                  await editorProvider.openLocation(location);
+                },
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _showProblemsPanel(
+    BuildContext context,
+    EditorProvider editorProvider,
+  ) async {
+    final diagnostics = editorProvider.allDiagnostics;
+    if (diagnostics.isEmpty) {
+      await _showFeedback(context, 'No problems for open files.');
+      return;
+    }
+
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: ListView.separated(
+            itemCount: diagnostics.length,
+            separatorBuilder: (_, _) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final diagnostic = diagnostics[index];
+              return ListTile(
+                leading: Icon(
+                  diagnostic.isError
+                      ? Icons.error_outline
+                      : diagnostic.isWarning
+                      ? Icons.warning_amber_rounded
+                      : Icons.info_outline,
+                  color: diagnostic.isError
+                      ? Theme.of(context).colorScheme.error
+                      : diagnostic.isWarning
+                      ? Colors.orange
+                      : Theme.of(context).colorScheme.primary,
+                ),
+                title: Text(
+                  diagnostic.message,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                subtitle: Text(
+                  '${diagnostic.filePath}:${diagnostic.line}:${diagnostic.column}',
+                ),
+                onTap: () async {
+                  Navigator.of(sheetContext).pop();
+                  await editorProvider.openDiagnostic(diagnostic);
+                },
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _showHover(
+    BuildContext context,
+    EditorProvider editorProvider,
+  ) async {
+    final hover = await editorProvider.requestHover();
+    if (!context.mounted) {
+      return;
+    }
+    final hoverText = hover?.plainText ?? '';
+    if (hover == null || hoverText.isEmpty) {
+      await _showFeedback(context, 'No hover details available here.');
+      return;
+    }
+
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: SingleChildScrollView(child: SelectableText(hoverText)),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _showQuickFixes(
+    BuildContext context,
+    EditorProvider editorProvider,
+  ) async {
+    final actions = await editorProvider.loadCodeActions(quickFixOnly: true);
+    if (!context.mounted) {
+      return;
+    }
+    if (actions.isEmpty) {
+      await _showFeedback(context, 'No quick fixes available.');
+      return;
+    }
+
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: ListView.builder(
+            itemCount: actions.length,
+            itemBuilder: (context, index) {
+              final action = actions[index];
+              return ListTile(
+                leading: const Icon(Icons.auto_fix_high),
+                title: Text(action.title),
+                subtitle: action.kind.isNotEmpty ? Text(action.kind) : null,
+                onTap: () async {
+                  Navigator.of(sheetContext).pop();
+                  final applied = await editorProvider.applyCodeAction(action);
+                  if (!context.mounted) {
+                    return;
+                  }
+                  await _showFeedback(
+                    context,
+                    applied
+                        ? 'Applied quick fix.'
+                        : 'Quick fix did not return edits.',
+                  );
+                },
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _renameSymbol(
+    BuildContext context,
+    EditorProvider editorProvider,
+  ) async {
+    final controller = TextEditingController();
+    final newName = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Rename symbol'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(
+            labelText: 'New name',
+            border: OutlineInputBorder(),
+          ),
+          onSubmitted: (value) => Navigator.of(dialogContext).pop(value.trim()),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () =>
+                Navigator.of(dialogContext).pop(controller.text.trim()),
+            child: const Text('Apply'),
+          ),
+        ],
+      ),
+    );
+    if (newName == null || newName.isEmpty) {
+      return;
+    }
+
+    final renamed = await editorProvider.renameSymbol(newName);
+    if (!context.mounted) {
+      return;
+    }
+    await _showFeedback(
+      context,
+      renamed ? 'Rename applied.' : 'Rename did not return any edits.',
+    );
+  }
+
+  Future<void> _handleMenuAction(
+    BuildContext context,
+    EditorProvider editorProvider,
+    _EditorMenuAction action,
+  ) async {
+    switch (action) {
+      case _EditorMenuAction.requestCompletion:
+        final items = await editorProvider.requestCompletion();
+        if (items.isEmpty && context.mounted) {
+          await _showFeedback(context, 'No completion items available.');
+        }
+        break;
+      case _EditorMenuAction.hover:
+        await _showHover(context, editorProvider);
+        break;
+      case _EditorMenuAction.definition:
+        await _showLocations(
+          context,
+          editorProvider,
+          'definitions',
+          editorProvider.requestDefinition,
+        );
+        break;
+      case _EditorMenuAction.references:
+        await _showLocations(
+          context,
+          editorProvider,
+          'references',
+          editorProvider.requestReferences,
+        );
+        break;
+      case _EditorMenuAction.rename:
+        await _renameSymbol(context, editorProvider);
+        break;
+      case _EditorMenuAction.format:
+        final formatted = await editorProvider.formatCurrentFile();
+        if (context.mounted) {
+          await _showFeedback(
+            context,
+            formatted
+                ? 'Formatting edits applied.'
+                : 'No formatting edits available.',
+          );
+        }
+        break;
+      case _EditorMenuAction.quickFixes:
+        await _showQuickFixes(context, editorProvider);
+        break;
+      case _EditorMenuAction.problems:
+        await _showProblemsPanel(context, editorProvider);
+        break;
+      case _EditorMenuAction.close:
+        await _closeCurrentFile(context, editorProvider);
+        break;
+    }
+  }
+
+  Widget _buildBridgeBanner(
+    BuildContext context,
+    EditorProvider editorProvider,
+  ) {
+    final file = editorProvider.currentFile;
+    if (file == null || file.bridgeTracking) {
+      return const SizedBox.shrink();
+    }
+
+    return MaterialBanner(
+      content: const Text(
+        'Bridge-backed editor features are limited until the runtime bridge is ready.',
+      ),
+      leading: const Icon(Icons.link_off),
+      actions: [
+        TextButton(
+          onPressed: editorProvider.refreshCapabilities,
+          child: const Text('Retry'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildErrorBanner(
+    BuildContext context,
+    EditorProvider editorProvider,
+  ) {
+    final error = editorProvider.error;
+    if (error == null || error.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return MaterialBanner(
+      content: Text(error),
+      backgroundColor: Theme.of(context).colorScheme.errorContainer,
+      leading: const Icon(Icons.error_outline),
+      actions: [
+        TextButton(
+          onPressed: editorProvider.clearError,
+          child: const Text('Dismiss'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCompletionPanel(
+    BuildContext context,
+    EditorProvider editorProvider,
+  ) {
+    if (editorProvider.completionItems.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Positioned(
+      left: 16,
+      right: 16,
+      bottom: 16,
+      child: Material(
+        elevation: 6,
+        borderRadius: BorderRadius.circular(12),
+        color: Theme.of(context).colorScheme.surface,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 220),
+          child: ListView.separated(
+            shrinkWrap: true,
+            itemCount: editorProvider.completionItems.length,
+            separatorBuilder: (_, _) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final item = editorProvider.completionItems[index];
+              return ListTile(
+                dense: true,
+                leading: const Icon(Icons.bolt),
+                title: Text(item.label),
+                subtitle: item.detail.isNotEmpty
+                    ? Text(
+                        item.detail,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      )
+                    : item.documentationText.isNotEmpty
+                    ? Text(
+                        item.documentationText,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      )
+                    : null,
+                onTap: () async {
+                  final applied = await editorProvider.applyCompletionItem(
+                    item,
+                  );
+                  if (!applied && context.mounted) {
+                    await _showFeedback(
+                      context,
+                      'Failed to apply completion item.',
+                    );
+                  }
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSignatureHelpCard(
+    BuildContext context,
+    EditorProvider editorProvider,
+  ) {
+    final signatureHelp = editorProvider.signatureHelp;
+    final label = signatureHelp?.activeLabel;
+    if (label == null || label.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Positioned(
+      left: 16,
+      right: 16,
+      top: 16,
+      child: Material(
+        elevation: 3,
+        borderRadius: BorderRadius.circular(12),
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          child: Row(
+            children: [
+              const Icon(Icons.functions, size: 18),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  label,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Consumer<EditorProvider>(
-      builder: (context, editorProvider, child) {
+      builder: (context, editorProvider, _) {
         final file = editorProvider.currentFile;
         if (file == null) {
           return Scaffold(
@@ -64,6 +535,29 @@ class _CodeScreenState extends State<CodeScreen> {
 
         final isEditing = file.isEditing;
         final hasChanges = file.hasUnsavedChanges;
+        final diagnosticsCount = editorProvider.allDiagnostics.length;
+        final canRequestCompletions =
+            isEditing &&
+            file.bridgeTracking &&
+            editorProvider.capabilityEnabled('completion');
+        final canHover =
+            file.bridgeTracking && editorProvider.capabilityEnabled('hover');
+        final canDefinition =
+            file.bridgeTracking &&
+            editorProvider.capabilityEnabled('definition');
+        final canReferences =
+            file.bridgeTracking &&
+            editorProvider.capabilityEnabled('references');
+        final canRename =
+            file.bridgeTracking && editorProvider.capabilityEnabled('rename');
+        final canFormat =
+            file.bridgeTracking &&
+            editorProvider.capabilityEnabled('formatting');
+        final canQuickFix =
+            file.bridgeTracking &&
+            editorProvider.capabilityEnabled('codeActions', const <String>[
+              'code-actions',
+            ]);
 
         return Scaffold(
           appBar: AppBar(
@@ -86,6 +580,44 @@ class _CodeScreenState extends State<CodeScreen> {
               ],
             ),
             actions: [
+              if (editorProvider.canJumpBack)
+                IconButton(
+                  icon: const Icon(Icons.reply),
+                  tooltip: 'Jump back',
+                  onPressed: () => editorProvider.jumpBack(),
+                ),
+              IconButton(
+                icon: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    const Icon(Icons.rule_folder_outlined),
+                    if (diagnosticsCount > 0)
+                      Positioned(
+                        right: -6,
+                        top: -6,
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 4,
+                            vertical: 1,
+                          ),
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.error,
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: Text(
+                            diagnosticsCount.toString(),
+                            style: Theme.of(context).textTheme.labelSmall
+                                ?.copyWith(
+                                  color: Theme.of(context).colorScheme.onError,
+                                ),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+                tooltip: 'Problems',
+                onPressed: () => _showProblemsPanel(context, editorProvider),
+              ),
               if (isEditing) ...[
                 if (editorProvider.isLoading)
                   const Padding(
@@ -105,15 +637,9 @@ class _CodeScreenState extends State<CodeScreen> {
                             final saved = await editorProvider
                                 .saveCurrentFile();
                             if (context.mounted) {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(
-                                  content: Text(
-                                    saved
-                                        ? 'File saved'
-                                        : 'Failed to save file',
-                                  ),
-                                  duration: const Duration(seconds: 1),
-                                ),
+                              await _showFeedback(
+                                context,
+                                saved ? 'File saved.' : 'Failed to save file.',
                               );
                             }
                           }
@@ -122,25 +648,92 @@ class _CodeScreenState extends State<CodeScreen> {
                 IconButton(
                   icon: const Icon(Icons.visibility),
                   tooltip: 'View mode',
-                  onPressed: () => editorProvider.exitEditMode(),
+                  onPressed: editorProvider.exitEditMode,
                 ),
               ] else
                 IconButton(
                   icon: const Icon(Icons.edit),
                   tooltip: 'Edit mode',
-                  onPressed: () => editorProvider.enterEditMode(),
+                  onPressed: editorProvider.enterEditMode,
                 ),
-              PopupMenuButton<String>(
-                onSelected: (value) async {
-                  switch (value) {
-                    case 'close':
-                      await _confirmClose(context, editorProvider);
-                      break;
-                  }
-                },
+              PopupMenuButton<_EditorMenuAction>(
+                onSelected: (action) =>
+                    _handleMenuAction(context, editorProvider, action),
                 itemBuilder: (context) => [
-                  const PopupMenuItem(
-                    value: 'close',
+                  PopupMenuItem<_EditorMenuAction>(
+                    value: _EditorMenuAction.requestCompletion,
+                    enabled: canRequestCompletions,
+                    child: const ListTile(
+                      leading: Icon(Icons.bolt_outlined),
+                      title: Text('Request completions'),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  ),
+                  PopupMenuItem<_EditorMenuAction>(
+                    value: _EditorMenuAction.hover,
+                    enabled: canHover,
+                    child: const ListTile(
+                      leading: Icon(Icons.info_outline),
+                      title: Text('Hover details'),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  ),
+                  PopupMenuItem<_EditorMenuAction>(
+                    value: _EditorMenuAction.definition,
+                    enabled: canDefinition,
+                    child: const ListTile(
+                      leading: Icon(Icons.my_location_outlined),
+                      title: Text('Go to definition'),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  ),
+                  PopupMenuItem<_EditorMenuAction>(
+                    value: _EditorMenuAction.references,
+                    enabled: canReferences,
+                    child: const ListTile(
+                      leading: Icon(Icons.find_in_page_outlined),
+                      title: Text('Find references'),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  ),
+                  PopupMenuItem<_EditorMenuAction>(
+                    value: _EditorMenuAction.rename,
+                    enabled: canRename,
+                    child: const ListTile(
+                      leading: Icon(Icons.drive_file_rename_outline),
+                      title: Text('Rename symbol'),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  ),
+                  PopupMenuItem<_EditorMenuAction>(
+                    value: _EditorMenuAction.format,
+                    enabled: canFormat,
+                    child: const ListTile(
+                      leading: Icon(Icons.auto_fix_high_outlined),
+                      title: Text('Format file'),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  ),
+                  PopupMenuItem<_EditorMenuAction>(
+                    value: _EditorMenuAction.quickFixes,
+                    enabled: canQuickFix,
+                    child: const ListTile(
+                      leading: Icon(Icons.build_circle_outlined),
+                      title: Text('Quick fixes'),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  ),
+                  const PopupMenuDivider(),
+                  const PopupMenuItem<_EditorMenuAction>(
+                    value: _EditorMenuAction.problems,
+                    child: ListTile(
+                      leading: Icon(Icons.rule_folder_outlined),
+                      title: Text('Problems panel'),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  ),
+                  const PopupMenuItem<_EditorMenuAction>(
+                    value: _EditorMenuAction.close,
                     child: ListTile(
                       leading: Icon(Icons.close),
                       title: Text('Close file'),
@@ -151,52 +744,77 @@ class _CodeScreenState extends State<CodeScreen> {
               ),
             ],
           ),
-          body: Stack(
+          body: Column(
             children: [
-              isEditing
-                  ? CodeEditor(
-                      content: file.currentContent,
-                      fileName: file.name,
-                      onContentChanged: (content) {
-                        editorProvider.updateContent(content);
-                      },
-                      onCursorChanged: editorProvider.updateCursor,
-                      onSelectionChanged: (selection, cursor) {
-                        editorProvider.updateSelection(
-                          selection,
-                          cursor: cursor,
-                        );
-                      },
-                      onSave: hasChanges
-                          ? () => editorProvider.saveCurrentFile()
-                          : null,
-                    )
-                  : CodeViewer(
-                      content: file.currentContent,
-                      fileName: file.name,
-                      diagnostics: editorProvider.diagnostics,
-                      onSelectionChanged: (selection) {
-                        editorProvider.updateSelection(
-                          selection,
-                          cursor: selection?.end ?? editorProvider.cursor,
-                        );
-                      },
-                      onAskAi: () {
-                        setState(() => _showChat = true);
-                      },
-                      onEditRequested: () {
-                        editorProvider.enterEditMode();
-                      },
-                    ),
-              if (_showChat)
-                ContextualChat(
-                  onExpandToFullChat: () {
-                    setState(() => _showChat = false);
-                    Navigator.of(context).push(
-                      MaterialPageRoute(builder: (_) => const ChatScreen()),
-                    );
-                  },
+              _buildBridgeBanner(context, editorProvider),
+              _buildErrorBanner(context, editorProvider),
+              Expanded(
+                child: Stack(
+                  children: [
+                    isEditing
+                        ? CodeEditor(
+                            content: file.currentContent,
+                            fileName: file.name,
+                            diagnostics: editorProvider.diagnostics,
+                            revealSelection: editorProvider.revealSelection,
+                            revealNonce: editorProvider.revealNonce,
+                            onContentChanged: editorProvider.updateContent,
+                            onCursorChanged: editorProvider.updateCursor,
+                            onSelectionChanged: (selection, cursor) {
+                              editorProvider.updateSelection(
+                                selection,
+                                cursor: cursor,
+                              );
+                            },
+                            onSave: hasChanges
+                                ? () => editorProvider.saveCurrentFile()
+                                : null,
+                          )
+                        : CodeViewer(
+                            content: file.currentContent,
+                            fileName: file.name,
+                            diagnostics: editorProvider.diagnostics,
+                            revealSelection: editorProvider.revealSelection,
+                            revealNonce: editorProvider.revealNonce,
+                            onSelectionChanged: (selection) {
+                              editorProvider.updateSelection(
+                                selection,
+                                cursor: selection?.end ?? editorProvider.cursor,
+                              );
+                            },
+                            onAskAi: () {
+                              setState(() => _showChat = true);
+                            },
+                            onEditRequested: editorProvider.enterEditMode,
+                            onLongPressHover: canHover
+                                ? () => _showHover(context, editorProvider)
+                                : null,
+                            onDefinitionRequested: canDefinition
+                                ? () => _showLocations(
+                                    context,
+                                    editorProvider,
+                                    'definitions',
+                                    editorProvider.requestDefinition,
+                                  )
+                                : null,
+                          ),
+                    _buildSignatureHelpCard(context, editorProvider),
+                    if (isEditing)
+                      _buildCompletionPanel(context, editorProvider),
+                    if (_showChat)
+                      ContextualChat(
+                        onExpandToFullChat: () {
+                          setState(() => _showChat = false);
+                          Navigator.of(context).push(
+                            MaterialPageRoute<void>(
+                              builder: (_) => const ChatScreen(),
+                            ),
+                          );
+                        },
+                      ),
+                  ],
                 ),
+              ),
             ],
           ),
         );

--- a/app/lib/screens/files_screen.dart
+++ b/app/lib/screens/files_screen.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../navigation/editor_navigation.dart';
 import '../providers/chat_provider.dart';
 import '../providers/file_provider.dart';
 import '../providers/git_provider.dart';
-import '../providers/editor_provider.dart';
 import '../providers/workspace_provider.dart';
 import '../widgets/file_tree_view.dart';
-import 'code_screen.dart';
 
 class FilesScreen extends StatelessWidget {
   const FilesScreen({super.key});
@@ -47,19 +46,7 @@ class FilesScreen extends StatelessWidget {
       ),
       body: FileTreeView(
         onFileTap: (path, name) {
-          final editorProvider = context.read<EditorProvider>();
-          editorProvider.openFile(path).then((_) {
-            if (context.mounted) {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => ChangeNotifierProvider.value(
-                    value: editorProvider,
-                    child: const CodeScreen(),
-                  ),
-                ),
-              );
-            }
-          });
+          openCodePath(context, path: path);
         },
         onCreateFile: (parentPath, name) =>
             _handleCreateFile(context, parentPath, name),
@@ -195,8 +182,9 @@ class FilesScreen extends StatelessWidget {
                           'Recent',
                           style: Theme.of(listCtx).textTheme.labelLarge
                               ?.copyWith(
-                                color:
-                                    Theme.of(listCtx).colorScheme.onSurfaceVariant,
+                                color: Theme.of(
+                                  listCtx,
+                                ).colorScheme.onSurfaceVariant,
                               ),
                         ),
                       ),

--- a/app/lib/screens/search_screen.dart
+++ b/app/lib/screens/search_screen.dart
@@ -2,10 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../navigation/editor_navigation.dart';
 import '../providers/search_provider.dart';
-import '../providers/editor_provider.dart';
 import '../providers/workspace_provider.dart';
-import 'code_screen.dart';
 
 class SearchScreen extends StatefulWidget {
   const SearchScreen({super.key});
@@ -37,20 +36,8 @@ class _SearchScreenState extends State<SearchScreen> {
     }
   }
 
-  void _onResultTap(String path, String name) {
-    final editorProvider = context.read<EditorProvider>();
-    editorProvider.openFile(path).then((_) {
-      if (mounted) {
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (_) => ChangeNotifierProvider.value(
-              value: editorProvider,
-              child: const CodeScreen(),
-            ),
-          ),
-        );
-      }
-    });
+  Future<void> _onResultTap(String path, {int? line}) {
+    return openCodePath(context, path: path, line: line);
   }
 
   @override
@@ -240,9 +227,7 @@ class _SearchScreenState extends State<SearchScreen> {
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
           ),
-          onTap: result.isDirectory
-              ? null
-              : () => _onResultTap(result.path, result.name),
+          onTap: result.isDirectory ? null : () => _onResultTap(result.path),
         );
       },
     );
@@ -280,7 +265,7 @@ class _SearchScreenState extends State<SearchScreen> {
             ],
           ),
           isThreeLine: true,
-          onTap: () => _onResultTap(result.file, fileName),
+          onTap: () => _onResultTap(result.file, line: result.line),
         );
       },
     );

--- a/app/lib/screens/session_detail_screen.dart
+++ b/app/lib/screens/session_detail_screen.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../navigation/editor_navigation.dart';
 import '../models/chat_message.dart';
 import '../models/session.dart';
 import '../providers/chat_provider.dart';
-import '../providers/editor_provider.dart';
 import '../widgets/chat_bubble.dart';
-import 'code_screen.dart';
 
 /// Read-only view of a past session's full conversation.
 /// Fetches messages from GET /api/sessions/:id/messages.
@@ -57,20 +56,8 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
     }
   }
 
-  void _navigateToFile(String filePath) {
-    final editorProvider = context.read<EditorProvider>();
-    editorProvider.openFile(filePath).then((_) {
-      if (mounted) {
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (_) => ChangeNotifierProvider.value(
-              value: editorProvider,
-              child: const CodeScreen(),
-            ),
-          ),
-        );
-      }
-    });
+  Future<void> _navigateToFile(String filePath, FileAnnotation? annotation) {
+    return openCodeAnnotation(context, path: filePath, annotation: annotation);
   }
 
   @override
@@ -160,7 +147,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
           message: msg,
           nextMessage: nextMsg,
           sessionId: widget.session.sessionId,
-          onFileTap: (filePath) => _navigateToFile(filePath),
+          onFileTap: _navigateToFile,
         );
       },
     );

--- a/app/lib/services/editor_api_client.dart
+++ b/app/lib/services/editor_api_client.dart
@@ -1,0 +1,433 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../models/diagnostic.dart';
+import '../models/editor_models.dart';
+import 'api_client.dart' show ApiException;
+import 'settings_service.dart';
+
+typedef EditorChannelFactory = WebSocketChannel Function(Uri uri);
+
+class EditorApiClient {
+  EditorApiClient({
+    required SettingsService settings,
+    http.Client? client,
+    EditorChannelFactory? channelFactory,
+  }) : _settings = settings,
+       _client = client ?? http.Client(),
+       _channelFactory = channelFactory ?? WebSocketChannel.connect;
+
+  final SettingsService _settings;
+  final http.Client _client;
+  final EditorChannelFactory _channelFactory;
+
+  String get baseUrl => _settings.serverUrl;
+  String get token => _settings.authToken;
+
+  Map<String, String> get _headers => {
+    'Authorization': 'Bearer $token',
+    'Content-Type': 'application/json',
+  };
+
+  Uri _httpUri(String path, {Map<String, String>? queryParams}) {
+    final base = baseUrl.endsWith('/')
+        ? baseUrl.substring(0, baseUrl.length - 1)
+        : baseUrl;
+    if (queryParams != null && queryParams.isNotEmpty) {
+      return Uri.parse('$base$path').replace(queryParameters: queryParams);
+    }
+    return Uri.parse('$base$path');
+  }
+
+  Uri _wsUri(String path) {
+    final wsBase = baseUrl
+        .replaceFirst('https://', 'wss://')
+        .replaceFirst('http://', 'ws://');
+    final base = wsBase.endsWith('/')
+        ? wsBase.substring(0, wsBase.length - 1)
+        : wsBase;
+    return Uri.parse('$base$path?token=$token');
+  }
+
+  Future<BridgeCapabilitiesDocument> getCapabilities() async {
+    final response = await _client.get(
+      _httpUri('/bridge/capabilities'),
+      headers: {'Authorization': 'Bearer $token'},
+    );
+    _ensureSuccess(response, 'load bridge capabilities');
+    return BridgeCapabilitiesDocument.fromJson(
+      _decodeMap(response.body, 'bridge capabilities'),
+    );
+  }
+
+  WebSocketChannel connectEventsWebSocket() {
+    return _channelFactory(_wsUri('/bridge/ws/events'));
+  }
+
+  Future<DocumentSnapshot> openDocument({
+    required String path,
+    required int version,
+    String? content,
+  }) async {
+    final response = await _post('/bridge/doc/open', <String, dynamic>{
+      'path': path,
+      'version': version,
+      ...?content == null ? null : <String, dynamic>{'content': content},
+    }, action: 'open document');
+    return DocumentSnapshot.fromJson(
+      _decodeMap(response.body, 'document open'),
+    );
+  }
+
+  Future<DocumentSnapshot> changeDocument({
+    required String path,
+    required int version,
+    required List<DocumentChange> changes,
+  }) async {
+    final response = await _post('/bridge/doc/change', <String, dynamic>{
+      'path': path,
+      'version': version,
+      'changes': changes.map((change) => change.toJson()).toList(),
+    }, action: 'change document');
+    return DocumentSnapshot.fromJson(
+      _decodeMap(response.body, 'document change'),
+    );
+  }
+
+  Future<DocumentSnapshot> saveDocument(String path) async {
+    final response = await _post('/bridge/doc/save', <String, dynamic>{
+      'path': path,
+    }, action: 'save document');
+    return DocumentSnapshot.fromJson(
+      _decodeMap(response.body, 'document save'),
+    );
+  }
+
+  Future<void> closeDocument(String path) async {
+    await _post('/bridge/doc/close', <String, dynamic>{
+      'path': path,
+    }, action: 'close document');
+  }
+
+  Future<List<Diagnostic>> diagnostics({
+    required String path,
+    required int version,
+    String? workDir,
+  }) async {
+    final response =
+        await _post('/bridge/editor/diagnostics', <String, dynamic>{
+          'path': path,
+          'version': version,
+          if (workDir != null && workDir.isNotEmpty) 'workDir': workDir,
+        }, action: 'load diagnostics');
+    return Diagnostic.listFromReportJson(
+      _decodeMap(response.body, 'editor diagnostics report'),
+    );
+  }
+
+  Future<EditorCompletionList> completion({
+    required String path,
+    required int version,
+    required DocumentPosition position,
+    String? workDir,
+  }) async {
+    final response = await _post(
+      '/bridge/editor/completion',
+      _editorPayload(
+        path: path,
+        version: version,
+        position: position,
+        workDir: workDir,
+      ),
+      action: 'request completion',
+    );
+    return EditorCompletionList.fromJson(
+      _decodeMap(response.body, 'completion response'),
+    );
+  }
+
+  Future<EditorHover> hover({
+    required String path,
+    required int version,
+    required DocumentPosition position,
+    String? workDir,
+  }) async {
+    final response = await _post(
+      '/bridge/editor/hover',
+      _editorPayload(
+        path: path,
+        version: version,
+        position: position,
+        workDir: workDir,
+      ),
+      action: 'request hover',
+    );
+    return EditorHover.fromJson(_decodeMap(response.body, 'hover response'));
+  }
+
+  Future<List<EditorLocation>> definition({
+    required String path,
+    required int version,
+    required DocumentPosition position,
+    String? workDir,
+  }) {
+    return _locationRequest(
+      '/bridge/editor/definition',
+      action: 'request definition',
+      path: path,
+      version: version,
+      position: position,
+      workDir: workDir,
+    );
+  }
+
+  Future<List<EditorLocation>> references({
+    required String path,
+    required int version,
+    required DocumentPosition position,
+    String? workDir,
+  }) {
+    return _locationRequest(
+      '/bridge/editor/references',
+      action: 'request references',
+      path: path,
+      version: version,
+      position: position,
+      workDir: workDir,
+    );
+  }
+
+  Future<EditorSignatureHelp?> signatureHelp({
+    required String path,
+    required int version,
+    required DocumentPosition position,
+    String? workDir,
+  }) async {
+    final response = await _post(
+      '/bridge/editor/signature-help',
+      _editorPayload(
+        path: path,
+        version: version,
+        position: position,
+        workDir: workDir,
+      ),
+      action: 'request signature help',
+    );
+    final decoded = _decodeJson(response.body, 'signature help');
+    if (decoded is! Map<String, dynamic>) {
+      return null;
+    }
+    return EditorSignatureHelp.fromJson(decoded);
+  }
+
+  Future<List<EditorTextEdit>> formatting({
+    required String path,
+    required int version,
+    String? workDir,
+  }) async {
+    final response = await _post(
+      '/bridge/editor/formatting',
+      _editorPayload(path: path, version: version, workDir: workDir),
+      action: 'request formatting',
+    );
+    return _decodeList(response.body, 'formatting response')
+        .whereType<Map>()
+        .map(
+          (entry) => EditorTextEdit.fromJson(Map<String, dynamic>.from(entry)),
+        )
+        .toList();
+  }
+
+  Future<List<EditorCodeAction>> codeActions({
+    required String path,
+    required int version,
+    required DocumentRange range,
+    String? workDir,
+  }) async {
+    final response = await _post(
+      '/bridge/editor/code-actions',
+      _editorPayload(
+        path: path,
+        version: version,
+        range: range,
+        workDir: workDir,
+      ),
+      action: 'request code actions',
+    );
+    return _decodeList(response.body, 'code actions response')
+        .whereType<Map>()
+        .map(
+          (entry) =>
+              EditorCodeAction.fromJson(Map<String, dynamic>.from(entry)),
+        )
+        .toList();
+  }
+
+  Future<EditorWorkspaceEdit> rename({
+    required String path,
+    required int version,
+    required DocumentPosition position,
+    required String newName,
+    String? workDir,
+  }) async {
+    final response = await _post(
+      '/bridge/editor/rename',
+      _editorPayload(
+        path: path,
+        version: version,
+        position: position,
+        workDir: workDir,
+        newName: newName,
+      ),
+      action: 'rename symbol',
+    );
+    return EditorWorkspaceEdit.fromJson(
+      _decodeMap(response.body, 'rename response'),
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> documentSymbols({
+    required String path,
+    required int version,
+    String? workDir,
+  }) async {
+    final response = await _post(
+      '/bridge/editor/document-symbols',
+      _editorPayload(path: path, version: version, workDir: workDir),
+      action: 'request document symbols',
+    );
+    return _decodeList(response.body, 'document symbols response')
+        .whereType<Map>()
+        .map((entry) => Map<String, dynamic>.from(entry))
+        .toList();
+  }
+
+  Future<List<EditorLocation>> _locationRequest(
+    String endpoint, {
+    required String action,
+    required String path,
+    required int version,
+    required DocumentPosition position,
+    String? workDir,
+  }) async {
+    final response = await _post(
+      endpoint,
+      _editorPayload(
+        path: path,
+        version: version,
+        position: position,
+        workDir: workDir,
+      ),
+      action: action,
+    );
+    return _decodeList(response.body, 'location response')
+        .whereType<Map>()
+        .map(
+          (entry) => EditorLocation.fromJson(Map<String, dynamic>.from(entry)),
+        )
+        .toList();
+  }
+
+  Map<String, dynamic> _editorPayload({
+    required String path,
+    required int version,
+    DocumentPosition? position,
+    DocumentRange? range,
+    String? workDir,
+    String? newName,
+  }) {
+    return <String, dynamic>{
+      'path': path,
+      'version': version,
+      if (position != null) 'position': position.toJson(),
+      if (range != null) 'range': range.toJson(),
+      if (workDir != null && workDir.isNotEmpty) 'workDir': workDir,
+      if (newName != null && newName.isNotEmpty) 'newName': newName,
+    };
+  }
+
+  Future<http.Response> _post(
+    String path,
+    Map<String, dynamic> payload, {
+    required String action,
+  }) async {
+    final response = await _client.post(
+      _httpUri(path),
+      headers: _headers,
+      body: jsonEncode(payload),
+    );
+    _ensureSuccess(response, action);
+    return response;
+  }
+
+  void _ensureSuccess(http.Response response, String action) {
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      return;
+    }
+    throw ApiException(
+      'Failed to $action: ${_extractErrorMessage(response.body)}',
+      response.statusCode,
+    );
+  }
+
+  Map<String, dynamic> _decodeMap(String body, String action) {
+    final decoded = _decodeJson(body, action);
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+    if (decoded is Map) {
+      return Map<String, dynamic>.from(decoded);
+    }
+    throw StateError('unexpected $action payload: $decoded');
+  }
+
+  List<dynamic> _decodeList(String body, String action) {
+    final decoded = _decodeJson(body, action);
+    if (decoded is List<dynamic>) {
+      return decoded;
+    }
+    throw StateError('unexpected $action payload: $decoded');
+  }
+
+  dynamic _decodeJson(String body, String action) {
+    try {
+      return jsonDecode(body);
+    } catch (error) {
+      throw StateError('failed to decode $action: $error');
+    }
+  }
+
+  String _extractErrorMessage(String body) {
+    if (body.isEmpty) {
+      return 'unexpected empty response';
+    }
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map<String, dynamic>) {
+        final code = decoded['code'] as String?;
+        final message = decoded['message'] as String?;
+        if (code != null &&
+            code.isNotEmpty &&
+            message != null &&
+            message.isNotEmpty) {
+          return '$code: $message';
+        }
+        if (message != null && message.isNotEmpty) {
+          return message;
+        }
+        if (code != null && code.isNotEmpty) {
+          return code;
+        }
+      }
+    } catch (_) {
+      // Fall back to the raw response body.
+    }
+    return body;
+  }
+
+  void dispose() {
+    _client.close();
+  }
+}

--- a/app/lib/widgets/chat_bubble.dart
+++ b/app/lib/widgets/chat_bubble.dart
@@ -20,7 +20,7 @@ class ChatBubble extends StatelessWidget {
   final ChatMessage? nextMessage;
 
   /// Callback when a file path in a tool card is tapped.
-  final void Function(String filePath)? onFileTap;
+  final void Function(String filePath, FileAnnotation? annotation)? onFileTap;
 
   /// Session ID for loading subagent conversations.
   final String? sessionId;

--- a/app/lib/widgets/code_editor.dart
+++ b/app/lib/widgets/code_editor.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../models/diagnostic.dart';
 import '../models/editor_context.dart';
 
 class CodeEditor extends StatefulWidget {
@@ -10,6 +11,9 @@ class CodeEditor extends StatefulWidget {
   final void Function(EditorSelection? selection, EditorCursor cursor)?
   onSelectionChanged;
   final VoidCallback? onSave;
+  final List<Diagnostic> diagnostics;
+  final EditorSelection? revealSelection;
+  final int revealNonce;
 
   const CodeEditor({
     super.key,
@@ -19,6 +23,9 @@ class CodeEditor extends StatefulWidget {
     this.onCursorChanged,
     this.onSelectionChanged,
     this.onSave,
+    this.diagnostics = const <Diagnostic>[],
+    this.revealSelection,
+    this.revealNonce = 0,
   });
 
   @override
@@ -34,6 +41,9 @@ class _CodeEditorState extends State<CodeEditor> {
   double _baseScaleFontSize = 13.0;
   bool _isSyncing = false;
 
+  double get _lineHeight => _fontSize * 1.5;
+  double get _characterWidth => _fontSize * 0.62;
+
   @override
   void initState() {
     super.initState();
@@ -45,6 +55,9 @@ class _CodeEditorState extends State<CodeEditor> {
     _controller.addListener(_onSelectionChanged);
     _editorScrollController.addListener(_syncLineNumbersFromEditor);
     _lineNumberScrollController.addListener(_syncEditorFromLineNumbers);
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => _applyRevealSelection(),
+    );
   }
 
   @override
@@ -54,9 +67,31 @@ class _CodeEditorState extends State<CodeEditor> {
         widget.content != _controller.text) {
       _controller.removeListener(_onTextChanged);
       _controller.removeListener(_onSelectionChanged);
+      final selection = _controller.selection;
       _controller.text = widget.content;
+      if (selection.isValid) {
+        final clampedBase = selection.baseOffset.clamp(
+          0,
+          widget.content.length,
+        );
+        final clampedExtent = selection.extentOffset.clamp(
+          0,
+          widget.content.length,
+        );
+        _controller.selection = TextSelection(
+          baseOffset: clampedBase,
+          extentOffset: clampedExtent,
+        );
+      }
       _controller.addListener(_onTextChanged);
       _controller.addListener(_onSelectionChanged);
+    }
+
+    if (oldWidget.revealNonce != widget.revealNonce ||
+        oldWidget.revealSelection != widget.revealSelection) {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => _applyRevealSelection(),
+      );
     }
   }
 
@@ -109,6 +144,36 @@ class _CodeEditorState extends State<CodeEditor> {
     );
   }
 
+  void _applyRevealSelection() {
+    final selection = widget.revealSelection;
+    if (selection == null || !mounted) {
+      return;
+    }
+
+    if (!_focusNode.hasFocus) {
+      _focusNode.requestFocus();
+    }
+
+    final startOffset = _cursorToOffset(selection.start);
+    final endOffset = _cursorToOffset(selection.end);
+    _controller.selection = TextSelection(
+      baseOffset: startOffset,
+      extentOffset: endOffset,
+    );
+
+    if (_editorScrollController.hasClients) {
+      final targetOffset = ((selection.start.line - 1) * _lineHeight).clamp(
+        0.0,
+        _editorScrollController.position.maxScrollExtent,
+      );
+      _editorScrollController.animateTo(
+        targetOffset,
+        duration: const Duration(milliseconds: 180),
+        curve: Curves.easeOut,
+      );
+    }
+  }
+
   EditorCursor _offsetToCursor(int rawOffset) {
     final text = _controller.text;
     final clampedOffset = rawOffset.clamp(0, text.length);
@@ -125,6 +190,105 @@ class _CodeEditorState extends State<CodeEditor> {
     }
 
     return EditorCursor(line: line, column: column);
+  }
+
+  int _cursorToOffset(EditorCursor cursor) {
+    final text = _controller.text;
+    final targetLine = cursor.line > 0 ? cursor.line : 1;
+    final targetColumn = cursor.column > 0 ? cursor.column : 1;
+    var line = 1;
+    var column = 1;
+
+    for (var index = 0; index < text.length; index += 1) {
+      if (line == targetLine && column == targetColumn) {
+        return index;
+      }
+      if (text.codeUnitAt(index) == 10) {
+        line += 1;
+        column = 1;
+      } else {
+        column += 1;
+      }
+    }
+
+    return text.length;
+  }
+
+  bool _isLineHighlighted(int lineNumber) {
+    final selection = widget.revealSelection;
+    if (selection == null) {
+      return false;
+    }
+    return lineNumber >= selection.start.line &&
+        lineNumber <= selection.end.line;
+  }
+
+  Diagnostic? _diagnosticForLine(int lineNumber) {
+    Diagnostic? candidate;
+    for (final diagnostic in widget.diagnostics) {
+      if (!diagnostic.range.containsLine(lineNumber)) {
+        continue;
+      }
+      if (candidate == null ||
+          _severityRank(diagnostic.severity) >
+              _severityRank(candidate.severity)) {
+        candidate = diagnostic;
+      }
+    }
+    return candidate;
+  }
+
+  int _severityRank(String severity) {
+    switch (severity) {
+      case 'error':
+        return 3;
+      case 'warning':
+        return 2;
+      case 'info':
+        return 1;
+      default:
+        return 0;
+    }
+  }
+
+  Color _severityColor(String severity) {
+    switch (severity) {
+      case 'error':
+        return const Color(0xFFFF4444);
+      case 'warning':
+        return const Color(0xFFFF8800);
+      case 'info':
+        return const Color(0xFF4488FF);
+      default:
+        return const Color(0xFF888888);
+    }
+  }
+
+  double _editorContentWidth(BuildContext context, double lineNumberWidth) {
+    final longestLineLength = _controller.text
+        .split('\n')
+        .fold<int>(
+          0,
+          (maxLength, line) =>
+              line.length > maxLength ? line.length : maxLength,
+        );
+    final viewportWidth =
+        MediaQuery.of(context).size.width - lineNumberWidth - 16;
+    final contentWidth = (longestLineLength + 1) * _characterWidth;
+    return contentWidth > viewportWidth ? contentWidth : viewportWidth;
+  }
+
+  IconData _severityIcon(String severity) {
+    switch (severity) {
+      case 'error':
+        return Icons.error;
+      case 'warning':
+        return Icons.warning;
+      case 'info':
+        return Icons.info_outline;
+      default:
+        return Icons.circle;
+    }
   }
 
   @override
@@ -145,6 +309,9 @@ class _CodeEditorState extends State<CodeEditor> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final lines = _controller.text.split('\n');
     final lineNumberWidth = '${lines.length}'.length * 10.0 + 24.0;
+    final highlightColor = Theme.of(
+      context,
+    ).colorScheme.primary.withValues(alpha: 0.12);
 
     return GestureDetector(
       onScaleStart: (_) {
@@ -160,9 +327,9 @@ class _CodeEditorState extends State<CodeEditor> {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Line numbers
           Container(
-            width: lineNumberWidth,
+            width:
+                lineNumberWidth + (widget.diagnostics.isNotEmpty ? 20.0 : 0.0),
             color: isDark ? const Color(0xFF1E1E1E) : const Color(0xFFF5F5F5),
             child: SingleChildScrollView(
               controller: _lineNumberScrollController,
@@ -171,30 +338,51 @@ class _CodeEditorState extends State<CodeEditor> {
                 child: RepaintBoundary(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.end,
-                    children: List.generate(
-                      lines.length,
-                      (i) => SizedBox(
-                        height: _fontSize * 1.5,
-                        child: Text(
-                          '${i + 1}',
-                          style: TextStyle(
-                            fontFamily: 'monospace',
-                            fontSize: _fontSize,
-                            height: 1.5,
-                            color: isDark
-                                ? Colors.grey.shade600
-                                : Colors.grey.shade400,
-                          ),
-                          textAlign: TextAlign.right,
+                    children: List.generate(lines.length, (index) {
+                      final lineNumber = index + 1;
+                      final diagnostic = _diagnosticForLine(lineNumber);
+                      return Container(
+                        height: _lineHeight,
+                        color: _isLineHighlighted(lineNumber)
+                            ? highlightColor
+                            : null,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            if (diagnostic != null)
+                              Tooltip(
+                                message:
+                                    '${diagnostic.severity}: ${diagnostic.message}',
+                                child: Icon(
+                                  _severityIcon(diagnostic.severity),
+                                  size: _fontSize,
+                                  color: _severityColor(diagnostic.severity),
+                                ),
+                              ),
+                            if (diagnostic != null) const SizedBox(width: 2),
+                            Text(
+                              '$lineNumber',
+                              style: TextStyle(
+                                fontFamily: 'monospace',
+                                fontSize: _fontSize,
+                                height: 1.5,
+                                color: diagnostic != null
+                                    ? _severityColor(diagnostic.severity)
+                                    : (isDark
+                                          ? Colors.grey.shade600
+                                          : Colors.grey.shade400),
+                              ),
+                              textAlign: TextAlign.right,
+                            ),
+                          ],
                         ),
-                      ),
-                    ),
+                      );
+                    }),
                   ),
                 ),
               ),
             ),
           ),
-          // Editor area
           Expanded(
             child: Container(
               color: isDark ? const Color(0xFF1E1E1E) : const Color(0xFFFFFFFF),
@@ -202,30 +390,31 @@ class _CodeEditorState extends State<CodeEditor> {
                 controller: _editorScrollController,
                 child: SingleChildScrollView(
                   scrollDirection: Axis.horizontal,
-                  child: ConstrainedBox(
-                    constraints: BoxConstraints(
-                      minWidth:
-                          MediaQuery.of(context).size.width - lineNumberWidth,
-                      minHeight: MediaQuery.of(context).size.height,
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(8),
-                      child: TextField(
-                        controller: _controller,
-                        focusNode: _focusNode,
-                        maxLines: null,
-                        expands: false,
-                        keyboardType: TextInputType.multiline,
-                        style: TextStyle(
-                          fontFamily: 'monospace',
-                          fontSize: _fontSize,
-                          height: 1.5,
-                          color: isDark ? Colors.white : Colors.black87,
-                        ),
-                        decoration: const InputDecoration(
-                          border: InputBorder.none,
-                          contentPadding: EdgeInsets.zero,
-                          isDense: true,
+                  child: SizedBox(
+                    width: _editorContentWidth(context, lineNumberWidth),
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(
+                        minHeight: MediaQuery.of(context).size.height,
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.all(8),
+                        child: TextField(
+                          controller: _controller,
+                          focusNode: _focusNode,
+                          maxLines: null,
+                          expands: false,
+                          keyboardType: TextInputType.multiline,
+                          style: TextStyle(
+                            fontFamily: 'monospace',
+                            fontSize: _fontSize,
+                            height: 1.5,
+                            color: isDark ? Colors.white : Colors.black87,
+                          ),
+                          decoration: const InputDecoration(
+                            border: InputBorder.none,
+                            contentPadding: EdgeInsets.zero,
+                            isDense: true,
+                          ),
                         ),
                       ),
                     ),

--- a/app/lib/widgets/code_viewer.dart
+++ b/app/lib/widgets/code_viewer.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:highlight/highlight.dart' show highlight, Node;
+import 'package:highlight/highlight.dart' show Node, highlight;
+
 import '../models/diagnostic.dart';
 import '../models/editor_context.dart';
 
-/// Maps highlight.js CSS class names to TextStyle.
 class _SyntaxTheme {
   final Map<String, TextStyle> styles;
   final TextStyle defaultStyle;
@@ -86,6 +86,10 @@ class CodeViewer extends StatefulWidget {
   final void Function(EditorSelection? selection)? onSelectionChanged;
   final VoidCallback? onEditRequested;
   final List<Diagnostic> diagnostics;
+  final VoidCallback? onLongPressHover;
+  final VoidCallback? onDefinitionRequested;
+  final EditorSelection? revealSelection;
+  final int revealNonce;
 
   const CodeViewer({
     super.key,
@@ -94,7 +98,11 @@ class CodeViewer extends StatefulWidget {
     this.onAskAi,
     this.onSelectionChanged,
     this.onEditRequested,
-    this.diagnostics = const [],
+    this.diagnostics = const <Diagnostic>[],
+    this.onLongPressHover,
+    this.onDefinitionRequested,
+    this.revealSelection,
+    this.revealNonce = 0,
   });
 
   @override
@@ -107,8 +115,10 @@ class _CodeViewerState extends State<CodeViewer> {
   String? _selectedText;
   bool _showToolbar = false;
   int _selectionGeneration = 0;
+  late ScrollController _lineNumberScrollController;
+  late ScrollController _viewerScrollController;
+  bool _isSyncing = false;
 
-  // Cached computations to avoid re-running on every zoom frame.
   Map<int, Diagnostic>? _cachedDiagnosticsByLine;
   List<Diagnostic>? _cachedDiagnosticsSource;
   List<TextSpan>? _cachedHighlightedSpans;
@@ -116,20 +126,89 @@ class _CodeViewerState extends State<CodeViewer> {
   String? _cachedFileName;
   Brightness? _cachedBrightness;
 
+  double get _lineHeight => _fontSize * 1.5;
+
+  @override
+  void initState() {
+    super.initState();
+    _lineNumberScrollController = ScrollController();
+    _viewerScrollController = ScrollController();
+    _viewerScrollController.addListener(_syncLineNumbersFromViewer);
+    _lineNumberScrollController.addListener(_syncViewerFromLineNumbers);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _revealSelection());
+  }
+
+  @override
+  void didUpdateWidget(CodeViewer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.revealNonce != widget.revealNonce ||
+        oldWidget.revealSelection != widget.revealSelection) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _revealSelection());
+    }
+  }
+
+  @override
+  void dispose() {
+    _viewerScrollController.removeListener(_syncLineNumbersFromViewer);
+    _lineNumberScrollController.removeListener(_syncViewerFromLineNumbers);
+    _lineNumberScrollController.dispose();
+    _viewerScrollController.dispose();
+    super.dispose();
+  }
+
+  void _syncLineNumbersFromViewer() {
+    if (_isSyncing) {
+      return;
+    }
+    _isSyncing = true;
+    if (_lineNumberScrollController.hasClients) {
+      _lineNumberScrollController.jumpTo(_viewerScrollController.offset);
+    }
+    _isSyncing = false;
+  }
+
+  void _syncViewerFromLineNumbers() {
+    if (_isSyncing) {
+      return;
+    }
+    _isSyncing = true;
+    if (_viewerScrollController.hasClients) {
+      _viewerScrollController.jumpTo(_lineNumberScrollController.offset);
+    }
+    _isSyncing = false;
+  }
+
+  void _revealSelection() {
+    final selection = widget.revealSelection;
+    if (selection == null || !_viewerScrollController.hasClients) {
+      return;
+    }
+    final targetOffset = ((selection.start.line - 1) * _lineHeight).clamp(
+      0.0,
+      _viewerScrollController.position.maxScrollExtent,
+    );
+    _viewerScrollController.animateTo(
+      targetOffset,
+      duration: const Duration(milliseconds: 180),
+      curve: Curves.easeOut,
+    );
+  }
+
   Map<int, Diagnostic> get _diagnosticsByLine {
     if (_cachedDiagnosticsSource != widget.diagnostics) {
       _cachedDiagnosticsSource = widget.diagnostics;
       final map = <int, Diagnostic>{};
-      for (final d in widget.diagnostics) {
-        final existing = map[d.line];
+      for (final diagnostic in widget.diagnostics) {
+        final existing = map[diagnostic.line];
         if (existing == null ||
-            _severityRank(d.severity) > _severityRank(existing.severity)) {
-          map[d.line] = d;
+            _severityRank(diagnostic.severity) >
+                _severityRank(existing.severity)) {
+          map[diagnostic.line] = diagnostic;
         }
       }
       _cachedDiagnosticsByLine = map;
     }
-    return _cachedDiagnosticsByLine!;
+    return _cachedDiagnosticsByLine ?? <int, Diagnostic>{};
   }
 
   int _severityRank(String severity) {
@@ -216,7 +295,6 @@ class _CodeViewerState extends State<CodeViewer> {
         return 'swift';
       case 'c':
       case 'h':
-        return 'cpp';
       case 'cpp':
       case 'cc':
       case 'hpp':
@@ -241,9 +319,12 @@ class _CodeViewerState extends State<CodeViewer> {
     _cachedBrightness = brightness;
     try {
       final result = highlight.parse(widget.content, language: _language);
-      _cachedHighlightedSpans = _convertNodes(result.nodes ?? [], syntaxTheme);
+      _cachedHighlightedSpans = _convertNodes(
+        result.nodes ?? <Node>[],
+        syntaxTheme,
+      );
     } catch (_) {
-      _cachedHighlightedSpans = [
+      _cachedHighlightedSpans = <TextSpan>[
         TextSpan(text: widget.content, style: syntaxTheme.defaultStyle),
       ];
     }
@@ -273,9 +354,13 @@ class _CodeViewerState extends State<CodeViewer> {
   }
 
   EditorSelection? _selectionFromText(String? text) {
-    if (text == null || text.isEmpty) return null;
+    if (text == null || text.isEmpty) {
+      return null;
+    }
     final startOffset = widget.content.indexOf(text);
-    if (startOffset < 0) return null;
+    if (startOffset < 0) {
+      return null;
+    }
     final endOffset = startOffset + text.length;
     return EditorSelection(
       start: _offsetToCursor(startOffset),
@@ -300,18 +385,41 @@ class _CodeViewerState extends State<CodeViewer> {
     return EditorCursor(line: line, column: column);
   }
 
+  bool _isLineHighlighted(int lineNumber) {
+    final selection = widget.revealSelection;
+    if (selection == null) {
+      return false;
+    }
+    return lineNumber >= selection.start.line &&
+        lineNumber <= selection.end.line;
+  }
+
   @override
   Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final brightness = Theme.of(context).brightness;
+    final isDark = brightness == Brightness.dark;
     final syntaxTheme = isDark ? _SyntaxTheme.dark() : _SyntaxTheme.light();
     final lines = widget.content.split('\n');
     final lineNumberWidth = '${lines.length}'.length * 10.0 + 24.0;
+    final highlightColor = Theme.of(
+      context,
+    ).colorScheme.primary.withValues(alpha: 0.12);
+    final revealSelection = widget.revealSelection;
+    final revealTop = revealSelection == null
+        ? 0.0
+        : 8 + ((revealSelection.start.line - 1) * _lineHeight);
+    final revealHeight = revealSelection == null
+        ? 0.0
+        : ((revealSelection.end.line - revealSelection.start.line + 1) *
+                  _lineHeight)
+              .clamp(_lineHeight, lines.length * _lineHeight);
 
     return Column(
       children: [
         Expanded(
           child: GestureDetector(
-            onScaleStart: (details) {
+            onLongPress: widget.onLongPressHover,
+            onScaleStart: (_) {
               _baseScaleFontSize = _fontSize;
             },
             onScaleUpdate: (details) {
@@ -339,7 +447,7 @@ class _CodeViewerState extends State<CodeViewer> {
                   } else if ((text == null || text.isEmpty) && _showToolbar) {
                     widget.onSelectionChanged?.call(null);
                     final expectedGeneration = _selectionGeneration;
-                    Future.delayed(const Duration(milliseconds: 300), () {
+                    Future<void>.delayed(const Duration(milliseconds: 300), () {
                       if (mounted &&
                           _selectionGeneration == expectedGeneration) {
                         setState(() {
@@ -349,49 +457,51 @@ class _CodeViewerState extends State<CodeViewer> {
                     });
                   }
                 },
-                child: SingleChildScrollView(
-                  child: SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        // Line numbers with diagnostic gutter
-                        Container(
-                          width:
-                              lineNumberWidth +
-                              (widget.diagnostics.isNotEmpty ? 20.0 : 0.0),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      width:
+                          lineNumberWidth +
+                          (widget.diagnostics.isNotEmpty ? 20.0 : 0.0),
+                      color: isDark
+                          ? const Color(0xFF1E1E1E)
+                          : const Color(0xFFF5F5F5),
+                      child: SingleChildScrollView(
+                        controller: _lineNumberScrollController,
+                        child: Padding(
                           padding: const EdgeInsets.symmetric(
                             vertical: 8,
                             horizontal: 4,
                           ),
-                          color: isDark
-                              ? const Color(0xFF1E1E1E)
-                              : const Color(0xFFF5F5F5),
                           child: RepaintBoundary(
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.end,
-                              children: List.generate(lines.length, (i) {
-                                final lineNum = i + 1;
-                                final diag = _diagnosticsByLine[lineNum];
-                                return SizedBox(
-                                  height: _fontSize * 1.5,
+                              children: List.generate(lines.length, (index) {
+                                final lineNum = index + 1;
+                                final diagnostic = _diagnosticsByLine[lineNum];
+                                return Container(
+                                  height: _lineHeight,
+                                  color: _isLineHighlighted(lineNum)
+                                      ? highlightColor
+                                      : null,
                                   child: Row(
                                     mainAxisSize: MainAxisSize.min,
                                     mainAxisAlignment: MainAxisAlignment.end,
                                     children: [
-                                      if (diag != null)
+                                      if (diagnostic != null)
                                         Tooltip(
                                           message:
-                                              '${diag.severity}: ${diag.message}',
+                                              '${diagnostic.severity}: ${diagnostic.message}',
                                           child: Icon(
-                                            _severityIcon(diag.severity),
+                                            _severityIcon(diagnostic.severity),
                                             size: _fontSize,
                                             color: _severityColor(
-                                              diag.severity,
+                                              diagnostic.severity,
                                             ),
                                           ),
                                         ),
-                                      if (diag != null)
+                                      if (diagnostic != null)
                                         const SizedBox(width: 2),
                                       Text(
                                         '$lineNum',
@@ -399,8 +509,10 @@ class _CodeViewerState extends State<CodeViewer> {
                                           fontFamily: 'monospace',
                                           fontSize: _fontSize,
                                           height: 1.5,
-                                          color: diag != null
-                                              ? _severityColor(diag.severity)
+                                          color: diagnostic != null
+                                              ? _severityColor(
+                                                  diagnostic.severity,
+                                                )
                                               : (isDark
                                                     ? Colors.grey.shade600
                                                     : Colors.grey.shade400),
@@ -414,32 +526,66 @@ class _CodeViewerState extends State<CodeViewer> {
                             ),
                           ),
                         ),
-                        // Code content with syntax highlighting
-                        Padding(
-                          padding: const EdgeInsets.all(8),
-                          child: RichText(
-                            text: TextSpan(
-                              style: TextStyle(
-                                fontFamily: 'monospace',
-                                fontSize: _fontSize,
-                                height: 1.5,
+                      ),
+                    ),
+                    Expanded(
+                      child: SingleChildScrollView(
+                        controller: _viewerScrollController,
+                        child: SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          child: Container(
+                            color: syntaxTheme.backgroundColor,
+                            child: ConstrainedBox(
+                              constraints: BoxConstraints(
+                                minWidth:
+                                    MediaQuery.of(context).size.width -
+                                    lineNumberWidth,
                               ),
-                              children: _buildHighlightedSpans(
-                                syntaxTheme,
-                                isDark ? Brightness.dark : Brightness.light,
+                              child: Stack(
+                                children: [
+                                  if (revealSelection != null)
+                                    Positioned(
+                                      left: 0,
+                                      right: 0,
+                                      top: revealTop,
+                                      height: revealHeight,
+                                      child: IgnorePointer(
+                                        child: DecoratedBox(
+                                          decoration: BoxDecoration(
+                                            color: highlightColor,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  Padding(
+                                    padding: const EdgeInsets.all(8),
+                                    child: RichText(
+                                      text: TextSpan(
+                                        style: TextStyle(
+                                          fontFamily: 'monospace',
+                                          fontSize: _fontSize,
+                                          height: 1.5,
+                                        ),
+                                        children: _buildHighlightedSpans(
+                                          syntaxTheme,
+                                          brightness,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ],
                               ),
                             ),
                           ),
                         ),
-                      ],
+                      ),
                     ),
-                  ),
+                  ],
                 ),
               ),
             ),
           ),
         ),
-        // Selection toolbar
         if (_showToolbar && _selectedText != null && _selectedText!.isNotEmpty)
           _SelectionToolbar(
             onAskAi: widget.onAskAi != null
@@ -454,8 +600,14 @@ class _CodeViewerState extends State<CodeViewer> {
                     setState(() => _showToolbar = false);
                   }
                 : null,
-            onCopy: () {
-              Clipboard.setData(ClipboardData(text: _selectedText!));
+            onDefinition: widget.onDefinitionRequested != null
+                ? () {
+                    widget.onDefinitionRequested!();
+                    setState(() => _showToolbar = false);
+                  }
+                : null,
+            onCopy: () async {
+              await Clipboard.setData(ClipboardData(text: _selectedText!));
               setState(() => _showToolbar = false);
               if (context.mounted) {
                 ScaffoldMessenger.of(context).showSnackBar(
@@ -475,9 +627,15 @@ class _CodeViewerState extends State<CodeViewer> {
 class _SelectionToolbar extends StatelessWidget {
   final VoidCallback? onAskAi;
   final VoidCallback? onEdit;
+  final VoidCallback? onDefinition;
   final VoidCallback onCopy;
 
-  const _SelectionToolbar({this.onAskAi, this.onEdit, required this.onCopy});
+  const _SelectionToolbar({
+    this.onAskAi,
+    this.onEdit,
+    this.onDefinition,
+    required this.onCopy,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -489,14 +647,22 @@ class _SelectionToolbar extends StatelessWidget {
         ),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      child: Wrap(
+        alignment: WrapAlignment.center,
+        spacing: 12,
+        runSpacing: 8,
         children: [
           if (onAskAi != null)
             TextButton.icon(
               onPressed: onAskAi,
               icon: const Icon(Icons.smart_toy, size: 20),
               label: const Text('Ask AI'),
+            ),
+          if (onDefinition != null)
+            TextButton.icon(
+              onPressed: onDefinition,
+              icon: const Icon(Icons.my_location, size: 20),
+              label: const Text('Go to'),
             ),
           if (onEdit != null)
             TextButton.icon(

--- a/app/lib/widgets/tool_use_card.dart
+++ b/app/lib/widgets/tool_use_card.dart
@@ -8,7 +8,7 @@ class ToolUseCard extends StatefulWidget {
   final ContentBlock? toolResult;
 
   /// Callback when a file path is tapped (for navigation to code viewer).
-  final void Function(String filePath)? onFileTap;
+  final void Function(String filePath, FileAnnotation? annotation)? onFileTap;
 
   const ToolUseCard({
     super.key,
@@ -85,7 +85,8 @@ class _ToolUseCardState extends State<ToolUseCard> {
       case 'Glob':
         icon = Icons.search;
         iconColor = Colors.indigo;
-        subtitle = filePath ?? widget.toolUse.input?['pattern'] as String? ?? 'Search';
+        subtitle =
+            filePath ?? widget.toolUse.input?['pattern'] as String? ?? 'Search';
         break;
       case 'Agent':
         icon = Icons.smart_toy_outlined;
@@ -101,7 +102,7 @@ class _ToolUseCardState extends State<ToolUseCard> {
     return InkWell(
       onTap: () {
         if (filePath != null && widget.onFileTap != null) {
-          widget.onFileTap!(filePath);
+          widget.onFileTap!(filePath, annotation);
         }
       },
       borderRadius: const BorderRadius.vertical(top: Radius.circular(10)),

--- a/app/test/providers/editor_provider_test.dart
+++ b/app/test/providers/editor_provider_test.dart
@@ -1,0 +1,215 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vscode_mobile/models/editor_context.dart';
+import 'package:vscode_mobile/models/editor_models.dart';
+import 'package:vscode_mobile/providers/editor_provider.dart';
+
+import '../test_support/editor_test_helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeFileApiClient fileApi;
+  late FakeEditorApiClient editorApi;
+  late EditorProvider provider;
+
+  setUp(() async {
+    final settings = await createTestSettings();
+    fileApi = FakeFileApiClient(
+      settings: settings,
+      seedFiles: <String, String>{
+        '/workspace/lib/main.dart': 'foo();\n',
+        '/workspace/lib/helper.dart': 'foo();\n',
+      },
+    );
+    editorApi = FakeEditorApiClient(
+      settings: settings,
+      seedDocuments: <String, String>{
+        '/workspace/lib/main.dart': 'foo();\n',
+        '/workspace/lib/helper.dart': 'foo();\n',
+      },
+    );
+    provider = EditorProvider(apiClient: fileApi, editorApiClient: editorApi);
+    await settleAsync();
+  });
+
+  tearDown(() async {
+    provider.dispose();
+    await editorApi.disposeFakes();
+  });
+
+  test(
+    'tracks bridge-backed open, change, save, and close lifecycle',
+    () async {
+      await provider.openFile('/workspace/lib/main.dart');
+      await settleAsync();
+
+      expect(provider.currentFile?.bridgeTracking, isTrue);
+      expect(provider.currentFile?.version, 1);
+      expect(
+        editorApi.lifecycleCalls.map(
+          (Map<String, dynamic> call) => call['method'],
+        ),
+        contains('doc/open'),
+      );
+
+      provider.updateCursor(const EditorCursor(line: 1, column: 1));
+      provider.updateContent('bar();\n');
+      await settleAsync();
+
+      expect(provider.currentFile?.hasUnsavedChanges, isTrue);
+      expect(
+        editorApi.lifecycleCalls.map(
+          (Map<String, dynamic> call) => call['method'],
+        ),
+        contains('doc/change'),
+      );
+
+      final saved = await provider.saveCurrentFile();
+      expect(saved, isTrue);
+      expect(provider.currentFile?.hasUnsavedChanges, isFalse);
+      expect(
+        editorApi.lifecycleCalls.map(
+          (Map<String, dynamic> call) => call['method'],
+        ),
+        contains('doc/save'),
+      );
+
+      final closed = await provider.closeFile(0);
+      expect(closed, isTrue);
+      expect(provider.openFiles, isEmpty);
+      expect(
+        editorApi.lifecycleCalls.map(
+          (Map<String, dynamic> call) => call['method'],
+        ),
+        contains('doc/close'),
+      );
+    },
+  );
+
+  test(
+    'applies completion edits and workspace edits across open files',
+    () async {
+      await provider.openFile('/workspace/lib/main.dart');
+      await settleAsync();
+
+      provider.updateCursor(const EditorCursor(line: 1, column: 4));
+      final completionApplied = await provider.applyCompletionItem(
+        completionItem(
+          label: 'print',
+        primaryEdit: textEdit(
+          startLine: 0,
+          startCharacter: 0,
+          endLine: 0,
+          endCharacter: 5,
+          newText: 'print()',
+        ),
+          additionalTextEdits: <EditorTextEdit>[
+            textEdit(
+              startLine: 0,
+              startCharacter: 0,
+              endLine: 0,
+              endCharacter: 0,
+              newText: '// generated\n',
+            ),
+          ],
+        ),
+      );
+      await settleAsync();
+
+      expect(completionApplied, isTrue);
+      expect(provider.currentFile?.currentContent, '// generated\nprint();\n');
+
+      final workspaceApplied = await provider.applyWorkspaceEdit(
+        const EditorWorkspaceEdit(
+          changes: <String, List<EditorTextEdit>>{
+            '/workspace/lib/main.dart': <EditorTextEdit>[
+              EditorTextEdit(
+                range: DocumentRange(
+                  start: DocumentPosition(line: 1, character: 0),
+                  end: DocumentPosition(line: 1, character: 5),
+                ),
+                newText: 'log()',
+              ),
+            ],
+            '/workspace/lib/helper.dart': <EditorTextEdit>[
+              EditorTextEdit(
+                range: DocumentRange(
+                  start: DocumentPosition(line: 0, character: 0),
+                  end: DocumentPosition(line: 0, character: 3),
+                ),
+                newText: 'log',
+              ),
+            ],
+          },
+        ),
+      );
+      await settleAsync();
+
+      expect(workspaceApplied, isTrue);
+      final helper = provider.openFiles.firstWhere(
+        (OpenFile file) => file.path == '/workspace/lib/helper.dart',
+      );
+      expect(helper.currentContent, 'log();\n');
+    },
+  );
+
+  test(
+    'records jump history and jumps back to the previous location',
+    () async {
+      await provider.openFileAt('/workspace/lib/main.dart', line: 1);
+      await provider.openFileAt('/workspace/lib/helper.dart', line: 1);
+      await settleAsync();
+
+      expect(provider.currentFile?.path, '/workspace/lib/helper.dart');
+      expect(provider.canJumpBack, isTrue);
+
+      final jumped = await provider.jumpBack();
+      await settleAsync();
+
+      expect(jumped, isTrue);
+      expect(provider.currentFile?.path, '/workspace/lib/main.dart');
+      expect(provider.revealSelection?.start.line, 1);
+    },
+  );
+
+  test(
+    'gates unavailable capabilities and refreshes diagnostics from bridge events',
+    () async {
+      editorApi.capabilitiesDocument = defaultCapabilities(
+        overrides: <String, dynamic>{
+          'completion': <String, dynamic>{'enabled': false},
+        },
+      );
+      await provider.refreshCapabilities();
+      await provider.openFile('/workspace/lib/main.dart');
+      await settleAsync();
+
+      final completions = await provider.requestCompletion();
+      expect(completions, isEmpty);
+      expect(provider.error, contains('Completion'));
+
+      editorApi.eventsChannel.serverSendJson(<String, dynamic>{
+        'type': 'bridge/diagnosticsChanged',
+        'payload': <String, dynamic>{
+          'path': '/workspace/lib/main.dart',
+          'diagnostics': <Map<String, dynamic>>[
+            <String, dynamic>{
+              'range': <String, dynamic>{
+                'start': <String, dynamic>{'line': 2, 'character': 1},
+                'end': <String, dynamic>{'line': 2, 'character': 5},
+              },
+              'severity': 2,
+              'message': 'unused value',
+              'source': 'dart',
+            },
+          ],
+        },
+      });
+      await settleAsync();
+
+      expect(provider.diagnostics, hasLength(1));
+      expect(provider.diagnostics.single.message, 'unused value');
+      expect(provider.diagnostics.single.severity, 'warning');
+    },
+  );
+}

--- a/app/test/services/editor_api_client_test.dart
+++ b/app/test/services/editor_api_client_test.dart
@@ -1,0 +1,344 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:vscode_mobile/models/diagnostic.dart';
+import 'package:vscode_mobile/models/editor_models.dart';
+import 'package:vscode_mobile/services/api_client.dart';
+import 'package:vscode_mobile/services/editor_api_client.dart';
+
+import '../test_support/editor_test_helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('fetches bridge capabilities with typed protocol metadata', () async {
+    final settings = await createTestSettings();
+    final client = EditorApiClient(
+      settings: settings,
+      client: MockClient((http.Request request) async {
+        expect(request.method, 'GET');
+        expect(request.url.path, '/bridge/capabilities');
+        expect(request.headers['Authorization'], 'Bearer dev-token');
+        return http.Response(
+          jsonEncode(<String, dynamic>{
+            'state': 'ready',
+            'generation': 'gen-editor',
+            'protocolVersion': '2026-04-20',
+            'bridgeVersion': '0.3.0',
+            'capabilities': <String, dynamic>{
+              'completion': <String, dynamic>{
+                'enabled': true,
+                'textEdit': true,
+              },
+              'rename': <String, dynamic>{'enabled': false},
+            },
+          }),
+          200,
+        );
+      }),
+    );
+
+    final document = await client.getCapabilities();
+
+    expect(document.state, 'ready');
+    expect(document.generation, 'gen-editor');
+    expect(document.protocolVersion, '2026-04-20');
+    expect(document.bridgeVersion, '0.3.0');
+    expect(document.isEnabled('completion'), isTrue);
+    expect(document.capabilities['completion']?.raw['textEdit'], isTrue);
+    expect(document.isEnabled('rename'), isFalse);
+  });
+
+  test('sends versioned document lifecycle payloads to the bridge', () async {
+    final settings = await createTestSettings();
+    var requestIndex = 0;
+    final client = EditorApiClient(
+      settings: settings,
+      client: MockClient((http.Request request) async {
+        final body = request.body.isEmpty
+            ? <String, dynamic>{}
+            : jsonDecode(request.body) as Map<String, dynamic>;
+
+        switch (requestIndex++) {
+          case 0:
+            expect(request.method, 'POST');
+            expect(request.url.path, '/bridge/doc/open');
+            expect(body, <String, dynamic>{
+              'path': '/workspace/lib/main.dart',
+              'version': 1,
+              'content': 'void main() {}\n',
+            });
+            return http.Response(
+              jsonEncode(<String, dynamic>{
+                'path': '/workspace/lib/main.dart',
+                'version': 1,
+                'content': 'void main() {}\n',
+              }),
+              200,
+            );
+          case 1:
+            expect(request.method, 'POST');
+            expect(request.url.path, '/bridge/doc/change');
+            expect(body, <String, dynamic>{
+              'path': '/workspace/lib/main.dart',
+              'version': 2,
+              'changes': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'range': <String, dynamic>{
+                    'start': <String, dynamic>{'line': 0, 'character': 13},
+                    'end': <String, dynamic>{'line': 0, 'character': 13},
+                  },
+                  'text': '\nprint("hi");',
+                },
+              ],
+            });
+            return http.Response(
+              jsonEncode(<String, dynamic>{
+                'path': '/workspace/lib/main.dart',
+                'version': 2,
+                'content': 'void main() {}\nprint("hi");',
+              }),
+              200,
+            );
+          case 2:
+            expect(request.method, 'POST');
+            expect(request.url.path, '/bridge/doc/save');
+            expect(body, <String, dynamic>{'path': '/workspace/lib/main.dart'});
+            return http.Response(
+              jsonEncode(<String, dynamic>{
+                'path': '/workspace/lib/main.dart',
+                'version': 2,
+                'content': 'void main() {}\nprint("hi");',
+              }),
+              200,
+            );
+          case 3:
+            expect(request.method, 'POST');
+            expect(request.url.path, '/bridge/doc/close');
+            expect(body, <String, dynamic>{'path': '/workspace/lib/main.dart'});
+            return http.Response(
+              jsonEncode(<String, dynamic>{'closed': true}),
+              200,
+            );
+          default:
+            fail('Unexpected request #$requestIndex');
+        }
+      }),
+    );
+
+    final opened = await client.openDocument(
+      path: '/workspace/lib/main.dart',
+      version: 1,
+      content: 'void main() {}\n',
+    );
+    final changed = await client.changeDocument(
+      path: '/workspace/lib/main.dart',
+      version: 2,
+      changes: <DocumentChange>[
+        const DocumentChange(
+          text: '\nprint("hi");',
+          range: DocumentRange(
+            start: DocumentPosition(line: 0, character: 13),
+            end: DocumentPosition(line: 0, character: 13),
+          ),
+        ),
+      ],
+    );
+    final saved = await client.saveDocument('/workspace/lib/main.dart');
+    await client.closeDocument('/workspace/lib/main.dart');
+
+    expect(opened.version, 1);
+    expect(changed.version, 2);
+    expect(saved.content, contains('print("hi");'));
+    expect(requestIndex, 4);
+  });
+
+  test(
+    'parses completion, diagnostics, and workspace edits into typed models',
+    () async {
+      final settings = await createTestSettings();
+      final client = EditorApiClient(
+        settings: settings,
+        client: MockClient((http.Request request) async {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          switch (request.url.path) {
+            case '/bridge/editor/completion':
+              expect(body['position'], <String, dynamic>{
+                'line': 3,
+                'character': 10,
+              });
+              return http.Response(
+                jsonEncode(<String, dynamic>{
+                  'isIncomplete': false,
+                  'items': <Map<String, dynamic>>[
+                    <String, dynamic>{
+                      'label': 'print',
+                      'detail': 'dart:core',
+                      'textEdit': <String, dynamic>{
+                        'range': <String, dynamic>{
+                          'start': <String, dynamic>{'line': 3, 'character': 7},
+                          'end': <String, dynamic>{'line': 3, 'character': 10},
+                        },
+                        'newText': 'print()',
+                      },
+                      'additionalTextEdits': <Map<String, dynamic>>[
+                        <String, dynamic>{
+                          'range': <String, dynamic>{
+                            'start': <String, dynamic>{
+                              'line': 0,
+                              'character': 0,
+                            },
+                            'end': <String, dynamic>{'line': 0, 'character': 0},
+                          },
+                          'newText': "import 'dart:developer';\\n",
+                        },
+                      ],
+                    },
+                  ],
+                }),
+                200,
+              );
+            case '/bridge/editor/diagnostics':
+              return http.Response(
+                jsonEncode(<String, dynamic>{
+                  'path': '/workspace/lib/main.dart',
+                  'diagnostics': <Map<String, dynamic>>[
+                    <String, dynamic>{
+                      'range': <String, dynamic>{
+                        'start': <String, dynamic>{'line': 4, 'character': 2},
+                        'end': <String, dynamic>{'line': 4, 'character': 8},
+                      },
+                      'severity': 1,
+                      'message': 'Undefined name',
+                      'source': 'dart',
+                    },
+                  ],
+                }),
+                200,
+              );
+            case '/bridge/editor/rename':
+              return http.Response(
+                jsonEncode(<String, dynamic>{
+                  'changes': <String, dynamic>{
+                    '/workspace/lib/main.dart': <Map<String, dynamic>>[
+                      <String, dynamic>{
+                        'range': <String, dynamic>{
+                          'start': <String, dynamic>{'line': 1, 'character': 4},
+                          'end': <String, dynamic>{'line': 1, 'character': 7},
+                        },
+                        'newText': 'renamedValue',
+                      },
+                    ],
+                  },
+                }),
+                200,
+              );
+            default:
+              fail('Unexpected editor RPC ${request.url.path}');
+          }
+        }),
+      );
+
+      final completions = await client.completion(
+        path: '/workspace/lib/main.dart',
+        version: 4,
+        position: const DocumentPosition(line: 3, character: 10),
+        workDir: '/workspace/lib',
+      );
+      final diagnostics = await client.diagnostics(
+        path: '/workspace/lib/main.dart',
+        version: 4,
+        workDir: '/workspace/lib',
+      );
+      final renameEdit = await client.rename(
+        path: '/workspace/lib/main.dart',
+        version: 4,
+        position: const DocumentPosition(line: 1, character: 4),
+        newName: 'renamedValue',
+        workDir: '/workspace/lib',
+      );
+
+      expect(completions.isIncomplete, isFalse);
+      expect(completions.items, hasLength(1));
+      expect(completions.items.single.label, 'print');
+      expect(completions.items.single.textEdit?.newText, 'print()');
+      expect(
+        completions.items.single.additionalTextEdits.single.newText,
+        "import 'dart:developer';\\n",
+      );
+
+      expect(diagnostics, hasLength(1));
+      expect(diagnostics.single, isA<Diagnostic>());
+      expect(diagnostics.single.line, 5);
+      expect(diagnostics.single.severity, 'error');
+      expect(diagnostics.single.message, 'Undefined name');
+
+      expect(renameEdit.changes.keys, contains('/workspace/lib/main.dart'));
+      final fileEdits = renameEdit.changes['/workspace/lib/main.dart']!;
+      expect(fileEdits.single.newText, 'renamedValue');
+      expect(fileEdits.single.range.start.line, 1);
+    },
+  );
+
+  test('surfaces structured bridge errors through ApiException', () async {
+    final settings = await createTestSettings();
+    final client = EditorApiClient(
+      settings: settings,
+      client: MockClient((http.Request request) async {
+        expect(request.method, 'POST');
+        expect(request.url.path, '/bridge/editor/rename');
+        return http.Response(
+          jsonEncode(<String, dynamic>{
+            'code': 'version_conflict',
+            'message': 'document version does not match the tracked buffer',
+          }),
+          409,
+        );
+      }),
+    );
+
+    await expectLater(
+      () => client.rename(
+        path: '/workspace/lib/main.dart',
+        version: 3,
+        position: const DocumentPosition(line: 5, character: 8),
+        newName: 'renamedValue',
+        workDir: '/workspace/lib',
+      ),
+      throwsA(
+        isA<ApiException>()
+            .having((ApiException error) => error.statusCode, 'statusCode', 409)
+            .having(
+              (ApiException error) => error.toString(),
+              'message',
+              allOf(
+                contains('version_conflict'),
+                contains('document version does not match the tracked buffer'),
+              ),
+            ),
+      ),
+    );
+  });
+
+  test('builds the unified bridge events websocket URI', () async {
+    final settings = await createTestSettings();
+    Uri? capturedUri;
+    final client = EditorApiClient(
+      settings: settings,
+      channelFactory: (Uri uri) {
+        capturedUri = uri;
+        return RecordingJsonChannel();
+      },
+    );
+
+    final channel = client.connectEventsWebSocket();
+
+    expect(
+      capturedUri?.toString(),
+      'ws://server.test/bridge/ws/events?token=dev-token',
+    );
+    await channel.sink.close();
+  });
+}

--- a/app/test/test_support/editor_test_helpers.dart
+++ b/app/test/test_support/editor_test_helpers.dart
@@ -1,0 +1,640 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:vscode_mobile/models/diagnostic.dart';
+import 'package:vscode_mobile/models/editor_models.dart';
+import 'package:vscode_mobile/models/search_result.dart';
+import 'package:vscode_mobile/providers/editor_provider.dart';
+import 'package:vscode_mobile/services/api_client.dart';
+import 'package:vscode_mobile/services/editor_api_client.dart';
+import 'package:vscode_mobile/services/settings_service.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+Future<SettingsService> createTestSettings({
+  String serverUrl = 'http://server.test',
+  String token = 'dev-token',
+}) async {
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  final settings = SettingsService();
+  await settings.load();
+  await settings.save(serverUrl, token);
+  return settings;
+}
+
+Future<void> settleAsync([int turns = 6]) async {
+  for (var index = 0; index < turns; index += 1) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+Future<void> pumpEditorUi(
+  WidgetTester tester, {
+  Duration settleFor = const Duration(milliseconds: 350),
+}) async {
+  await tester.pump();
+  await tester.pump(settleFor);
+}
+
+Future<void> disposeEditorHarness(
+  EditorProvider provider,
+  FakeEditorApiClient editorApi,
+  WidgetTester? tester,
+) async {
+  if (tester != null) {
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  }
+  provider.dispose();
+  if (!editorApi.eventsChannel.sink.isClosed) {
+    await editorApi.eventsChannel.sink.close();
+  }
+}
+
+class RecordingJsonSink implements WebSocketSink {
+  final List<dynamic> sentMessages = <dynamic>[];
+  bool isClosed = false;
+
+  @override
+  void add(dynamic event) {
+    if (isClosed) {
+      return;
+    }
+    sentMessages.add(event);
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> addStream(Stream<dynamic> stream) async {
+    await for (final dynamic event in stream) {
+      add(event);
+    }
+  }
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) async {
+    isClosed = true;
+  }
+
+  @override
+  Future<void> get done async {}
+}
+
+class RecordingJsonChannel extends StreamChannelMixin<dynamic>
+    implements WebSocketChannel {
+  RecordingJsonChannel()
+    : _controller = StreamController<dynamic>.broadcast(),
+      _sink = RecordingJsonSink();
+
+  final StreamController<dynamic> _controller;
+  final RecordingJsonSink _sink;
+  bool _isDisposed = false;
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  String? get closeReason => null;
+
+  @override
+  String? get protocol => null;
+
+  @override
+  Future<void> get ready async {}
+
+  @override
+  Stream<dynamic> get stream => _controller.stream;
+
+  @override
+  RecordingJsonSink get sink => _sink;
+
+  void serverSendJson(Map<String, dynamic> payload) {
+    if (_isDisposed || _controller.isClosed) {
+      return;
+    }
+    _controller.add(jsonEncode(payload));
+  }
+
+  Future<void> dispose() async {
+    if (_isDisposed) {
+      return;
+    }
+    _isDisposed = true;
+    await _sink.close();
+    await _controller.close();
+  }
+}
+
+class FakeFileApiClient extends ApiClient {
+  FakeFileApiClient({
+    Map<String, String>? seedFiles,
+    Map<String, List<Diagnostic>>? seedDiagnostics,
+    List<Map<String, dynamic>>? seedFileSearchResults,
+    List<ContentSearchResult>? seedContentSearchResults,
+    SettingsService? settings,
+    super.client,
+  }) : files = Map<String, String>.from(seedFiles ?? const <String, String>{}),
+       diagnosticsByPath = Map<String, List<Diagnostic>>.from(
+         seedDiagnostics ?? const <String, List<Diagnostic>>{},
+       ),
+       fileSearchResults = List<Map<String, dynamic>>.from(
+         seedFileSearchResults ?? const <Map<String, dynamic>>[],
+       ),
+       contentSearchResults = List<ContentSearchResult>.from(
+         seedContentSearchResults ?? const <ContentSearchResult>[],
+       ),
+       super(settings: settings ?? SettingsService());
+
+  final Map<String, String> files;
+  final Map<String, List<Diagnostic>> diagnosticsByPath;
+  final List<Map<String, dynamic>> lifecycleCalls = <Map<String, dynamic>>[];
+  final List<Map<String, dynamic>> fileSearchResults;
+  final List<ContentSearchResult> contentSearchResults;
+
+  @override
+  Future<String> readFile(String path) async {
+    lifecycleCalls.add(<String, dynamic>{'method': 'readFile', 'path': path});
+    return files[path] ?? '';
+  }
+
+  @override
+  Future<void> writeFile(String path, String content) async {
+    lifecycleCalls.add(<String, dynamic>{
+      'method': 'writeFile',
+      'path': path,
+      'content': content,
+    });
+    files[path] = content;
+  }
+
+  @override
+  Future<List<Diagnostic>> getDiagnostics({
+    String? filePath,
+    String workDir = '/',
+  }) async {
+    lifecycleCalls.add(<String, dynamic>{
+      'method': 'getDiagnostics',
+      'path': filePath,
+      'workDir': workDir,
+    });
+    return List<Diagnostic>.from(
+      diagnosticsByPath[filePath] ?? const <Diagnostic>[],
+    );
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> searchFiles(
+    String query,
+    String path,
+  ) async {
+    lifecycleCalls.add(<String, dynamic>{
+      'method': 'searchFiles',
+      'query': query,
+      'path': path,
+    });
+    return List<Map<String, dynamic>>.from(fileSearchResults);
+  }
+
+  @override
+  Future<List<ContentSearchResult>> searchContent(
+    String query,
+    String path,
+  ) async {
+    lifecycleCalls.add(<String, dynamic>{
+      'method': 'searchContent',
+      'query': query,
+      'path': path,
+    });
+    return List<ContentSearchResult>.from(contentSearchResults);
+  }
+}
+
+class FakeEditorApiClient extends EditorApiClient {
+  FakeEditorApiClient({
+    BridgeCapabilitiesDocument? capabilities,
+    Map<String, String>? seedDocuments,
+    RecordingJsonChannel? eventsChannel,
+    SettingsService? settings,
+  }) : _capabilities = capabilities ?? defaultCapabilities(),
+       documents = Map<String, String>.from(
+         seedDocuments ?? const <String, String>{},
+       ),
+       eventsChannel = eventsChannel ?? RecordingJsonChannel(),
+       super(settings: settings ?? SettingsService());
+
+  final Map<String, String> documents;
+  final RecordingJsonChannel eventsChannel;
+  final List<Map<String, dynamic>> lifecycleCalls = <Map<String, dynamic>>[];
+  final List<Map<String, dynamic>> rpcCalls = <Map<String, dynamic>>[];
+  final Map<String, int> versionsByPath = <String, int>{};
+
+  BridgeCapabilitiesDocument _capabilities;
+  List<Diagnostic> diagnosticsResponse = const <Diagnostic>[];
+  EditorCompletionList completionResponse = const EditorCompletionList(
+    isIncomplete: false,
+    items: <EditorCompletionItem>[],
+  );
+  EditorHover hoverResponse = const EditorHover(contents: 'hover');
+  List<EditorLocation> definitionResponse = const <EditorLocation>[];
+  List<EditorLocation> referencesResponse = const <EditorLocation>[];
+  EditorSignatureHelp? signatureHelpResponse;
+  List<EditorTextEdit> formattingResponse = const <EditorTextEdit>[];
+  List<EditorCodeAction> codeActionsResponse = const <EditorCodeAction>[];
+  EditorWorkspaceEdit renameResponse = const EditorWorkspaceEdit(
+    changes: <String, List<EditorTextEdit>>{},
+  );
+  List<Map<String, dynamic>> documentSymbolsResponse =
+      const <Map<String, dynamic>>[];
+
+  Future<DocumentSnapshot> Function(String path, int version, String? content)?
+  openDocumentHandler;
+  Future<DocumentSnapshot> Function(
+    String path,
+    int version,
+    List<DocumentChange> changes,
+  )?
+  changeDocumentHandler;
+  Future<DocumentSnapshot> Function(String path)? saveDocumentHandler;
+  Future<void> Function(String path)? closeDocumentHandler;
+
+  set capabilitiesDocument(BridgeCapabilitiesDocument value) {
+    _capabilities = value;
+  }
+
+  @override
+  Future<BridgeCapabilitiesDocument> getCapabilities() async => _capabilities;
+
+  Map<String, dynamic> _workDirField(String? workDir) => workDir == null
+      ? const <String, dynamic>{}
+      : <String, dynamic>{'workDir': workDir};
+
+  Map<String, dynamic> _contentField(String? content) => content == null
+      ? const <String, dynamic>{}
+      : <String, dynamic>{'content': content};
+
+  @override
+  WebSocketChannel connectEventsWebSocket() => eventsChannel;
+
+  @override
+  Future<DocumentSnapshot> openDocument({
+    required String path,
+    required int version,
+    String? content,
+  }) async {
+    lifecycleCalls.add(<String, dynamic>{
+      'method': 'doc/open',
+      'path': path,
+      'version': version,
+      ..._contentField(content),
+    });
+    if (openDocumentHandler != null) {
+      return openDocumentHandler!(path, version, content);
+    }
+    if (content != null) {
+      documents[path] = content;
+    }
+    versionsByPath[path] = version;
+    return DocumentSnapshot(
+      path: path,
+      version: version,
+      content: documents[path] ?? content ?? '',
+    );
+  }
+
+  @override
+  Future<DocumentSnapshot> changeDocument({
+    required String path,
+    required int version,
+    required List<DocumentChange> changes,
+  }) async {
+    lifecycleCalls.add(<String, dynamic>{
+      'method': 'doc/change',
+      'path': path,
+      'version': version,
+      'changes': changes
+          .map((DocumentChange change) => change.toJson())
+          .toList(),
+    });
+    if (changeDocumentHandler != null) {
+      return changeDocumentHandler!(path, version, changes);
+    }
+    final fullReplacement = changes.lastWhere(
+      (DocumentChange change) => change.range == null,
+      orElse: () => DocumentChange.fullReplacement(documents[path] ?? ''),
+    );
+    documents[path] = fullReplacement.text;
+    versionsByPath[path] = version;
+    return DocumentSnapshot(
+      path: path,
+      version: version,
+      content: documents[path] ?? '',
+    );
+  }
+
+  @override
+  Future<DocumentSnapshot> saveDocument(String path) async {
+    lifecycleCalls.add(<String, dynamic>{'method': 'doc/save', 'path': path});
+    if (saveDocumentHandler != null) {
+      return saveDocumentHandler!(path);
+    }
+    return DocumentSnapshot(
+      path: path,
+      version: versionsByPath[path] ?? 1,
+      content: documents[path] ?? '',
+    );
+  }
+
+  @override
+  Future<void> closeDocument(String path) async {
+    lifecycleCalls.add(<String, dynamic>{'method': 'doc/close', 'path': path});
+    if (closeDocumentHandler != null) {
+      await closeDocumentHandler!(path);
+    }
+  }
+
+  @override
+  Future<List<Diagnostic>> diagnostics({
+    required String path,
+    required int version,
+    String? workDir,
+  }) async {
+    rpcCalls.add(<String, dynamic>{
+      'method': 'diagnostics',
+      'path': path,
+      'version': version,
+      ..._workDirField(workDir),
+    });
+    return List<Diagnostic>.from(diagnosticsResponse);
+  }
+
+  @override
+  Future<EditorCompletionList> completion({
+    required String path,
+    required int version,
+    required DocumentPosition position,
+    String? workDir,
+  }) async {
+    rpcCalls.add(<String, dynamic>{
+      'method': 'completion',
+      'path': path,
+      'version': version,
+      'position': position.toJson(),
+      ..._workDirField(workDir),
+    });
+    return completionResponse;
+  }
+
+  @override
+  Future<EditorHover> hover({
+    required String path,
+    required int version,
+    required DocumentPosition position,
+    String? workDir,
+  }) async {
+    rpcCalls.add(<String, dynamic>{
+      'method': 'hover',
+      'path': path,
+      'version': version,
+      'position': position.toJson(),
+      ..._workDirField(workDir),
+    });
+    return hoverResponse;
+  }
+
+  @override
+  Future<List<EditorLocation>> definition({
+    required String path,
+    required int version,
+    required DocumentPosition position,
+    String? workDir,
+  }) async {
+    rpcCalls.add(<String, dynamic>{
+      'method': 'definition',
+      'path': path,
+      'version': version,
+      'position': position.toJson(),
+      ..._workDirField(workDir),
+    });
+    return List<EditorLocation>.from(definitionResponse);
+  }
+
+  @override
+  Future<List<EditorLocation>> references({
+    required String path,
+    required int version,
+    required DocumentPosition position,
+    String? workDir,
+  }) async {
+    rpcCalls.add(<String, dynamic>{
+      'method': 'references',
+      'path': path,
+      'version': version,
+      'position': position.toJson(),
+      ..._workDirField(workDir),
+    });
+    return List<EditorLocation>.from(referencesResponse);
+  }
+
+  @override
+  Future<EditorSignatureHelp?> signatureHelp({
+    required String path,
+    required int version,
+    required DocumentPosition position,
+    String? workDir,
+  }) async {
+    rpcCalls.add(<String, dynamic>{
+      'method': 'signatureHelp',
+      'path': path,
+      'version': version,
+      'position': position.toJson(),
+      ..._workDirField(workDir),
+    });
+    return signatureHelpResponse;
+  }
+
+  @override
+  Future<List<EditorTextEdit>> formatting({
+    required String path,
+    required int version,
+    String? workDir,
+  }) async {
+    rpcCalls.add(<String, dynamic>{
+      'method': 'formatting',
+      'path': path,
+      'version': version,
+      ..._workDirField(workDir),
+    });
+    return List<EditorTextEdit>.from(formattingResponse);
+  }
+
+  @override
+  Future<List<EditorCodeAction>> codeActions({
+    required String path,
+    required int version,
+    required DocumentRange range,
+    String? workDir,
+  }) async {
+    rpcCalls.add(<String, dynamic>{
+      'method': 'codeActions',
+      'path': path,
+      'version': version,
+      'range': range.toJson(),
+      ..._workDirField(workDir),
+    });
+    return List<EditorCodeAction>.from(codeActionsResponse);
+  }
+
+  @override
+  Future<EditorWorkspaceEdit> rename({
+    required String path,
+    required int version,
+    required DocumentPosition position,
+    required String newName,
+    String? workDir,
+  }) async {
+    rpcCalls.add(<String, dynamic>{
+      'method': 'rename',
+      'path': path,
+      'version': version,
+      'position': position.toJson(),
+      'newName': newName,
+      ..._workDirField(workDir),
+    });
+    return renameResponse;
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> documentSymbols({
+    required String path,
+    required int version,
+    String? workDir,
+  }) async {
+    rpcCalls.add(<String, dynamic>{
+      'method': 'documentSymbols',
+      'path': path,
+      'version': version,
+      ..._workDirField(workDir),
+    });
+    return List<Map<String, dynamic>>.from(documentSymbolsResponse);
+  }
+
+  Future<void> disposeFakes() async {
+    await Future<void>.delayed(Duration.zero);
+    await eventsChannel.dispose();
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+BridgeCapabilitiesDocument defaultCapabilities({
+  Map<String, dynamic>? overrides,
+}) {
+  return BridgeCapabilitiesDocument.fromJson(<String, dynamic>{
+    'state': 'ready',
+    'generation': 'gen-1',
+    'protocolVersion': '2026-04-20',
+    'bridgeVersion': '0.3.0',
+    'capabilities': <String, dynamic>{
+      'diagnostics': <String, dynamic>{'enabled': true},
+      'completion': <String, dynamic>{'enabled': true, 'textEdit': true},
+      'hover': <String, dynamic>{'enabled': true},
+      'definition': <String, dynamic>{'enabled': true},
+      'references': <String, dynamic>{'enabled': true},
+      'signatureHelp': <String, dynamic>{'enabled': true},
+      'formatting': <String, dynamic>{'enabled': true},
+      'codeActions': <String, dynamic>{'enabled': true},
+      'rename': <String, dynamic>{'enabled': true},
+      ...?overrides,
+    },
+  });
+}
+
+Diagnostic diagnostic({
+  String path = '/workspace/lib/main.dart',
+  int startLine = 0,
+  int startCharacter = 0,
+  int endLine = 0,
+  int endCharacter = 1,
+  String severity = 'error',
+  String message = 'Example problem',
+  String source = 'test',
+}) {
+  return Diagnostic(
+    filePath: path,
+    range: DocumentRange(
+      start: DocumentPosition(line: startLine, character: startCharacter),
+      end: DocumentPosition(line: endLine, character: endCharacter),
+    ),
+    severity: severity,
+    message: message,
+    source: source,
+  );
+}
+
+EditorLocation location({
+  required String path,
+  int startLine = 0,
+  int startCharacter = 0,
+  int endLine = 0,
+  int endCharacter = 1,
+}) {
+  return EditorLocation(
+    uri: Uri.file(path).toString(),
+    path: path,
+    range: DocumentRange(
+      start: DocumentPosition(line: startLine, character: startCharacter),
+      end: DocumentPosition(line: endLine, character: endCharacter),
+    ),
+  );
+}
+
+EditorTextEdit textEdit({
+  required int startLine,
+  required int startCharacter,
+  required int endLine,
+  required int endCharacter,
+  required String newText,
+}) {
+  return EditorTextEdit(
+    range: DocumentRange(
+      start: DocumentPosition(line: startLine, character: startCharacter),
+      end: DocumentPosition(line: endLine, character: endCharacter),
+    ),
+    newText: newText,
+  );
+}
+
+EditorCompletionItem completionItem({
+  required String label,
+  String detail = '',
+  String? insertText,
+  EditorTextEdit? primaryEdit,
+  List<EditorTextEdit> additionalTextEdits = const <EditorTextEdit>[],
+  dynamic documentation,
+}) {
+  return EditorCompletionItem(
+    label: label,
+    detail: detail,
+    insertText: insertText,
+    textEdit: primaryEdit,
+    additionalTextEdits: List<EditorTextEdit>.from(additionalTextEdits),
+    documentation: documentation,
+    raw: <String, dynamic>{'label': label},
+  );
+}
+
+Widget wrapWithMaterialApp({
+  required Widget child,
+  List<SingleChildWidget> providers = const <SingleChildWidget>[],
+}) {
+  return MultiProvider(
+    providers: providers,
+    child: MaterialApp(home: child),
+  );
+}

--- a/app/test/widgets/chat_bubble_test.dart
+++ b/app/test/widgets/chat_bubble_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vscode_mobile/models/chat_message.dart';
+import 'package:vscode_mobile/widgets/chat_bubble.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('forwards file taps from assistant tool cards', (tester) async {
+    String? tappedFilePath;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ChatBubble(
+            message: const ChatMessage(
+              role: 'assistant',
+              content: <ContentBlock>[
+                ContentBlock(
+                  type: 'tool_use',
+                  name: 'Read',
+                  input: <String, dynamic>{
+                    'file_path': '/workspace/lib/main.dart',
+                  },
+                ),
+              ],
+            ),
+            onFileTap: (String filePath, FileAnnotation? annotation) {
+              tappedFilePath = filePath;
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Read'), findsOneWidget);
+    expect(find.textContaining('/workspace/lib/main.dart'), findsOneWidget);
+
+    await tester.tap(find.textContaining('/workspace/lib/main.dart'));
+    await tester.pumpAndSettle();
+
+    expect(tappedFilePath, '/workspace/lib/main.dart');
+  });
+}

--- a/app/test/widgets/code_screen_test.dart
+++ b/app/test/widgets/code_screen_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
+import 'package:vscode_mobile/models/diagnostic.dart';
+import 'package:vscode_mobile/models/editor_context.dart';
+import 'package:vscode_mobile/models/editor_models.dart';
+import 'package:vscode_mobile/providers/editor_provider.dart';
+import 'package:vscode_mobile/screens/code_screen.dart';
+import 'package:vscode_mobile/widgets/code_viewer.dart';
+
+import '../test_support/editor_test_helpers.dart';
+
+Future<
+  ({
+    FakeFileApiClient fileApi,
+    FakeEditorApiClient editorApi,
+    EditorProvider provider,
+  })
+>
+_createProvider({
+  String content = 'foo\n',
+  List<Diagnostic> diagnostics = const <Diagnostic>[],
+}) async {
+  final settings = await createTestSettings();
+  final fileApi = FakeFileApiClient(
+    settings: settings,
+    seedFiles: <String, String>{'/workspace/lib/main.dart': content},
+  );
+  final editorApi = FakeEditorApiClient(
+    settings: settings,
+    seedDocuments: <String, String>{'/workspace/lib/main.dart': content},
+  )..diagnosticsResponse = diagnostics.cast();
+  final provider = EditorProvider(
+    apiClient: fileApi,
+    editorApiClient: editorApi,
+  );
+  await provider.openFile('/workspace/lib/main.dart');
+  return (fileApi: fileApi, editorApi: editorApi, provider: provider);
+}
+
+Widget _buildScreen(EditorProvider provider) {
+  return wrapWithMaterialApp(
+    providers: <SingleChildWidget>[
+      ChangeNotifierProvider<EditorProvider>.value(value: provider),
+    ],
+    child: const CodeScreen(),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('shows completion items and applies the selected completion', (
+    WidgetTester tester,
+  ) async {
+    final setup = await _createProvider();
+    addTearDown(() async {
+      await disposeEditorHarness(setup.provider, setup.editorApi, tester);
+    });
+
+    setup.provider.enterEditMode();
+    setup.provider.updateCursor(const EditorCursor(line: 1, column: 1));
+    setup.editorApi.completionResponse = EditorCompletionList(
+      isIncomplete: false,
+      items: <EditorCompletionItem>[
+        completionItem(
+          label: 'print',
+          detail: 'Insert print call',
+          primaryEdit: textEdit(
+            startLine: 0,
+            startCharacter: 0,
+            endLine: 0,
+            endCharacter: 3,
+            newText: 'print()',
+          ),
+        ),
+      ],
+    );
+    setup.editorApi.signatureHelpResponse = const EditorSignatureHelp(
+      signatures: <String>['print(value)'],
+      activeSignature: 0,
+      activeParameter: 0,
+    );
+
+    await setup.provider.requestCompletion();
+    await tester.pumpWidget(_buildScreen(setup.provider));
+    await pumpEditorUi(tester);
+
+    expect(find.text('print'), findsOneWidget);
+
+    tester
+        .widget<ListTile>(
+          find.ancestor(
+            of: find.text('print'),
+            matching: find.byType(ListTile),
+          ),
+        )
+        .onTap!
+        .call();
+    await pumpEditorUi(tester);
+
+    expect(setup.provider.currentFile?.currentContent, 'print()\n');
+    expect(find.text('print(value)'), findsOneWidget);
+    expect(setup.provider.completionItems, isEmpty);
+  });
+
+  testWidgets(
+    'long press opens hover details and problems panel navigates to the diagnostic range',
+    (WidgetTester tester) async {
+      final setup = await _createProvider(
+        content: 'one\nproblem\nthree\n',
+        diagnostics: <Diagnostic>[
+          diagnostic(
+            startLine: 1,
+            startCharacter: 0,
+            endLine: 1,
+            endCharacter: 7,
+            severity: 'error',
+            message: 'Broken line',
+          ),
+        ],
+      );
+      addTearDown(() async {
+        await disposeEditorHarness(setup.provider, setup.editorApi, tester);
+      });
+
+      setup.editorApi.hoverResponse = const EditorHover(contents: 'hover docs');
+      await tester.pumpWidget(_buildScreen(setup.provider));
+      await pumpEditorUi(tester);
+
+      tester
+          .widget<CodeViewer>(find.byType(CodeViewer))
+          .onLongPressHover!
+          .call();
+      await pumpEditorUi(tester);
+      expect(find.text('hover docs'), findsOneWidget);
+
+      Navigator.of(tester.element(find.byType(CodeViewer))).pop();
+      await pumpEditorUi(tester);
+
+      await tester.tap(find.byTooltip('Problems'));
+      await pumpEditorUi(tester);
+      expect(find.text('Broken line'), findsOneWidget);
+
+      await tester.tap(find.text('Broken line'));
+      await pumpEditorUi(tester);
+
+      expect(setup.provider.selection?.start.line, 2);
+      expect(setup.provider.selection?.end.line, 2);
+    },
+  );
+
+  testWidgets('closing a dirty file can save before closing the document', (
+    WidgetTester tester,
+  ) async {
+    final setup = await _createProvider();
+    addTearDown(() async {
+      await disposeEditorHarness(setup.provider, setup.editorApi, tester);
+    });
+
+    setup.provider.enterEditMode();
+    setup.provider.updateContent('bar\n');
+
+    await tester.pumpWidget(_buildScreen(setup.provider));
+    await pumpEditorUi(tester);
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await pumpEditorUi(tester);
+    await tester.tap(find.text('Close file'));
+    await pumpEditorUi(tester);
+
+    expect(find.text('Unsaved changes'), findsOneWidget);
+
+    await tester.tap(find.text('Save'));
+    await pumpEditorUi(tester);
+
+    expect(setup.provider.openFiles, isEmpty);
+    expect(
+      setup.editorApi.lifecycleCalls.map(
+        (Map<String, dynamic> call) => call['method'],
+      ),
+      containsAll(<String>['doc/save', 'doc/close']),
+    );
+  });
+}

--- a/app/test/widgets/code_viewer_test.dart
+++ b/app/test/widgets/code_viewer_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vscode_mobile/widgets/code_viewer.dart';
+
+import '../test_support/editor_test_helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('renders inline diagnostics in the viewer gutter', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CodeViewer(
+            content: 'void main() {\n  print("hi");\n}\n',
+            fileName: 'main.dart',
+            diagnostics: <dynamic>[
+              diagnostic(
+                path: '/workspace/lib/main.dart',
+                startLine: 1,
+                startCharacter: 2,
+                endLine: 1,
+                endCharacter: 7,
+                severity: 'error',
+                message: 'Example viewer error',
+              ),
+            ].cast(),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.error), findsOneWidget);
+
+    await tester.longPress(find.byIcon(Icons.error));
+    await tester.pumpAndSettle();
+
+    expect(find.text('error: Example viewer error'), findsOneWidget);
+    expect(find.text('2'), findsWidgets);
+  });
+}

--- a/app/test/widgets/search_screen_test.dart
+++ b/app/test/widgets/search_screen_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
+import 'package:vscode_mobile/models/search_result.dart';
+import 'package:vscode_mobile/providers/editor_provider.dart';
+import 'package:vscode_mobile/providers/search_provider.dart';
+import 'package:vscode_mobile/providers/workspace_provider.dart';
+import 'package:vscode_mobile/screens/code_screen.dart';
+import 'package:vscode_mobile/screens/search_screen.dart';
+
+import '../test_support/editor_test_helpers.dart';
+
+Future<
+  ({
+    FakeFileApiClient fileApi,
+    FakeEditorApiClient editorApi,
+    EditorProvider editorProvider,
+    SearchProvider searchProvider,
+    WorkspaceProvider workspaceProvider,
+  })
+>
+_createSearchHarness() async {
+  final settings = await createTestSettings();
+  final fileApi = FakeFileApiClient(
+    settings: settings,
+    seedFiles: <String, String>{
+      '/workspace/lib/main.dart': 'line 1\nneedle match\nline 3\n',
+      '/workspace/lib/other.dart': 'other file\n',
+    },
+    seedFileSearchResults: <Map<String, dynamic>>[
+      <String, dynamic>{
+        'path': '/workspace/lib/main.dart',
+        'name': 'main.dart',
+        'isDir': false,
+      },
+    ],
+    seedContentSearchResults: const <ContentSearchResult>[
+      ContentSearchResult(
+        file: '/workspace/lib/main.dart',
+        line: 2,
+        content: 'needle match',
+      ),
+    ],
+  );
+  final editorApi = FakeEditorApiClient(
+    settings: settings,
+    seedDocuments: <String, String>{
+      '/workspace/lib/main.dart': 'line 1\nneedle match\nline 3\n',
+      '/workspace/lib/other.dart': 'other file\n',
+    },
+  );
+  final workspaceProvider = WorkspaceProvider();
+  await workspaceProvider.setWorkspace('/workspace');
+  final editorProvider = EditorProvider(
+    apiClient: fileApi,
+    editorApiClient: editorApi,
+  );
+  final searchProvider = SearchProvider(apiClient: fileApi);
+  return (
+    fileApi: fileApi,
+    editorApi: editorApi,
+    editorProvider: editorProvider,
+    searchProvider: searchProvider,
+    workspaceProvider: workspaceProvider,
+  );
+}
+
+Widget _buildScreen({
+  required EditorProvider editorProvider,
+  required SearchProvider searchProvider,
+  required WorkspaceProvider workspaceProvider,
+}) {
+  return wrapWithMaterialApp(
+    providers: <SingleChildWidget>[
+      ChangeNotifierProvider<EditorProvider>.value(value: editorProvider),
+      ChangeNotifierProvider<SearchProvider>.value(value: searchProvider),
+      ChangeNotifierProvider<WorkspaceProvider>.value(value: workspaceProvider),
+    ],
+    child: const SearchScreen(),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'tapping a file search result opens the file in the code screen',
+    (WidgetTester tester) async {
+      final setup = await _createSearchHarness();
+      addTearDown(() async {
+        await disposeEditorHarness(
+          setup.editorProvider,
+          setup.editorApi,
+          tester,
+        );
+      });
+
+      await setup.searchProvider.search('main', '/workspace');
+      await tester.pumpWidget(
+        _buildScreen(
+          editorProvider: setup.editorProvider,
+          searchProvider: setup.searchProvider,
+          workspaceProvider: setup.workspaceProvider,
+        ),
+      );
+      await pumpEditorUi(tester);
+
+      expect(find.text('main.dart'), findsOneWidget);
+
+      tester
+          .widget<ListTile>(
+            find.ancestor(
+              of: find.text('main.dart'),
+              matching: find.byType(ListTile),
+            ),
+          )
+          .onTap!
+          .call();
+      await pumpEditorUi(tester);
+
+      expect(find.byType(CodeScreen), findsOneWidget);
+      expect(
+        setup.editorProvider.currentFile?.path,
+        '/workspace/lib/main.dart',
+      );
+      expect(setup.editorProvider.selection, isNull);
+      expect(setup.editorProvider.cursor?.line, 1);
+
+      Navigator.of(tester.element(find.byType(CodeScreen))).pop();
+      await pumpEditorUi(tester);
+    },
+  );
+
+  testWidgets('tapping a content result opens and locates the matching line', (
+    WidgetTester tester,
+  ) async {
+    final setup = await _createSearchHarness();
+    addTearDown(() async {
+      await disposeEditorHarness(setup.editorProvider, setup.editorApi, tester);
+    });
+
+    await setup.editorProvider.openFile('/workspace/lib/other.dart');
+
+    setup.searchProvider.setSearchMode(SearchMode.fileContent);
+    await setup.searchProvider.searchContent('needle', '/workspace');
+    await tester.pumpWidget(
+      _buildScreen(
+        editorProvider: setup.editorProvider,
+        searchProvider: setup.searchProvider,
+        workspaceProvider: setup.workspaceProvider,
+      ),
+    );
+    await pumpEditorUi(tester);
+
+    expect(find.text('main.dart:2'), findsOneWidget);
+
+    tester
+        .widget<ListTile>(
+          find.ancestor(
+            of: find.text('main.dart:2'),
+            matching: find.byType(ListTile),
+          ),
+        )
+        .onTap!
+        .call();
+    await pumpEditorUi(tester);
+
+    expect(find.byType(CodeScreen), findsOneWidget);
+    expect(setup.editorProvider.currentFile?.path, '/workspace/lib/main.dart');
+    expect(setup.editorProvider.selection?.start.line, 2);
+    expect(setup.editorProvider.selection?.end.line, 2);
+    expect(setup.editorProvider.revealSelection?.start.line, 2);
+    expect(setup.editorProvider.cursor?.line, 2);
+    expect(setup.editorProvider.canJumpBack, isTrue);
+
+    final jumped = await setup.editorProvider.jumpBack();
+    await pumpEditorUi(tester);
+
+    expect(jumped, isTrue);
+    expect(setup.editorProvider.currentFile?.path, '/workspace/lib/other.dart');
+
+    Navigator.of(tester.element(find.byType(CodeScreen))).pop();
+    await pumpEditorUi(tester);
+  });
+}

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -557,6 +557,46 @@ requirements:
       - server/internal/api/bridge_documents_test.go
     depends_on: [REQ-003, REQ-023]
 
+  - id: REQ-029
+    title: Flutter bridge-backed editor experience
+    description: >
+      Ticket ASE-44 upgrades the mobile editor from a local text field wrapper
+      into a bridge-backed document experience. Open documents track synced
+      content, version, dirty state, cursor/selection, and bridge lifecycle
+      events; editor RPCs respect `/bridge/capabilities`; definitions,
+      references, diagnostics, content search hits, and chat/session file
+      annotations share one open-and-locate flow with reveal state and jump
+      history; and diagnostics are visible both inline and through a
+      problems-style surface.
+    priority: P0
+    status: implemented
+    code:
+      - project-index.yaml
+      - app/lib/main.dart
+      - app/lib/models/chat_message.dart
+      - app/lib/models/diagnostic.dart
+      - app/lib/models/editor_models.dart
+      - app/lib/navigation/editor_navigation.dart
+      - app/lib/providers/editor_provider.dart
+      - app/lib/screens/chat_screen.dart
+      - app/lib/screens/code_screen.dart
+      - app/lib/screens/files_screen.dart
+      - app/lib/screens/search_screen.dart
+      - app/lib/screens/session_detail_screen.dart
+      - app/lib/services/editor_api_client.dart
+      - app/lib/widgets/chat_bubble.dart
+      - app/lib/widgets/code_editor.dart
+      - app/lib/widgets/code_viewer.dart
+      - app/lib/widgets/tool_use_card.dart
+    tests:
+      - app/test/services/editor_api_client_test.dart
+      - app/test/providers/editor_provider_test.dart
+      - app/test/widgets/code_screen_test.dart
+      - app/test/widgets/code_viewer_test.dart
+      - app/test/widgets/search_screen_test.dart
+      - app/test/widgets/contextual_chat_test.dart
+    depends_on: [REQ-007, REQ-008, REQ-010, REQ-013, REQ-024, REQ-025, REQ-026]
+
   # ============================================================
   # Iteration 5: Bug fixes from code review audit
   # ============================================================


### PR DESCRIPTION
## What changed
- replace the local code-screen text editing flow with a bridge-backed editor state layer that tracks document versions, cursor/selection state, completion/hover/signature sessions, diagnostics, jump history, and workspace edit application
- add a typed editor bridge client plus editor models so the Flutter app can call capabilities, document lifecycle, completion, hover, definition, references, formatting, rename, code actions, and diagnostics APIs consistently
- wire shared open-and-locate navigation across search/chat/files/session detail, extend inline diagnostics and problems UI, and add focused provider/service/widget coverage for the ASE-44 interaction slice

## Why
This finishes the mobile editor UX slice from ASE-44 / GitHub issue #5 so the Flutter client can consume runtime document + language features instead of behaving like a plain text box.

## Issue
- Closes #5
- Source issue: https://github.com/Lincyaw/openvsmobile/issues/5

## Validation
- `cd app && ~/flutter/bin/dart analyze`
- `cd app && ~/flutter/bin/flutter test test/providers/editor_provider_test.dart test/widgets/code_screen_test.dart`
- `cd app && ~/flutter/bin/flutter test test/services/editor_api_client_test.dart test/widgets/code_viewer_test.dart test/widgets/search_screen_test.dart`
- `cd app && ~/flutter/bin/flutter test test/widgets/chat_bubble_test.dart`

## Notes
- The local workspace still contains unrelated uncommitted harness files (`.claude/*`, `.codex/`, `.openase*`) that were intentionally left out of this branch commit.
