### PR TITLE
ASE-55: add GitHub issue/PR AI entry handoff

### DIFF
--- a/app/lib/models/chat_context_attachment.dart
+++ b/app/lib/models/chat_context_attachment.dart
@@ -1,0 +1,201 @@
+import 'github_collaboration_models.dart';
+
+enum ChatContextAttachmentSource { github }
+
+enum GitHubAttachmentKind {
+  issue,
+  issueComment,
+  pullRequest,
+  pullRequestComment,
+  pullRequestFile,
+}
+
+class ChatContextAttachment {
+  final ChatContextAttachmentSource source;
+  final GitHubAttachmentKind kind;
+  final String actionLabel;
+  final String reference;
+  final String title;
+  final String body;
+  final String? repositoryFullName;
+  final String? path;
+  final String? authorLogin;
+  final String? url;
+
+  const ChatContextAttachment({
+    required this.source,
+    required this.kind,
+    required this.actionLabel,
+    required this.reference,
+    required this.title,
+    required this.body,
+    this.repositoryFullName,
+    this.path,
+    this.authorLogin,
+    this.url,
+  });
+
+  String get sourceLabel => 'GitHub';
+
+  String get kindLabel => switch (kind) {
+    GitHubAttachmentKind.issue => 'Issue',
+    GitHubAttachmentKind.issueComment => 'Issue comment',
+    GitHubAttachmentKind.pullRequest => 'Pull request',
+    GitHubAttachmentKind.pullRequestComment => 'PR review comment',
+    GitHubAttachmentKind.pullRequestFile => 'PR file',
+  };
+
+  List<String> get previewDetails => <String>[
+    if (repositoryFullName != null && repositoryFullName!.isNotEmpty)
+      repositoryFullName!,
+    reference,
+    if (path != null && path!.isNotEmpty) 'Path: $path',
+    if (authorLogin != null && authorLogin!.isNotEmpty) 'Author: $authorLogin',
+    if (body.isNotEmpty) excerpt(body),
+  ];
+
+  Map<String, dynamic> toTransportJson() {
+    return <String, dynamic>{
+      'source': 'github',
+      'kind': _kindTransportValue(kind),
+      'action': actionLabel,
+      'reference': reference,
+      'title': title,
+      'body': body,
+      if (repositoryFullName != null && repositoryFullName!.isNotEmpty)
+        'repository': repositoryFullName,
+      if (path != null && path!.isNotEmpty) 'path': path,
+      if (authorLogin != null && authorLogin!.isNotEmpty) 'author': authorLogin,
+      if (url != null && url!.isNotEmpty) 'url': url,
+    };
+  }
+
+  static String excerpt(String text, {int maxLength = 280}) {
+    final normalized = text.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (normalized.length <= maxLength) {
+      return normalized;
+    }
+    return '${normalized.substring(0, maxLength - 1)}...';
+  }
+
+  static String _kindTransportValue(GitHubAttachmentKind kind) {
+    return switch (kind) {
+      GitHubAttachmentKind.issue => 'issue',
+      GitHubAttachmentKind.issueComment => 'issue_comment',
+      GitHubAttachmentKind.pullRequest => 'pull_request',
+      GitHubAttachmentKind.pullRequestComment => 'pull_request_comment',
+      GitHubAttachmentKind.pullRequestFile => 'pull_request_file',
+    };
+  }
+}
+
+class GitHubChatAttachment extends ChatContextAttachment {
+  const GitHubChatAttachment({
+    required super.kind,
+    required super.actionLabel,
+    required super.reference,
+    required super.title,
+    required super.body,
+    super.repositoryFullName,
+    super.path,
+    super.authorLogin,
+    super.url,
+  }) : super(source: ChatContextAttachmentSource.github);
+
+  factory GitHubChatAttachment.issueBody({
+    required GitHubRepositoryContext repository,
+    required GitHubIssue issue,
+    required String action,
+  }) {
+    return GitHubChatAttachment(
+      kind: GitHubAttachmentKind.issue,
+      actionLabel: _actionLabel(action, fallback: 'Summarize issue'),
+      reference: 'Issue #${issue.number}',
+      title: issue.title,
+      body: ChatContextAttachment.excerpt(issue.body),
+      repositoryFullName: repository.fullName,
+      authorLogin: issue.author?.login,
+      url: issue.htmlUrl,
+    );
+  }
+
+  factory GitHubChatAttachment.issueComment({
+    required GitHubRepositoryContext repository,
+    required GitHubIssue issue,
+    required GitHubIssueComment comment,
+  }) {
+    return GitHubChatAttachment(
+      kind: GitHubAttachmentKind.issueComment,
+      actionLabel: 'Check comment',
+      reference: 'Issue #${issue.number}',
+      title: issue.title,
+      body: ChatContextAttachment.excerpt(comment.body),
+      repositoryFullName: repository.fullName,
+      authorLogin: comment.author?.login,
+      url: comment.htmlUrl.isNotEmpty ? comment.htmlUrl : issue.htmlUrl,
+    );
+  }
+
+  factory GitHubChatAttachment.pullRequestBody({
+    required GitHubRepositoryContext repository,
+    required GitHubPullRequest pullRequest,
+    required String action,
+  }) {
+    return GitHubChatAttachment(
+      kind: GitHubAttachmentKind.pullRequest,
+      actionLabel: _actionLabel(action, fallback: 'Summarize PR'),
+      reference: 'PR #${pullRequest.number}',
+      title: pullRequest.title,
+      body: ChatContextAttachment.excerpt(pullRequest.body),
+      repositoryFullName: repository.fullName,
+      authorLogin: pullRequest.author?.login,
+      url: pullRequest.htmlUrl,
+    );
+  }
+
+  factory GitHubChatAttachment.pullRequestComment({
+    required GitHubRepositoryContext repository,
+    required GitHubPullRequest pullRequest,
+    required GitHubPullRequestComment comment,
+  }) {
+    return GitHubChatAttachment(
+      kind: GitHubAttachmentKind.pullRequestComment,
+      actionLabel: 'Check comment',
+      reference: 'PR #${pullRequest.number}',
+      title: pullRequest.title,
+      body: ChatContextAttachment.excerpt(comment.body),
+      repositoryFullName: repository.fullName,
+      path: comment.path,
+      authorLogin: comment.author?.login,
+      url: comment.htmlUrl.isNotEmpty ? comment.htmlUrl : pullRequest.htmlUrl,
+    );
+  }
+
+  factory GitHubChatAttachment.pullRequestFile({
+    required GitHubRepositoryContext repository,
+    required GitHubPullRequest pullRequest,
+    required GitHubPullRequestFile file,
+  }) {
+    return GitHubChatAttachment(
+      kind: GitHubAttachmentKind.pullRequestFile,
+      actionLabel: 'Review file',
+      reference: 'PR #${pullRequest.number}',
+      title: pullRequest.title,
+      body: ChatContextAttachment.excerpt(file.patch),
+      repositoryFullName: repository.fullName,
+      path: file.filename,
+      url: pullRequest.htmlUrl,
+    );
+  }
+
+  static String _actionLabel(String action, {required String fallback}) {
+    switch (action) {
+      case 'issue_reply':
+        return 'Draft reply';
+      case 'pull_request_review':
+        return 'AI review';
+      default:
+        return fallback;
+    }
+  }
+}

--- a/app/lib/navigation/github_chat_navigation.dart
+++ b/app/lib/navigation/github_chat_navigation.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/chat_context_attachment.dart';
+import '../providers/chat_provider.dart';
+import '../screens/chat_screen.dart';
+
+Future<void> openChatWithGitHubAttachment(
+  BuildContext context, {
+  required String prompt,
+  required GitHubChatAttachment attachment,
+}) async {
+  final chatProvider = context.read<ChatProvider>();
+  chatProvider.queueGitHubAction(prompt: prompt, attachment: attachment);
+
+  if (!context.mounted) {
+    return;
+  }
+
+  await Navigator.of(
+    context,
+  ).push(MaterialPageRoute<void>(builder: (_) => const ChatScreen()));
+}

--- a/app/lib/providers/chat_provider.dart
+++ b/app/lib/providers/chat_provider.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
+import '../models/chat_context_attachment.dart';
 import '../models/chat_message.dart';
 import '../models/editor_context.dart';
 import '../models/session.dart';
@@ -16,6 +17,7 @@ import '../services/chat_api_client.dart';
 class ChatProvider extends ChangeNotifier {
   final ChatApiClient _apiClient;
   EditorChatContext? _editorContext;
+  GitHubChatAttachment? _pendingGitHubAttachment;
 
   ChatProvider({required ChatApiClient apiClient}) : _apiClient = apiClient;
 
@@ -43,6 +45,10 @@ class ChatProvider extends ChangeNotifier {
 
   // -- Editor context shared by contextual + full chat --
   EditorChatContext? get editorContext => _editorContext;
+  GitHubChatAttachment? get pendingGitHubAttachment => _pendingGitHubAttachment;
+
+  String? _pendingDraftMessage;
+  String? get pendingDraftMessage => _pendingDraftMessage;
 
   // -- Session list --
   List<SessionMeta> _sessions = [];
@@ -67,6 +73,8 @@ class ChatProvider extends ChangeNotifier {
     _streamingBlocks.clear();
     _conversationId = null;
     _pendingMessage = null;
+    _pendingGitHubAttachment = null;
+    _pendingDraftMessage = null;
     _isStreaming = false;
     _error = null;
     notifyListeners();
@@ -86,8 +94,37 @@ class ChatProvider extends ChangeNotifier {
     _streamingBlocks.clear();
     _conversationId = null;
     _pendingMessage = null;
+    _pendingGitHubAttachment = null;
+    _pendingDraftMessage = null;
     _isStreaming = false;
     _error = null;
+    notifyListeners();
+  }
+
+  void queueGitHubAction({
+    required String prompt,
+    required GitHubChatAttachment attachment,
+  }) {
+    _pendingDraftMessage = prompt;
+    _pendingGitHubAttachment = attachment;
+    notifyListeners();
+  }
+
+  void clearPendingAttachment() {
+    clearPendingGitHubAttachment();
+  }
+
+  GitHubChatAttachment? get pendingAttachment => _pendingGitHubAttachment;
+
+  void setPendingGitHubAttachment(GitHubChatAttachment? attachment) {
+    if (_pendingGitHubAttachment == attachment) return;
+    _pendingGitHubAttachment = attachment;
+    notifyListeners();
+  }
+
+  void clearPendingDraftMessage() {
+    if (_pendingDraftMessage == null) return;
+    _pendingDraftMessage = null;
     notifyListeners();
   }
 
@@ -131,6 +168,12 @@ class ChatProvider extends ChangeNotifier {
     startConversation(workDir: workDir);
   }
 
+  void clearPendingGitHubAttachment() {
+    if (_pendingGitHubAttachment == null) return;
+    _pendingGitHubAttachment = null;
+    notifyListeners();
+  }
+
   /// Resume an existing conversation.
   void resumeConversation(String sessionId) {
     _ensureConnected();
@@ -168,17 +211,22 @@ class ChatProvider extends ChangeNotifier {
     _streamingBlocks.clear();
     _error = null;
 
-    _channel!.sink.add(
-      jsonEncode({
-        'type': 'send',
-        'sessionId': _conversationId,
-        'message': text,
-        'workspaceRoot': _workspacePath,
-        'activeFile': _editorContext?.activeFile,
-        'cursor': _editorContext?.cursor?.toJson(),
-        'selection': _editorContext?.selection?.toJson(),
-      }),
-    );
+    final payload = <String, dynamic>{
+      'type': 'send',
+      'sessionId': _conversationId,
+      'message': text,
+      'workspaceRoot': _workspacePath,
+      'activeFile': _editorContext?.activeFile,
+      'cursor': _editorContext?.cursor?.toJson(),
+      'selection': _editorContext?.selection?.toJson(),
+    };
+    if (_pendingGitHubAttachment != null) {
+      payload['attachment'] = _pendingGitHubAttachment!.toTransportJson();
+    }
+
+    _channel!.sink.add(jsonEncode(payload));
+    _pendingGitHubAttachment = null;
+    _pendingDraftMessage = null;
     notifyListeners();
   }
 
@@ -304,8 +352,9 @@ class ChatProvider extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final effectiveWorkspaceRoot =
-          allProjects ? null : (workspaceRoot ?? _workspacePath);
+      final effectiveWorkspaceRoot = allProjects
+          ? null
+          : (workspaceRoot ?? _workspacePath);
       _sessions = await _apiClient.getSessions(
         query: query,
         workspaceRoot: effectiveWorkspaceRoot,

--- a/app/lib/screens/chat_screen.dart
+++ b/app/lib/screens/chat_screen.dart
@@ -3,9 +3,9 @@ import 'package:provider/provider.dart';
 
 import '../navigation/editor_navigation.dart';
 import '../providers/chat_provider.dart';
-import '../providers/editor_provider.dart';
 import '../providers/workspace_provider.dart';
 import '../widgets/chat_bubble.dart';
+import '../widgets/chat_context_summary.dart';
 import 'session_list_screen.dart';
 
 /// Full-screen AI chat view (tab 2 in bottom navigation).
@@ -20,6 +20,7 @@ class _ChatScreenState extends State<ChatScreen> {
   final _controller = TextEditingController();
   final _scrollController = ScrollController();
   int _lastMessageCount = 0;
+  String? _lastAppliedDraft;
 
   @override
   void dispose() {
@@ -58,6 +59,7 @@ class _ChatScreenState extends State<ChatScreen> {
   Widget build(BuildContext context) {
     return Consumer<ChatProvider>(
       builder: (context, provider, _) {
+        _syncDraft(provider);
         return Scaffold(
           appBar: AppBar(
             title: Consumer<WorkspaceProvider>(
@@ -100,8 +102,13 @@ class _ChatScreenState extends State<ChatScreen> {
           body: Column(
             children: [
               if (provider.error != null) _buildErrorBanner(context, provider),
-              if (provider.editorContext?.hasContext ?? false)
-                _buildContextSummary(context, provider),
+              if ((provider.editorContext?.hasContext ?? false) ||
+                  provider.pendingAttachment != null)
+                ChatContextSummary(
+                  editorContext: provider.editorContext,
+                  attachment: provider.pendingAttachment,
+                  onClearAttachment: provider.clearPendingAttachment,
+                ),
               Expanded(child: _buildMessageList(context, provider)),
               _buildInputBar(context, provider),
             ],
@@ -109,6 +116,18 @@ class _ChatScreenState extends State<ChatScreen> {
         );
       },
     );
+  }
+
+  void _syncDraft(ChatProvider provider) {
+    final draft = provider.pendingDraftMessage;
+    if (draft == null ||
+        draft == _lastAppliedDraft ||
+        _controller.text.isNotEmpty) {
+      return;
+    }
+    _controller.text = draft;
+    _controller.selection = TextSelection.collapsed(offset: draft.length);
+    _lastAppliedDraft = draft;
   }
 
   Widget _buildErrorBanner(BuildContext context, ChatProvider provider) {
@@ -123,55 +142,6 @@ class _ChatScreenState extends State<ChatScreen> {
           child: const Text('Dismiss'),
         ),
       ],
-    );
-  }
-
-  Widget _buildContextSummary(BuildContext context, ChatProvider provider) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final ctx = provider.editorContext!;
-    final workspace = context.read<WorkspaceProvider>();
-    final fileName = (ctx.activeFile ?? '').split('/').last;
-    final selectionLabel = ctx.selection?.lineLabel ?? 'No selection';
-
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-      decoration: BoxDecoration(
-        color: colorScheme.secondaryContainer,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Icon(Icons.code, size: 18, color: colorScheme.onSecondaryContainer),
-          const SizedBox(width: 8),
-          Expanded(
-            child: DefaultTextStyle(
-              style: theme.textTheme.labelMedium!.copyWith(
-                color: colorScheme.onSecondaryContainer,
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text('Workspace: ${workspace.displayName}'),
-                  Text('File: $fileName', overflow: TextOverflow.ellipsis),
-                  Text('Selection: $selectionLabel'),
-                ],
-              ),
-            ),
-          ),
-          if (ctx.selection != null)
-            InkWell(
-              onTap: () => context.read<EditorProvider>().clearSelection(),
-              child: Icon(
-                Icons.close,
-                size: 18,
-                color: colorScheme.onSecondaryContainer,
-              ),
-            ),
-        ],
-      ),
     );
   }
 

--- a/app/lib/screens/github_issue_detail_screen.dart
+++ b/app/lib/screens/github_issue_detail_screen.dart
@@ -3,7 +3,9 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
+import '../models/chat_context_attachment.dart';
 import '../models/github_collaboration_models.dart';
+import '../navigation/github_chat_navigation.dart';
 import '../providers/github_collaboration_provider.dart';
 
 class GitHubIssueDetailScreen extends StatefulWidget {
@@ -93,7 +95,21 @@ class _GitHubIssueDetailScreenState extends State<GitHubIssueDetailScreen> {
                 child: ListView(
                   padding: const EdgeInsets.all(16),
                   children: [
-                    _IssueHeader(issue: detail.issue),
+                    _IssueHeader(
+                      issue: detail.issue,
+                      onAiOverview: () => _openIssueAi(
+                        detail,
+                        action: 'issue_overview',
+                        prompt:
+                            'Summarize the key context and next steps for this GitHub issue.',
+                      ),
+                      onAiReply: () => _openIssueAi(
+                        detail,
+                        action: 'issue_reply',
+                        prompt:
+                            'Draft a helpful response or implementation plan for this GitHub issue.',
+                      ),
+                    ),
                     const SizedBox(height: 16),
                     Card(
                       child: Padding(
@@ -120,7 +136,10 @@ class _GitHubIssueDetailScreenState extends State<GitHubIssueDetailScreen> {
                       )
                     else
                       ...detail.comments.map(
-                        (comment) => _IssueCommentCard(comment: comment),
+                        (comment) => _IssueCommentCard(
+                          comment: comment,
+                          onAiReply: () => _openIssueCommentAi(detail, comment),
+                        ),
                       ),
                   ],
                 ),
@@ -160,12 +179,65 @@ class _GitHubIssueDetailScreenState extends State<GitHubIssueDetailScreen> {
       ),
     );
   }
+
+  Future<void> _openIssueAi(
+    GitHubIssueDetail detail, {
+    required String action,
+    required String prompt,
+  }) async {
+    final repository = context
+        .read<GitHubCollaborationProvider>()
+        .repoContext
+        ?.repository;
+    if (repository == null) {
+      return;
+    }
+
+    await openChatWithGitHubAttachment(
+      context,
+      prompt: prompt,
+      attachment: GitHubChatAttachment.issueBody(
+        repository: repository,
+        issue: detail.issue,
+        action: action,
+      ),
+    );
+  }
+
+  Future<void> _openIssueCommentAi(
+    GitHubIssueDetail detail,
+    GitHubIssueComment comment,
+  ) async {
+    final repository = context
+        .read<GitHubCollaborationProvider>()
+        .repoContext
+        ?.repository;
+    if (repository == null) {
+      return;
+    }
+
+    await openChatWithGitHubAttachment(
+      context,
+      prompt: 'Draft a response to this GitHub issue comment.',
+      attachment: GitHubChatAttachment.issueComment(
+        repository: repository,
+        issue: detail.issue,
+        comment: comment,
+      ),
+    );
+  }
 }
 
 class _IssueHeader extends StatelessWidget {
   final GitHubIssue issue;
+  final VoidCallback onAiOverview;
+  final VoidCallback onAiReply;
 
-  const _IssueHeader({required this.issue});
+  const _IssueHeader({
+    required this.issue,
+    required this.onAiOverview,
+    required this.onAiReply,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -197,6 +269,23 @@ class _IssueHeader extends StatelessWidget {
                   ),
               ],
             ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                FilledButton.icon(
+                  onPressed: onAiOverview,
+                  icon: const Icon(Icons.auto_awesome),
+                  label: const Text('Summarize issue'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: onAiReply,
+                  icon: const Icon(Icons.mode_comment_outlined),
+                  label: const Text('Draft reply'),
+                ),
+              ],
+            ),
           ],
         ),
       ),
@@ -206,8 +295,9 @@ class _IssueHeader extends StatelessWidget {
 
 class _IssueCommentCard extends StatelessWidget {
   final GitHubIssueComment comment;
+  final VoidCallback onAiReply;
 
-  const _IssueCommentCard({required this.comment});
+  const _IssueCommentCard({required this.comment, required this.onAiReply});
 
   @override
   Widget build(BuildContext context) {
@@ -219,11 +309,22 @@ class _IssueCommentCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              comment.author?.login.isNotEmpty == true
-                  ? comment.author!.login
-                  : 'Unknown author',
-              style: Theme.of(context).textTheme.titleSmall,
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    comment.author?.login.isNotEmpty == true
+                        ? comment.author!.login
+                        : 'Unknown author',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                ),
+                TextButton.icon(
+                  onPressed: onAiReply,
+                  icon: const Icon(Icons.auto_awesome_outlined, size: 18),
+                  label: const Text('Check comment'),
+                ),
+              ],
             ),
             if (comment.createdAt != null)
               Text(
@@ -264,7 +365,7 @@ class _IssueCommentComposer extends StatelessWidget {
               child: TextField(
                 controller: controller,
                 minLines: 1,
-                maxLines: 4,
+                maxLines: 5,
                 decoration: const InputDecoration(
                   labelText: 'Add a comment',
                   border: OutlineInputBorder(),
@@ -273,7 +374,7 @@ class _IssueCommentComposer extends StatelessWidget {
             ),
             const SizedBox(width: 12),
             FilledButton(
-              onPressed: isSubmitting ? null : () => onSubmit(),
+              onPressed: isSubmitting ? null : onSubmit,
               child: isSubmitting
                   ? const SizedBox(
                       width: 16,

--- a/app/lib/screens/github_pull_request_detail_screen.dart
+++ b/app/lib/screens/github_pull_request_detail_screen.dart
@@ -3,8 +3,10 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
+import '../models/chat_context_attachment.dart';
 import '../models/editor_context.dart';
 import '../models/github_collaboration_models.dart';
+import '../navigation/github_chat_navigation.dart';
 import '../providers/editor_provider.dart';
 import '../providers/github_collaboration_provider.dart';
 import 'code_screen.dart';
@@ -120,11 +122,27 @@ class _GitHubPullRequestDetailScreenState
                 Expanded(
                   child: TabBarView(
                     children: [
-                      _PullRequestOverviewTab(detail: detail),
+                      _PullRequestOverviewTab(
+                        detail: detail,
+                        onAiSummary: () => _openPullRequestAi(
+                          detail,
+                          action: 'pull_request_overview',
+                          prompt:
+                              'Summarize this pull request and call out review risks.',
+                        ),
+                        onAiReview: () => _openPullRequestAi(
+                          detail,
+                          action: 'pull_request_review',
+                          prompt:
+                              'Review this pull request and suggest feedback or follow-up changes.',
+                        ),
+                      ),
                       _PullRequestFilesTab(
-                        files: detail.files,
+                        detail: detail,
                         isResolvingFile: _isResolvingFile,
                         onOpenFile: (file) => _openFile(provider, file),
+                        onAiFile: (file) =>
+                            _openPullRequestFileAi(detail, file),
                       ),
                       _PullRequestConversationTab(
                         detail: detail,
@@ -137,6 +155,8 @@ class _GitHubPullRequestDetailScreenState
                           });
                         },
                         onSubmit: () => _submitReview(provider),
+                        onAiComment: (comment) =>
+                            _openPullRequestCommentAi(detail, comment),
                       ),
                       _PullRequestChecksTab(detail: detail),
                     ],
@@ -165,7 +185,7 @@ class _GitHubPullRequestDetailScreenState
       }
       if (action.shouldOpenLocalFile) {
         final editorProvider = context.read<EditorProvider>();
-        await editorProvider.openFile(
+        await editorProvider.openFileAt(
           action.localPath,
           cursor: EditorCursor(line: action.line ?? 1, column: 1),
         );
@@ -225,12 +245,89 @@ class _GitHubPullRequestDetailScreenState
       );
     }
   }
+
+  Future<void> _openPullRequestAi(
+    GitHubPullRequestDetail detail, {
+    required String action,
+    required String prompt,
+  }) async {
+    final repository = context
+        .read<GitHubCollaborationProvider>()
+        .repoContext
+        ?.repository;
+    if (repository == null) {
+      return;
+    }
+
+    await openChatWithGitHubAttachment(
+      context,
+      prompt: prompt,
+      attachment: GitHubChatAttachment.pullRequestBody(
+        repository: repository,
+        pullRequest: detail.pullRequest,
+        action: action,
+      ),
+    );
+  }
+
+  Future<void> _openPullRequestCommentAi(
+    GitHubPullRequestDetail detail,
+    GitHubPullRequestComment comment,
+  ) async {
+    final repository = context
+        .read<GitHubCollaborationProvider>()
+        .repoContext
+        ?.repository;
+    if (repository == null) {
+      return;
+    }
+
+    await openChatWithGitHubAttachment(
+      context,
+      prompt: 'Draft a response to this pull request comment.',
+      attachment: GitHubChatAttachment.pullRequestComment(
+        repository: repository,
+        pullRequest: detail.pullRequest,
+        comment: comment,
+      ),
+    );
+  }
+
+  Future<void> _openPullRequestFileAi(
+    GitHubPullRequestDetail detail,
+    GitHubPullRequestFile file,
+  ) async {
+    final repository = context
+        .read<GitHubCollaborationProvider>()
+        .repoContext
+        ?.repository;
+    if (repository == null) {
+      return;
+    }
+
+    await openChatWithGitHubAttachment(
+      context,
+      prompt:
+          'Review the changes in this pull request file and highlight issues.',
+      attachment: GitHubChatAttachment.pullRequestFile(
+        repository: repository,
+        pullRequest: detail.pullRequest,
+        file: file,
+      ),
+    );
+  }
 }
 
 class _PullRequestOverviewTab extends StatelessWidget {
   final GitHubPullRequestDetail detail;
+  final VoidCallback onAiSummary;
+  final VoidCallback onAiReview;
 
-  const _PullRequestOverviewTab({required this.detail});
+  const _PullRequestOverviewTab({
+    required this.detail,
+    required this.onAiSummary,
+    required this.onAiReview,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -271,6 +368,23 @@ class _PullRequestOverviewTab extends StatelessWidget {
                 const SizedBox(height: 12),
                 Text('Base: ${pull.baseRef.ref}'),
                 Text('Head: ${pull.headRef.ref}'),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    FilledButton.icon(
+                      onPressed: onAiSummary,
+                      icon: const Icon(Icons.auto_awesome),
+                      label: const Text('Summarize PR'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: onAiReview,
+                      icon: const Icon(Icons.rate_review_outlined),
+                      label: const Text('AI review'),
+                    ),
+                  ],
+                ),
               ],
             ),
           ),
@@ -292,18 +406,21 @@ class _PullRequestOverviewTab extends StatelessWidget {
 }
 
 class _PullRequestFilesTab extends StatelessWidget {
-  final List<GitHubPullRequestFile> files;
+  final GitHubPullRequestDetail detail;
   final bool isResolvingFile;
   final ValueChanged<GitHubPullRequestFile> onOpenFile;
+  final ValueChanged<GitHubPullRequestFile> onAiFile;
 
   const _PullRequestFilesTab({
-    required this.files,
+    required this.detail,
     required this.isResolvingFile,
     required this.onOpenFile,
+    required this.onAiFile,
   });
 
   @override
   Widget build(BuildContext context) {
+    final files = detail.files;
     if (files.isEmpty) {
       return const Center(child: Text('No changed files reported.'));
     }
@@ -320,7 +437,17 @@ class _PullRequestFilesTab extends StatelessWidget {
               subtitle: Text(
                 '${file.status} · +${file.additions} / -${file.deletions}',
               ),
-              trailing: const Icon(Icons.chevron_right),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    tooltip: 'Ask AI about file',
+                    onPressed: () => onAiFile(file),
+                    icon: const Icon(Icons.auto_awesome_outlined),
+                  ),
+                  const Icon(Icons.chevron_right),
+                ],
+              ),
               onTap: () => onOpenFile(file),
             );
           },
@@ -346,6 +473,7 @@ class _PullRequestConversationTab extends StatelessWidget {
   final bool isSubmitting;
   final ValueChanged<String> onEventChanged;
   final Future<void> Function() onSubmit;
+  final ValueChanged<GitHubPullRequestComment> onAiComment;
 
   const _PullRequestConversationTab({
     required this.detail,
@@ -354,6 +482,7 @@ class _PullRequestConversationTab extends StatelessWidget {
     required this.isSubmitting,
     required this.onEventChanged,
     required this.onSubmit,
+    required this.onAiComment,
   });
 
   @override
@@ -420,11 +549,25 @@ class _PullRequestConversationTab extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
-                      comment.author?.login.isNotEmpty == true
-                          ? comment.author!.login
-                          : 'Unknown author',
-                      style: Theme.of(context).textTheme.titleSmall,
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            comment.author?.login.isNotEmpty == true
+                                ? comment.author!.login
+                                : 'Unknown author',
+                            style: Theme.of(context).textTheme.titleSmall,
+                          ),
+                        ),
+                        TextButton.icon(
+                          onPressed: () => onAiComment(comment),
+                          icon: const Icon(
+                            Icons.auto_awesome_outlined,
+                            size: 18,
+                          ),
+                          label: const Text('Check comment'),
+                        ),
+                      ],
                     ),
                     if (comment.path.isNotEmpty)
                       Text(

--- a/app/lib/widgets/chat_context_summary.dart
+++ b/app/lib/widgets/chat_context_summary.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/chat_context_attachment.dart';
+import '../models/editor_context.dart';
+import '../providers/editor_provider.dart';
+import '../providers/workspace_provider.dart';
+
+class ChatContextSummary extends StatelessWidget {
+  final EditorChatContext? editorContext;
+  final ChatContextAttachment? attachment;
+  final EdgeInsetsGeometry margin;
+  final VoidCallback? onClearAttachment;
+
+  const ChatContextSummary({
+    super.key,
+    required this.editorContext,
+    required this.attachment,
+    this.margin = const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+    this.onClearAttachment,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final hasEditorContext = editorContext?.hasContext ?? false;
+    final hasPendingGitHubAttachment =
+        attachment?.source == ChatContextAttachmentSource.github;
+
+    if (!hasEditorContext && attachment == null) {
+      return const SizedBox.shrink();
+    }
+
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final workspace = context.read<WorkspaceProvider>();
+    final ctx = editorContext;
+    final fileName = (ctx?.activeFile ?? '').split('/').last;
+    final selectionLabel = ctx?.selection?.lineLabel ?? 'No selection';
+
+    return Container(
+      margin: margin,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: DefaultTextStyle(
+        style: theme.textTheme.labelMedium!.copyWith(
+          color: colorScheme.onSecondaryContainer,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (hasEditorContext)
+              _SummarySection(
+                icon: Icons.code,
+                title: 'Editor context',
+                trailing: ctx?.selection != null
+                    ? InkWell(
+                        onTap: () =>
+                            context.read<EditorProvider>().clearSelection(),
+                        child: Icon(
+                          Icons.close,
+                          size: 16,
+                          color: colorScheme.onSecondaryContainer,
+                        ),
+                      )
+                    : null,
+                lines: <String>[
+                  'Workspace: ${workspace.displayName}',
+                  'File: $fileName',
+                  'Selection: $selectionLabel',
+                ],
+              ),
+            if (hasEditorContext && hasPendingGitHubAttachment)
+              Divider(
+                height: 16,
+                color: colorScheme.onSecondaryContainer.withValues(alpha: 0.18),
+              ),
+            if (attachment != null)
+              _SummarySection(
+                icon: Icons.smart_toy_outlined,
+                title: 'GitHub attachment',
+                trailing: onClearAttachment == null
+                    ? null
+                    : InkWell(
+                        onTap: onClearAttachment,
+                        child: Icon(
+                          Icons.close,
+                          size: 16,
+                          color: colorScheme.onSecondaryContainer,
+                        ),
+                      ),
+                lines: <String>[
+                  attachment!.actionLabel,
+                  '${attachment!.kindLabel}: ${attachment!.title}',
+                  ...attachment!.previewDetails,
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SummarySection extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final List<String> lines;
+  final Widget? trailing;
+
+  const _SummarySection({
+    required this.icon,
+    required this.title,
+    required this.lines,
+    this.trailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, size: 16, color: colorScheme.onSecondaryContainer),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: colorScheme.onSecondaryContainer,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 2),
+              ...lines.map(
+                (line) =>
+                    Text(line, overflow: TextOverflow.ellipsis, maxLines: 2),
+              ),
+            ],
+          ),
+        ),
+        if (trailing != null) ...[const SizedBox(width: 8), trailing!],
+      ],
+    );
+  }
+}

--- a/app/lib/widgets/contextual_chat.dart
+++ b/app/lib/widgets/contextual_chat.dart
@@ -2,9 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../providers/chat_provider.dart';
-import '../providers/editor_provider.dart';
-import '../providers/workspace_provider.dart';
 import 'chat_bubble.dart';
+import 'chat_context_summary.dart';
 
 /// Draggable bottom sheet chat panel for contextual AI chat (REQ-009).
 ///
@@ -24,6 +23,7 @@ class _ContextualChatState extends State<ContextualChat> {
   final _controller = TextEditingController();
   ScrollController? _activeScrollController;
   int _lastMessageCount = 0;
+  String? _lastAppliedDraft;
 
   @override
   void dispose() {
@@ -63,12 +63,13 @@ class _ContextualChatState extends State<ContextualChat> {
   @override
   Widget build(BuildContext context) {
     return DraggableScrollableSheet(
-      initialChildSize: 0.4,
+      initialChildSize: 0.75,
       minChildSize: 0.15,
       maxChildSize: 0.85,
       builder: (context, sheetScrollController) {
         return Consumer<ChatProvider>(
           builder: (context, provider, _) {
+            _syncDraft(provider);
             return Container(
               decoration: BoxDecoration(
                 color: Theme.of(context).colorScheme.surface,
@@ -87,8 +88,17 @@ class _ContextualChatState extends State<ContextualChat> {
                 children: [
                   _buildHandle(context),
                   _buildHeader(context, provider),
-                  if (provider.editorContext?.hasContext ?? false)
-                    _buildContextSummary(context, provider),
+                  if ((provider.editorContext?.hasContext ?? false) ||
+                      provider.pendingAttachment != null)
+                    ChatContextSummary(
+                      editorContext: provider.editorContext,
+                      attachment: provider.pendingAttachment,
+                      margin: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 4,
+                      ),
+                      onClearAttachment: provider.clearPendingAttachment,
+                    ),
                   Expanded(
                     child: _buildMessageList(provider, sheetScrollController),
                   ),
@@ -100,6 +110,18 @@ class _ContextualChatState extends State<ContextualChat> {
         );
       },
     );
+  }
+
+  void _syncDraft(ChatProvider provider) {
+    final draft = provider.pendingDraftMessage;
+    if (draft == null ||
+        draft == _lastAppliedDraft ||
+        _controller.text.isNotEmpty) {
+      return;
+    }
+    _controller.text = draft;
+    _controller.selection = TextSelection.collapsed(offset: draft.length);
+    _lastAppliedDraft = draft;
   }
 
   Widget _buildHandle(BuildContext context) {
@@ -137,58 +159,6 @@ class _ContextualChatState extends State<ContextualChat> {
               tooltip: 'Open full chat',
               onPressed: widget.onExpandToFullChat,
               constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
-            ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildContextSummary(BuildContext context, ChatProvider provider) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final ctx = provider.editorContext!;
-    final workspace = context.read<WorkspaceProvider>();
-    final fileName = (ctx.activeFile ?? '').split('/').last;
-    final selectionLabel = ctx.selection?.lineLabel ?? 'No selection';
-
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-      decoration: BoxDecoration(
-        color: colorScheme.secondaryContainer,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Icon(Icons.code, size: 16, color: colorScheme.onSecondaryContainer),
-          const SizedBox(width: 8),
-          Expanded(
-            child: DefaultTextStyle(
-              style: theme.textTheme.labelMedium!.copyWith(
-                color: colorScheme.onSecondaryContainer,
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text('Workspace: ${workspace.displayName}'),
-                  Text(
-                    'File: $fileName',
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  Text('Selection: $selectionLabel'),
-                ],
-              ),
-            ),
-          ),
-          if (ctx.selection != null)
-            InkWell(
-              onTap: () => context.read<EditorProvider>().clearSelection(),
-              child: Icon(
-                Icons.close,
-                size: 16,
-                color: colorScheme.onSecondaryContainer,
-              ),
             ),
         ],
       ),

--- a/app/test/providers/chat_provider_test.dart
+++ b/app/test/providers/chat_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vscode_mobile/models/editor_context.dart';
 import 'package:vscode_mobile/providers/chat_provider.dart';
@@ -32,7 +34,7 @@ void main() {
     });
 
     test(
-      'serializes only workspace, file, cursor, and selection for each turn',
+      'serializes only workspace, file, cursor, and selection for each turn when no GitHub action is queued',
       () async {
         provider.setWorkspace('/workspaces/alpha');
         provider.setEditorContext(
@@ -84,6 +86,7 @@ void main() {
           'start': <String, dynamic>{'line': 10, 'column': 2},
           'end': <String, dynamic>{'line': 14, 'column': 8},
         });
+        expect(extractGitHubAttachmentPayload(sendPayload), isEmpty);
         expect(sendPayload.containsKey('git'), isFalse);
         expect(sendPayload.containsKey('diagnostics'), isFalse);
         expect(sendPayload.containsKey('terminal'), isFalse);
@@ -136,6 +139,121 @@ void main() {
         });
         expect(secondSendPayload.containsKey('selection'), isTrue);
         expect(secondSendPayload['selection'], isNull);
+        expect(extractGitHubAttachmentPayload(secondSendPayload), isEmpty);
+      },
+    );
+  });
+
+  group('ChatProvider one-shot GitHub attachments', () {
+    late RecordingWebSocketChannel channel;
+    late ChatProvider provider;
+
+    setUp(() {
+      channel = RecordingWebSocketChannel();
+      provider = ChatProvider(apiClient: FakeChatApiClient(channel: channel));
+      provider.setWorkspace('/workspaces/repo');
+      provider.setEditorContext(
+        const EditorChatContext(
+          activeFile: '/workspaces/repo/lib/chat.dart',
+          cursor: EditorCursor(line: 21, column: 6),
+          selection: EditorSelection(
+            start: EditorCursor(line: 18, column: 1),
+            end: EditorCursor(line: 24, column: 9),
+          ),
+        ),
+      );
+      provider.resumeConversation('sess-github');
+      channel.serverSend(<String, dynamic>{
+        'type': 'resumed',
+        'conversationId': 'sess-github',
+      });
+    });
+
+    tearDown(() async {
+      provider.dispose();
+      await channel.dispose();
+    });
+
+    test(
+      'serializes only the selected issue attachment on the next turn and preserves IDE context',
+      () async {
+        await Future<void>.delayed(Duration.zero);
+
+        queueIssueAttachmentForNextTurn(
+          provider,
+          actionLabel: 'Summarize issue',
+          repository: 'octo/repo',
+          issueNumber: 7,
+          title: 'Fix reconnect',
+          body: 'Reconnect stalls after sleep.',
+        );
+
+        final pending = pendingChatAttachmentJson(provider);
+        expect(jsonEncode(pending).toLowerCase(), contains('issue'));
+        expect(jsonEncode(pending), contains('Fix reconnect'));
+
+        provider.sendMessage('Summarize this issue');
+
+        final sendPayload = decodeSentJson(channel, 1);
+        final attachment = extractGitHubAttachmentPayload(sendPayload);
+        final encodedAttachment = jsonEncode(attachment);
+
+        expect(sendPayload['workspaceRoot'], '/workspaces/repo');
+        expect(sendPayload['activeFile'], '/workspaces/repo/lib/chat.dart');
+        expect(sendPayload['cursor'], <String, dynamic>{
+          'line': 21,
+          'column': 6,
+        });
+        expect(encodedAttachment.toLowerCase(), contains('issue'));
+        expect(encodedAttachment, contains('Summarize issue'));
+        expect(encodedAttachment, contains('octo/repo'));
+        expect(encodedAttachment, contains('Fix reconnect'));
+        expect(encodedAttachment, contains('Reconnect stalls after sleep.'));
+        expect(encodedAttachment, isNot(contains('Inline note')));
+        expect(encodedAttachment, isNot(contains('app/lib/main.dart')));
+      },
+    );
+
+    test(
+      'consumes the queued attachment after one send so it does not leak',
+      () async {
+        await Future<void>.delayed(Duration.zero);
+
+        queuePullRequestCommentAttachmentForNextTurn(
+          provider,
+          actionLabel: 'Check review comment',
+          repository: 'octo/repo',
+          pullRequestNumber: 12,
+          title: 'Add collaboration UI',
+          commentId: 22,
+          commentBody: 'Please cover the empty state.',
+          path: 'app/lib/chat.dart',
+        );
+
+        provider.sendMessage('Handle this comment');
+        final firstAttachment = extractGitHubAttachmentPayload(
+          decodeSentJson(channel, 1),
+        );
+        expect(
+          jsonEncode(firstAttachment),
+          contains('Please cover the empty state.'),
+        );
+        expect(jsonEncode(firstAttachment), contains('app/lib/chat.dart'));
+
+        final pendingAfterSend = pendingChatAttachmentJson(provider);
+        expect(pendingAfterSend, isEmpty);
+
+        provider.sendMessage('Now answer normally');
+        final secondSendPayload = decodeSentJson(channel, 2);
+        expect(extractGitHubAttachmentPayload(secondSendPayload), isEmpty);
+        expect(
+          jsonEncode(secondSendPayload),
+          isNot(contains('Please cover the empty state.')),
+        );
+        expect(
+          jsonEncode(secondSendPayload),
+          isNot(contains('app/lib/chat.dart')),
+        );
       },
     );
   });

--- a/app/test/test_support/chat_test_helpers.dart
+++ b/app/test/test_support/chat_test_helpers.dart
@@ -1,8 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vscode_mobile/models/chat_context_attachment.dart';
 import 'package:vscode_mobile/models/chat_message.dart';
 import 'package:vscode_mobile/models/session.dart';
+import 'package:vscode_mobile/providers/chat_provider.dart';
 import 'package:vscode_mobile/services/chat_api_client.dart';
 import 'package:vscode_mobile/services/settings_service.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -124,4 +128,223 @@ Map<String, dynamic> decodeSentJson(
 List<String> sortedKeys(Map<String, dynamic> payload) {
   final keys = payload.keys.toList()..sort();
   return keys;
+}
+
+Map<String, dynamic> extractGitHubAttachmentPayload(
+  Map<String, dynamic> payload,
+) {
+  final candidates = <dynamic>[
+    payload['attachment'],
+    payload['chatAttachment'],
+    payload['contextAttachment'],
+    payload['githubAttachment'],
+    payload['github'],
+  ];
+
+  for (final candidate in candidates) {
+    final normalized = _normalizeJsonLike(candidate);
+    if (normalized is Map<String, dynamic> && normalized.isNotEmpty) {
+      return normalized;
+    }
+  }
+  return <String, dynamic>{};
+}
+
+Object? _normalizeJsonLike(Object? value) {
+  if (value == null) {
+    return null;
+  }
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+  if (value is Map) {
+    return value.map(
+      (key, dynamic nested) =>
+          MapEntry(key.toString(), _normalizeJsonLike(nested)),
+    );
+  }
+  if (value is List) {
+    return value.map<Object?>((item) => _normalizeJsonLike(item)).toList();
+  }
+
+  final dynamic dynamicValue = value;
+  try {
+    return _normalizeJsonLike(dynamicValue.toTransportJson());
+  } catch (_) {
+    // ignored
+  }
+  try {
+    return _normalizeJsonLike(dynamicValue.toJson());
+  } catch (_) {
+    // ignored
+  }
+
+  return value;
+}
+
+Map<String, dynamic> pendingChatAttachmentJson(ChatProvider provider) {
+  final dynamic dynamicProvider = provider;
+  for (final getterName in <String>[
+    'pendingAttachment',
+    'pendingChatAttachment',
+    'pendingContextAttachment',
+    'pendingGithubAttachment',
+    'pendingGitHubAttachment',
+    'chatAttachment',
+  ]) {
+    try {
+      final value = switch (getterName) {
+        'pendingAttachment' => dynamicProvider.pendingAttachment,
+        'pendingChatAttachment' => dynamicProvider.pendingChatAttachment,
+        'pendingContextAttachment' => dynamicProvider.pendingContextAttachment,
+        'pendingGithubAttachment' => dynamicProvider.pendingGithubAttachment,
+        'pendingGitHubAttachment' => dynamicProvider.pendingGitHubAttachment,
+        'chatAttachment' => dynamicProvider.chatAttachment,
+        _ => null,
+      };
+      final normalized = _normalizeJsonLike(value);
+      if (normalized is Map<String, dynamic>) {
+        return normalized;
+      }
+    } catch (_) {
+      // Keep probing known public getter names.
+    }
+  }
+  return const <String, dynamic>{};
+}
+
+void queueIssueAttachmentForNextTurn(
+  ChatProvider provider, {
+  required String actionLabel,
+  required String repository,
+  required int issueNumber,
+  required String title,
+  required String body,
+  String htmlUrl = 'https://github.com/octo/repo/issues/7',
+}) {
+  final attachment = GitHubChatAttachment(
+    actionLabel: actionLabel,
+    kind: GitHubAttachmentKind.issue,
+    reference: '$repository#$issueNumber',
+    title: title,
+    body: body,
+    repositoryFullName: repository,
+    url: htmlUrl,
+  );
+  provider.queueGitHubAction(prompt: actionLabel, attachment: attachment);
+}
+
+void queueIssueCommentAttachmentForNextTurn(
+  ChatProvider provider, {
+  required String actionLabel,
+  required String repository,
+  required int issueNumber,
+  required String title,
+  required String commentBody,
+  required int commentId,
+  String authorLogin = 'octocat',
+  String htmlUrl = 'https://github.com/octo/repo/issues/7#issuecomment-11',
+}) {
+  final attachment = GitHubChatAttachment(
+    actionLabel: actionLabel,
+    kind: GitHubAttachmentKind.issueComment,
+    reference: '$repository#$issueNumber / comment $commentId',
+    title: title,
+    body: commentBody,
+    repositoryFullName: repository,
+    authorLogin: authorLogin,
+    url: htmlUrl,
+  );
+  provider.queueGitHubAction(prompt: actionLabel, attachment: attachment);
+}
+
+void queuePullRequestAttachmentForNextTurn(
+  ChatProvider provider, {
+  required String actionLabel,
+  required String repository,
+  required int pullRequestNumber,
+  required String title,
+  required String body,
+  String htmlUrl = 'https://github.com/octo/repo/pull/12',
+}) {
+  final attachment = GitHubChatAttachment(
+    actionLabel: actionLabel,
+    kind: GitHubAttachmentKind.pullRequest,
+    reference: '$repository#$pullRequestNumber',
+    title: title,
+    body: body,
+    repositoryFullName: repository,
+    url: htmlUrl,
+  );
+  provider.queueGitHubAction(prompt: actionLabel, attachment: attachment);
+}
+
+void queuePullRequestCommentAttachmentForNextTurn(
+  ChatProvider provider, {
+  required String actionLabel,
+  required String repository,
+  required int pullRequestNumber,
+  required String title,
+  required int commentId,
+  required String commentBody,
+  required String path,
+  String authorLogin = 'reviewer',
+  String htmlUrl = 'https://github.com/octo/repo/pull/12#discussion_r22',
+}) {
+  final attachment = GitHubChatAttachment(
+    actionLabel: actionLabel,
+    kind: GitHubAttachmentKind.pullRequestComment,
+    reference: '$repository#$pullRequestNumber / comment $commentId',
+    title: title,
+    body: commentBody,
+    repositoryFullName: repository,
+    path: path,
+    authorLogin: authorLogin,
+    url: htmlUrl,
+  );
+  provider.queueGitHubAction(prompt: actionLabel, attachment: attachment);
+}
+
+Finder findTextContaining(String text) {
+  return find.byWidgetPredicate(
+    (widget) => widget is Text && (widget.data?.contains(text) ?? false),
+    description: 'Text containing "$text"',
+  );
+}
+
+Finder findButtonContaining(String text) {
+  return find.byWidgetPredicate((widget) {
+    if (widget is FilledButton) {
+      return _widgetContainsText(widget.child, text);
+    }
+    if (widget is TextButton) {
+      return _widgetContainsText(widget.child, text);
+    }
+    if (widget is OutlinedButton) {
+      return _widgetContainsText(widget.child, text);
+    }
+    if (widget is IconButton) {
+      return widget.tooltip?.contains(text) ?? false;
+    }
+    return false;
+  }, description: 'Button containing "$text"');
+}
+
+bool _widgetContainsText(Widget? widget, String text) {
+  if (widget == null) {
+    return false;
+  }
+  if (widget is Text) {
+    return widget.data?.contains(text) ?? false;
+  }
+  if (widget is RichText) {
+    return widget.text.toPlainText().contains(text);
+  }
+  if (widget is SingleChildRenderObjectWidget) {
+    return _widgetContainsText(widget.child, text);
+  }
+  if (widget is MultiChildRenderObjectWidget) {
+    return widget.children.any((child) => _widgetContainsText(child, text));
+  }
+  return false;
 }

--- a/app/test/widgets/contextual_chat_test.dart
+++ b/app/test/widgets/contextual_chat_test.dart
@@ -68,15 +68,15 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('Workspace'), findsOneWidget);
-      expect(find.textContaining('alpha'), findsWidgets);
-      expect(find.textContaining('File'), findsOneWidget);
-      expect(find.textContaining('main.dart'), findsWidgets);
-      expect(find.textContaining('No selection'), findsOneWidget);
+      expect(findTextContaining('Workspace'), findsOneWidget);
+      expect(findTextContaining('alpha'), findsWidgets);
+      expect(findTextContaining('File'), findsOneWidget);
+      expect(findTextContaining('main.dart'), findsWidgets);
+      expect(findTextContaining('No selection'), findsOneWidget);
     });
 
     testWidgets(
-      'summary updates when selection is cleared and survives expand to full chat',
+      'summary shows the queued GitHub attachment details and survives expand to full chat',
       (WidgetTester tester) async {
         await workspaceProvider.setWorkspace('/workspaces/alpha');
         chatProvider.setWorkspace('/workspaces/alpha');
@@ -90,6 +90,15 @@ void main() {
             ),
           ),
         );
+        queueIssueCommentAttachmentForNextTurn(
+          chatProvider,
+          actionLabel: 'Check issue comment',
+          repository: 'octo/repo',
+          issueNumber: 7,
+          title: 'Fix reconnect',
+          commentId: 11,
+          commentBody: 'Can we narrow the retry window?',
+        );
 
         var expanded = false;
         await tester.pumpWidget(
@@ -101,19 +110,15 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.textContaining('Selection'), findsOneWidget);
-        expect(find.textContaining('No selection'), findsNothing);
-
-        chatProvider.setEditorContext(
-          const EditorChatContext(
-            activeFile: '/workspaces/alpha/lib/main.dart',
-            cursor: EditorCursor(line: 12, column: 6),
-            selection: null,
-          ),
+        expect(findTextContaining('Workspace'), findsOneWidget);
+        expect(findTextContaining('main.dart'), findsWidgets);
+        expect(findTextContaining('Selection'), findsOneWidget);
+        expect(findTextContaining('Fix reconnect'), findsOneWidget);
+        expect(
+          findTextContaining('Can we narrow the retry window?'),
+          findsOneWidget,
         );
-        await tester.pumpAndSettle();
-
-        expect(find.textContaining('No selection'), findsOneWidget);
+        expect(findTextContaining('octo/repo'), findsWidgets);
 
         await tester.tap(find.byTooltip('Open full chat'));
         await tester.pumpAndSettle();
@@ -128,9 +133,14 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.textContaining('Workspace'), findsOneWidget);
-        expect(find.textContaining('main.dart'), findsWidgets);
-        expect(find.textContaining('No selection'), findsOneWidget);
+        expect(findTextContaining('Workspace'), findsOneWidget);
+        expect(findTextContaining('main.dart'), findsWidgets);
+        expect(findTextContaining('Fix reconnect'), findsOneWidget);
+        expect(
+          findTextContaining('Can we narrow the retry window?'),
+          findsOneWidget,
+        );
+        expect(findTextContaining('octo/repo'), findsWidgets);
       },
     );
   });

--- a/app/test/widgets/github_issue_detail_screen_test.dart
+++ b/app/test/widgets/github_issue_detail_screen_test.dart
@@ -1,12 +1,20 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:vscode_mobile/models/editor_context.dart';
 import 'package:vscode_mobile/models/github_collaboration_models.dart';
+import 'package:vscode_mobile/providers/chat_provider.dart';
 import 'package:vscode_mobile/providers/github_collaboration_provider.dart';
+import 'package:vscode_mobile/providers/workspace_provider.dart';
+import 'package:vscode_mobile/screens/chat_screen.dart';
 import 'package:vscode_mobile/screens/github_issue_detail_screen.dart';
 import 'package:vscode_mobile/services/github_collaboration_api_client.dart';
 import 'package:vscode_mobile/services/settings_service.dart';
+
+import '../test_support/chat_test_helpers.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -15,33 +23,125 @@ void main() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
   });
 
-  testWidgets('renders issue detail and posts a new comment', (tester) async {
-    final settings = SettingsService();
-    await settings.save('http://server.test', 'secret-token');
-    final apiClient = _FakeGitHubCollaborationApiClient(settings);
-    final provider = GitHubCollaborationProvider(apiClient: apiClient);
-    await provider.setWorkspacePath('/workspace/repo');
+  testWidgets(
+    'renders issue AI action, opens chat, and attaches only issue context',
+    (tester) async {
+      final harness = await _buildHarness();
 
-    await tester.pumpWidget(
-      ChangeNotifierProvider<GitHubCollaborationProvider>.value(
-        value: provider,
-        child: const MaterialApp(home: GitHubIssueDetailScreen(issueNumber: 7)),
-      ),
-    );
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(harness.widget);
+      await tester.pumpAndSettle();
 
-    expect(find.text('#7 Fix reconnect'), findsOneWidget);
-    expect(find.text('No comments yet.'), findsNothing);
-    expect(find.text('Existing comment'), findsOneWidget);
+      expect(find.text('#7 Fix reconnect'), findsOneWidget);
+      expect(find.text('Summarize issue'), findsOneWidget);
 
-    await tester.enterText(find.byType(TextField), 'New issue comment');
-    await tester.tap(find.widgetWithText(FilledButton, 'Post'));
-    await tester.pump();
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('Summarize issue'));
+      await tester.pumpAndSettle();
 
-    expect(apiClient.submittedComments, ['New issue comment']);
-    expect(find.text('Issue comment posted'), findsOneWidget);
+      expect(find.byType(ChatScreen), findsOneWidget);
+      expect(findTextContaining('Fix reconnect'), findsWidgets);
+      expect(
+        findTextContaining('Reconnect stalls after sleep.'),
+        findsOneWidget,
+      );
+
+      final attachment = pendingChatAttachmentJson(harness.chatProvider);
+      final encoded = jsonEncode(attachment);
+      expect(encoded.toLowerCase(), contains('issue'));
+      expect(encoded, contains('Fix reconnect'));
+      expect(encoded, contains('Reconnect stalls after sleep.'));
+      expect(encoded, isNot(contains('Existing comment')));
+      expect(encoded, isNot(contains('Second issue comment')));
+    },
+  );
+
+  testWidgets(
+    'comment AI action attaches only the selected comment and keeps post intact',
+    (tester) async {
+      final harness = await _buildHarness();
+
+      await tester.pumpWidget(harness.widget);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Existing comment'), findsOneWidget);
+      expect(find.text('Second issue comment'), findsOneWidget);
+      expect(find.text('Check comment'), findsWidgets);
+
+      await tester.tap(find.text('Check comment').first);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ChatScreen), findsOneWidget);
+
+      final attachment = pendingChatAttachmentJson(harness.chatProvider);
+      final encoded = jsonEncode(attachment);
+      expect(encoded.toLowerCase(), contains('issue'));
+      expect(encoded, contains('Fix reconnect'));
+      expect(encoded, contains('Existing comment'));
+      expect(encoded, isNot(contains('Second issue comment')));
+
+      final postingHarness = await _buildHarness();
+      final submitted = await postingHarness.provider.submitIssueComment(
+        7,
+        'New issue comment',
+      );
+
+      expect(submitted, isTrue);
+      expect(postingHarness.apiClient.submittedComments, ['New issue comment']);
+    },
+  );
+}
+
+class _Harness {
+  final Widget widget;
+  final _FakeGitHubCollaborationApiClient apiClient;
+  final ChatProvider chatProvider;
+  final GitHubCollaborationProvider provider;
+
+  const _Harness({
+    required this.widget,
+    required this.apiClient,
+    required this.chatProvider,
+    required this.provider,
   });
+}
+
+Future<_Harness> _buildHarness() async {
+  final settings = SettingsService();
+  await settings.save('http://server.test', 'secret-token');
+  final apiClient = _FakeGitHubCollaborationApiClient(settings);
+  final provider = GitHubCollaborationProvider(apiClient: apiClient);
+  await provider.setWorkspacePath('/workspace/repo');
+  await provider.loadCurrentRepo();
+  final chatProvider = ChatProvider(
+    apiClient: FakeChatApiClient(channel: RecordingWebSocketChannel()),
+  );
+  chatProvider.setWorkspace('/workspace/repo');
+  chatProvider.setEditorContext(
+    const EditorChatContext(
+      activeFile: '/workspace/repo/lib/main.dart',
+      cursor: EditorCursor(line: 14, column: 2),
+      selection: null,
+    ),
+  );
+  final workspaceProvider = WorkspaceProvider();
+  await workspaceProvider.setWorkspace('/workspace/repo');
+
+  return _Harness(
+    apiClient: apiClient,
+    chatProvider: chatProvider,
+    provider: provider,
+    widget: MultiProvider(
+      providers: [
+        ChangeNotifierProvider<GitHubCollaborationProvider>.value(
+          value: provider,
+        ),
+        ChangeNotifierProvider<ChatProvider>.value(value: chatProvider),
+        ChangeNotifierProvider<WorkspaceProvider>.value(
+          value: workspaceProvider,
+        ),
+      ],
+      child: const MaterialApp(home: GitHubIssueDetailScreen(issueNumber: 7)),
+    ),
+  );
 }
 
 class _FakeGitHubCollaborationApiClient extends GitHubCollaborationApiClient {
@@ -49,6 +149,50 @@ class _FakeGitHubCollaborationApiClient extends GitHubCollaborationApiClient {
     : super(settings: settings);
 
   final List<String> submittedComments = <String>[];
+
+  @override
+  Future<GitHubCurrentRepoContext> fetchCurrentRepo({
+    String workspacePath = '',
+  }) async {
+    return GitHubCurrentRepoContext.fromJson(<String, dynamic>{
+      'status': 'ok',
+      'repository': <String, dynamic>{
+        'id': 1,
+        'github_host': 'github.com',
+        'owner': 'octo',
+        'name': 'repo',
+        'full_name': 'octo/repo',
+        'remote_name': 'origin',
+        'remote_url': 'git@github.com:octo/repo.git',
+        'repo_root': '/workspace/repo',
+        'private': false,
+      },
+    });
+  }
+
+  @override
+  Future<GitHubAccountContext> fetchAccount({String workspacePath = ''}) async {
+    return GitHubAccountContext.fromJson(<String, dynamic>{
+      'repository': <String, dynamic>{
+        'id': 1,
+        'github_host': 'github.com',
+        'owner': 'octo',
+        'name': 'repo',
+        'full_name': 'octo/repo',
+        'remote_name': 'origin',
+        'remote_url': 'git@github.com:octo/repo.git',
+        'repo_root': '/workspace/repo',
+        'private': false,
+      },
+      'account': <String, dynamic>{
+        'login': 'octocat',
+        'id': 9,
+        'name': 'Octo Cat',
+        'avatar_url': '',
+        'html_url': 'https://github.com/octocat',
+      },
+    });
+  }
 
   @override
   Future<GitHubIssueDetail> fetchIssueDetail(
@@ -61,13 +205,18 @@ class _FakeGitHubCollaborationApiClient extends GitHubCollaborationApiClient {
         'title': 'Fix reconnect',
         'state': 'open',
         'body': 'Reconnect stalls after sleep.',
-        'comments_count': 1,
+        'comments_count': 2,
       },
       'comments': [
         <String, dynamic>{
           'id': 1,
           'body': 'Existing comment',
           'author': <String, dynamic>{'login': 'octocat', 'id': 9},
+        },
+        <String, dynamic>{
+          'id': 2,
+          'body': 'Second issue comment',
+          'author': <String, dynamic>{'login': 'hubot', 'id': 10},
         },
       ],
     });
@@ -81,7 +230,7 @@ class _FakeGitHubCollaborationApiClient extends GitHubCollaborationApiClient {
   }) async {
     submittedComments.add(input.body);
     return GitHubIssueComment.fromJson(<String, dynamic>{
-      'id': 2,
+      'id': 3,
       'body': input.body,
     });
   }

--- a/app/test/widgets/github_pull_request_detail_screen_test.dart
+++ b/app/test/widgets/github_pull_request_detail_screen_test.dart
@@ -1,16 +1,25 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:vscode_mobile/models/diagnostic.dart';
+import 'package:vscode_mobile/models/editor_context.dart';
 import 'package:vscode_mobile/models/github_collaboration_models.dart';
+import 'package:vscode_mobile/providers/chat_provider.dart';
 import 'package:vscode_mobile/providers/editor_provider.dart';
 import 'package:vscode_mobile/providers/github_collaboration_provider.dart';
+import 'package:vscode_mobile/providers/workspace_provider.dart';
+import 'package:vscode_mobile/screens/chat_screen.dart';
 import 'package:vscode_mobile/screens/code_screen.dart';
 import 'package:vscode_mobile/screens/github_pull_request_detail_screen.dart';
 import 'package:vscode_mobile/services/api_client.dart';
 import 'package:vscode_mobile/services/github_collaboration_api_client.dart';
 import 'package:vscode_mobile/services/settings_service.dart';
+
+import '../test_support/chat_test_helpers.dart';
+import '../test_support/editor_test_helpers.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -18,6 +27,62 @@ void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
   });
+
+  testWidgets(
+    'renders PR AI action, opens chat, and attaches only PR context',
+    (tester) async {
+      final harness = await _buildHarness();
+
+      await tester.pumpWidget(harness.widget);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Summarize PR'), findsOneWidget);
+
+      await tester.tap(find.text('Summarize PR'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ChatScreen), findsOneWidget);
+
+      final attachment = pendingChatAttachmentJson(harness.chatProvider);
+      final encoded = jsonEncode(attachment);
+      expect(encoded.toLowerCase(), contains('pull'));
+      expect(encoded, contains('Add collaboration UI'));
+      expect(encoded, contains('Implements the GitHub collaboration flow.'));
+      expect(encoded, isNot(contains('Inline note')));
+      expect(encoded, isNot(contains('@@ -10,1 +42,2 @@')));
+    },
+  );
+
+  testWidgets(
+    'review comment AI action attaches only the selected comment and path',
+    (tester) async {
+      final harness = await _buildHarness();
+
+      await tester.pumpWidget(harness.widget);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Conversation'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Inline note'), findsOneWidget);
+      expect(find.text('Second inline note'), findsOneWidget);
+      expect(find.text('Check comment'), findsWidgets);
+
+      await tester.tap(find.text('Check comment').first);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ChatScreen), findsOneWidget);
+
+      final attachment = pendingChatAttachmentJson(harness.chatProvider);
+      final encoded = jsonEncode(attachment);
+      expect(encoded.toLowerCase(), contains('comment'));
+      expect(encoded, contains('Add collaboration UI'));
+      expect(encoded, contains('Inline note'));
+      expect(encoded, contains('app/lib/main.dart'));
+      expect(encoded, isNot(contains('Second inline note')));
+      expect(encoded, isNot(contains('@@ -10,1 +42,2 @@')));
+    },
+  );
 
   testWidgets('renders checks and submits a review action', (tester) async {
     final harness = await _buildHarness();
@@ -77,7 +142,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(CodeScreen), findsOneWidget);
-    expect(harness.editorProvider.currentFile?.path, '/workspace/repo/app/lib/main.dart');
+    expect(
+      harness.editorProvider.currentFile?.path,
+      '/workspace/repo/app/lib/main.dart',
+    );
     expect(harness.editorProvider.cursor?.line, 42);
   });
 
@@ -111,11 +179,13 @@ class _Harness {
   final Widget widget;
   final _FakeGitHubCollaborationApiClient collabApi;
   final EditorProvider editorProvider;
+  final ChatProvider chatProvider;
 
   const _Harness({
     required this.widget,
     required this.collabApi,
     required this.editorProvider,
+    required this.chatProvider,
   });
 }
 
@@ -124,19 +194,42 @@ Future<_Harness> _buildHarness() async {
   await settings.save('http://server.test', 'secret-token');
   final collabApi = _FakeGitHubCollaborationApiClient(settings);
   final editorApi = _FakeApiClient(settings);
+  final editorBridgeApi = FakeEditorApiClient(settings: settings);
   final collabProvider = GitHubCollaborationProvider(apiClient: collabApi);
   await collabProvider.setWorkspacePath('/workspace/repo');
-  final editorProvider = EditorProvider(apiClient: editorApi);
+  await collabProvider.loadCurrentRepo();
+  final editorProvider = EditorProvider(
+    apiClient: editorApi,
+    editorApiClient: editorBridgeApi,
+  );
+  final chatProvider = ChatProvider(
+    apiClient: FakeChatApiClient(channel: RecordingWebSocketChannel()),
+  );
+  chatProvider.setWorkspace('/workspace/repo');
+  chatProvider.setEditorContext(
+    const EditorChatContext(
+      activeFile: '/workspace/repo/app/lib/main.dart',
+      cursor: EditorCursor(line: 42, column: 1),
+      selection: null,
+    ),
+  );
+  final workspaceProvider = WorkspaceProvider();
+  await workspaceProvider.setWorkspace('/workspace/repo');
 
   return _Harness(
     collabApi: collabApi,
     editorProvider: editorProvider,
+    chatProvider: chatProvider,
     widget: MultiProvider(
       providers: [
         ChangeNotifierProvider<GitHubCollaborationProvider>.value(
           value: collabProvider,
         ),
         ChangeNotifierProvider<EditorProvider>.value(value: editorProvider),
+        ChangeNotifierProvider<ChatProvider>.value(value: chatProvider),
+        ChangeNotifierProvider<WorkspaceProvider>.value(
+          value: workspaceProvider,
+        ),
       ],
       child: const MaterialApp(
         home: GitHubPullRequestDetailScreen(pullRequestNumber: 12),
@@ -158,6 +251,50 @@ class _FakeGitHubCollaborationApiClient extends GitHubCollaborationApiClient {
       });
   final List<GitHubPullRequestReviewInput> reviewInputs =
       <GitHubPullRequestReviewInput>[];
+
+  @override
+  Future<GitHubCurrentRepoContext> fetchCurrentRepo({
+    String workspacePath = '',
+  }) async {
+    return GitHubCurrentRepoContext.fromJson(<String, dynamic>{
+      'status': 'ok',
+      'repository': <String, dynamic>{
+        'id': 1,
+        'github_host': 'github.com',
+        'owner': 'octo',
+        'name': 'repo',
+        'full_name': 'octo/repo',
+        'remote_name': 'origin',
+        'remote_url': 'git@github.com:octo/repo.git',
+        'repo_root': '/workspace/repo',
+        'private': false,
+      },
+    });
+  }
+
+  @override
+  Future<GitHubAccountContext> fetchAccount({String workspacePath = ''}) async {
+    return GitHubAccountContext.fromJson(<String, dynamic>{
+      'repository': <String, dynamic>{
+        'id': 1,
+        'github_host': 'github.com',
+        'owner': 'octo',
+        'name': 'repo',
+        'full_name': 'octo/repo',
+        'remote_name': 'origin',
+        'remote_url': 'git@github.com:octo/repo.git',
+        'repo_root': '/workspace/repo',
+        'private': false,
+      },
+      'account': <String, dynamic>{
+        'login': 'octocat',
+        'id': 9,
+        'name': 'Octo Cat',
+        'avatar_url': '',
+        'html_url': 'https://github.com/octocat',
+      },
+    });
+  }
 
   @override
   Future<GitHubPullRequestDetail> fetchPullRequestDetail(
@@ -199,6 +336,11 @@ class _FakeGitHubCollaborationApiClient extends GitHubCollaborationApiClient {
           'id': 2,
           'body': 'Inline note',
           'path': 'app/lib/main.dart',
+        },
+        <String, dynamic>{
+          'id': 3,
+          'body': 'Second inline note',
+          'path': 'app/lib/other.dart',
         },
       ],
       'reviews': [

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -870,3 +870,30 @@ requirements:
       - server/internal/github/service_test.go
       - server/internal/api/github_collaboration_test.go
     depends_on: [REQ-023, REQ-027]
+
+  - id: REQ-030
+    title: GitHub detail screens AI chat handoff
+    description: >
+      Ticket ASE-55 adds explicit AI entry points on GitHub issue and pull
+      request detail screens. The Flutter chat provider keeps default
+      workspace plus active editor context intact, supports a one-shot minimal
+      GitHub attachment for the next send only, and the chat UI previews both
+      IDE context and pending GitHub context before sending.
+    priority: P1
+    status: implemented
+    code:
+      - project-index.yaml
+      - app/lib/models/chat_context_attachment.dart
+      - app/lib/providers/chat_provider.dart
+      - app/lib/navigation/github_chat_navigation.dart
+      - app/lib/screens/chat_screen.dart
+      - app/lib/screens/github_issue_detail_screen.dart
+      - app/lib/screens/github_pull_request_detail_screen.dart
+      - app/lib/widgets/chat_context_summary.dart
+      - app/lib/widgets/contextual_chat.dart
+    tests:
+      - app/test/providers/chat_provider_test.dart
+      - app/test/widgets/contextual_chat_test.dart
+      - app/test/widgets/github_issue_detail_screen_test.dart
+      - app/test/widgets/github_pull_request_detail_screen_test.dart
+    depends_on: [REQ-010, REQ-028, REQ-029]


### PR DESCRIPTION
## Summary
- add explicit AI actions on GitHub issue and pull request detail pages instead of a generic chat handoff
- queue a one-shot GitHub attachment so only the user-selected issue, PR, review comment, or PR file is attached to the next chat turn
- show the pending GitHub attachment alongside the existing workspace/editor context preview and cover the flow with widget/provider tests

## Why
This implements the minimal-context GitHub x AI entry flow for ASE-55 so GitHub content is only attached when the user explicitly launches an AI action from an Issue or PR page.

## Issue
- Closes #16

## Validation
- `OPENVSMOBILE_FLUTTER=/home/ddq/flutter/bin/flutter ./scripts/verify_repo.sh`
- Focused widget/provider coverage is included for the GitHub issue/PR AI entry flow in `app/test/providers/chat_provider_test.dart`, `app/test/widgets/contextual_chat_test.dart`, `app/test/widgets/github_issue_detail_screen_test.dart`, and `app/test/widgets/github_pull_request_detail_screen_test.dart`
