### PR TITLE
feat(next): syntax-highlight the read-only file viewer

### DIFF
--- a/next/app/lib/screens/file_viewer.dart
+++ b/next/app/lib/screens/file_viewer.dart
@@ -1,10 +1,64 @@
-// Read-only file viewer. Monospace, no syntax highlighting in v0.
+// Read-only file viewer. Monospace, with syntax highlighting when the
+// filename extension maps to a language the `highlight` package knows;
+// plain monospace otherwise.
 
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_highlight/flutter_highlight.dart';
+import 'package:flutter_highlight/themes/monokai-sublime.dart';
 
 import '../models.dart';
+
+const _kCodeTextStyle = TextStyle(
+  fontFamily: 'monospace',
+  fontSize: 13,
+  height: 1.35,
+);
+
+// Extension → highlight.js language id. Anything not in this map renders as
+// plain monospace text (the original v0 behaviour). Keep entries lowercase;
+// lookup normalises to lowercase before indexing.
+//
+// `.toml` maps to `ini` and `.html` maps to `xml` — the `highlight` package
+// doesn't ship dedicated grammars for those, and these are the closest
+// supported substitutes. `.c` / `.h` ride on the `cpp` grammar for the
+// same reason.
+const Map<String, String> _kLanguageByExtension = {
+  'dart': 'dart',
+  'ts': 'typescript',
+  'tsx': 'typescript',
+  'js': 'javascript',
+  'jsx': 'javascript',
+  'json': 'json',
+  'yaml': 'yaml',
+  'yml': 'yaml',
+  'md': 'markdown',
+  'sh': 'bash',
+  'bash': 'bash',
+  'py': 'python',
+  'go': 'go',
+  'html': 'xml',
+  'css': 'css',
+  'toml': 'ini',
+  'xml': 'xml',
+  'kt': 'kotlin',
+  'swift': 'swift',
+  'rs': 'rust',
+  'c': 'cpp',
+  'h': 'cpp',
+  'cpp': 'cpp',
+  'hpp': 'cpp',
+  'java': 'java',
+  'gradle': 'gradle',
+};
+
+String? _languageForPath(String path) {
+  final fileName = path.split('/').last;
+  final dot = fileName.lastIndexOf('.');
+  if (dot <= 0 || dot == fileName.length - 1) return null;
+  return _kLanguageByExtension[fileName.substring(dot + 1).toLowerCase()];
+}
 
 class FileViewerScreen extends StatelessWidget {
   final String path;
@@ -44,20 +98,43 @@ class FileViewerScreen extends StatelessWidget {
                 ),
               ),
             )
-          : SingleChildScrollView(
-              padding: const EdgeInsets.all(12),
-              child: SelectableText(
-                // `allowMalformed: true` papers over a partial UTF-8 truncation
-                // at the file's tail (rare but legitimate, e.g. a large file
-                // clipped at MAX_FILE_BYTES mid-codepoint) instead of throwing.
-                utf8.decode(content.bytes, allowMalformed: true),
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 13,
-                  height: 1.35,
-                ),
-              ),
-            ),
+          : _TextBody(path: path, bytes: content.bytes),
+    );
+  }
+}
+
+class _TextBody extends StatelessWidget {
+  final String path;
+  final List<int> bytes;
+  const _TextBody({required this.path, required this.bytes});
+
+  @override
+  Widget build(BuildContext context) {
+    // `allowMalformed: true` papers over a partial UTF-8 truncation at the
+    // file's tail (rare but legitimate, e.g. a large file clipped at
+    // MAX_FILE_BYTES mid-codepoint) instead of throwing.
+    final text = utf8.decode(bytes, allowMalformed: true);
+    final language = _languageForPath(path);
+
+    if (language == null) {
+      return SingleChildScrollView(
+        padding: const EdgeInsets.all(12),
+        child: SelectableText(text, style: _kCodeTextStyle),
+      );
+    }
+
+    // `HighlightView` renders into a non-selectable `RichText`; wrapping in
+    // `SelectionArea` re-introduces long-press selection + clipboard copy.
+    return SingleChildScrollView(
+      child: SelectionArea(
+        child: HighlightView(
+          text,
+          language: language,
+          theme: monokaiSublimeTheme,
+          padding: const EdgeInsets.all(12),
+          textStyle: _kCodeTextStyle,
+        ),
+      ),
     );
   }
 }

--- a/next/app/pubspec.lock
+++ b/next/app/pubspec.lock
@@ -190,6 +190,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.2.2"
+  flutter_highlight:
+    dependency: "direct main"
+    description:
+      name: flutter_highlight
+      sha256: "7b96333867aa07e122e245c033b8ad622e4e3a42a1a2372cbb098a2541d8782c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -248,6 +256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  highlight:
+    dependency: transitive
+    description:
+      name: highlight
+      sha256: "5353a83ffe3e3eca7df0abfb72dcf3fa66cc56b953728e7113ad4ad88497cf21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   http:
     dependency: transitive
     description:

--- a/next/app/pubspec.yaml
+++ b/next/app/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   # cold-start (getInitialAppLink) and warm (uriLinkStream) deliveries so
   # main.dart can route to the notification center.
   app_links: ^6.3.2
+  flutter_highlight: ^0.7.0
 
 dev_dependencies:
   flutter_test:

--- a/next/app/test/file_viewer_widget_test.dart
+++ b/next/app/test/file_viewer_widget_test.dart
@@ -1,0 +1,74 @@
+// Smoke-level coverage for the read-only file viewer. The intent is to
+// catch dependency / wiring regressions in the syntax-highlight path —
+// asserting specific token colours is out of scope.
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mobilecode/models.dart';
+import 'package:mobilecode/screens/file_viewer.dart';
+
+FileContent _text(String source) =>
+    FileContent(bytes: utf8.encode(source), isBinary: false);
+
+Future<void> _pumpViewer(
+  WidgetTester tester, {
+  required String path,
+  required FileContent content,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: FileViewerScreen(path: path, content: content),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('renders a .dart snippet through the highlight pipeline',
+      (tester) async {
+    await _pumpViewer(
+      tester,
+      path: 'lib/sample.dart',
+      content: _text("void main() {\n  print('hello');\n}\n"),
+    );
+    expect(tester.takeException(), isNull);
+    expect(find.byType(FileViewerScreen), findsOneWidget);
+    expect(find.text('sample.dart'), findsOneWidget);
+  });
+
+  testWidgets('unknown extension falls back to plain SelectableText',
+      (tester) async {
+    await _pumpViewer(
+      tester,
+      path: 'notes/random.unknownext',
+      content: _text('hello world'),
+    );
+    expect(tester.takeException(), isNull);
+    expect(find.byType(SelectableText), findsOneWidget);
+  });
+
+  testWidgets('binary content still shows the byte-count placeholder',
+      (tester) async {
+    await _pumpViewer(
+      tester,
+      path: 'assets/blob.bin',
+      content: const FileContent(bytes: [0, 1, 2, 3], isBinary: true),
+    );
+    expect(tester.takeException(), isNull);
+    expect(find.textContaining('Binary file, 4 bytes'), findsOneWidget);
+  });
+
+  testWidgets('extensionless file does not crash and renders plain text',
+      (tester) async {
+    await _pumpViewer(
+      tester,
+      path: 'Makefile',
+      content: _text('all:\n\techo hi\n'),
+    );
+    expect(tester.takeException(), isNull);
+    expect(find.byType(SelectableText), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Closes #49. The file viewer in `next/app/lib/screens/file_viewer.dart` now syntax-highlights the source it shows, instead of rendering everything as plain monospace.

## Implementation

- **Package**: [`flutter_highlight`](https://pub.dev/packages/flutter_highlight) `^0.7.0` (BSD-3) — the pure-Dart highlighter the issue recommended. It pulls in `highlight` `^0.7.0` (the language grammars). Both are pure Dart, satisfying the CLAUDE.md hard non-goal of "no JS/WebView-based highlighters."
- **Theme**: `monokai-sublime` (dark). The issue accepted a single dark theme for v0; monokai-sublime reads well over both `ColorScheme.fromSeed` light and dark Material 3 surfaces because the highlighter renders its own background colour from the theme map, so it's a stable contrast island regardless of app theme. A user-facing theme picker is explicitly out of scope.
- **Selectability**: `HighlightView` builds a `RichText` (not selectable). Wrapping it in `SelectionArea` re-introduces long-press → text-selection handle → clipboard copy.
- **Fallback path**: extension not in the table, or no extension at all → the original `SelectableText` plain-monospace branch. Binary content → unchanged byte-count placeholder.
- **Soft wrap**: preserved (`RichText` defaults to soft-wrap, wrapped in vertical `SingleChildScrollView`).
- **UTF-8 tolerance**: `utf8.decode(..., allowMalformed: true)` is kept on both paths.

## Language ↔ extension mapping

| Extensions | Grammar | Note |
|---|---|---|
| `.dart` | `dart` | |
| `.ts`, `.tsx` | `typescript` | |
| `.js`, `.jsx` | `javascript` | |
| `.json` | `json` | |
| `.yaml`, `.yml` | `yaml` | |
| `.md` | `markdown` | |
| `.sh`, `.bash` | `bash` | |
| `.py` | `python` | |
| `.go` | `go` | |
| `.html`, `.xml` | `xml` | `highlight` doesn't ship a dedicated HTML grammar; `xml` is the canonical substitute. |
| `.css` | `css` | |
| `.toml` | `ini` | Same package gap; `ini` covers TOML's key=value lines acceptably for read-only viewing. |
| `.kt` | `kotlin` | |
| `.swift` | `swift` | |
| `.rs` | `rust` | |
| `.c`, `.h`, `.cpp`, `.hpp` | `cpp` | No standalone `c` grammar; `cpp` is the superset. |
| `.java` | `java` | |
| `.gradle` | `gradle` | |

Anything else → plain monospace.

## Test plan
- [x] `cd next/app && flutter analyze` — 0 issues.
- [x] `cd next/app && flutter test` — 45 / 45 pass, including the new `test/file_viewer_widget_test.dart` (mounts the viewer with a `.dart` snippet, an unknown extension, an extensionless `Makefile`, and a binary blob — all build without throwing).
- [x] `cd next/backend && pnpm typecheck` — clean.
- [ ] Manual: open a `.dart` file in the Files tab on device, confirm keywords/strings/comments are visibly distinct from identifiers and long-press still surfaces the selection handle. *(Not run on this branch — out of scope for the dev-agent loop; covered by the post-merge manual gate.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)