### PR TITLE
feat(next): plugin.* RPC namespace + plugin.stateChanged push (#58)

### DIFF
--- a/next/README.md
+++ b/next/README.md
@@ -149,6 +149,12 @@ Frontend → Backend:
 | `notification.markRead`      | `{ ids }` → `{ ok: true }`. Writes the connection's `deviceId` (from handshake) into each row's `read_by` array; broadcasts `notification.readChanged` to subscribed peers. Same id from the same device twice is a no-op (the array stays length-1). |
 | `notification.delete`        | `{ ids }` → `{ ok: true }`. Broadcasts `notification.deleted`. Unknown ids are silently swallowed. |
 | `notification.markImportant` | `{ id, important }` → `{ ok: true }`. Promote clears `ttl_until`. Demote always re-anchors at `now + 7d` (the original window is not preserved — promote wipes it). Unknown ids are silently swallowed. |
+| `plugin.subscribe`           | `{}` → `{ ok: true }`. Per-connection toggle for the `plugin.stateChanged` push surface; off until called so older clients don't receive the frames. |
+| `plugin.unsubscribe`         | `{}` → `{ ok: true }`. |
+| `plugin.list`                | `{}` → `{ plugins: PluginInfo[] }` where `PluginInfo = { id, name, version, state: "running" \| "stopped" \| "crashed" \| "disabled", capabilities, contributes, crashReason? }`. Backend is the source of truth — clients render from this, never from a cached copy. |
+| `plugin.enable`              | `{ id }` → `{ ok: true }`. Removes the plugin from the persisted disabled set; if the in-memory state was `disabled`, transitions to `stopped` and immediately activates when the manifest declares `onStartup`. Fires `plugin.stateChanged`. |
+| `plugin.disable`             | `{ id }` → `{ ok: true }`. Persists the disabled flag, then terminates the child process (SIGTERM, 10 s grace, SIGKILL). Fires `plugin.stateChanged` to `state: "disabled"`. |
+| `plugin.invokeCommand`       | `{ id, commandId, args? }` → `{ result?: any }`. Routed through the plugin's JSON-RPC channel as a host→plugin `command.invoke` request; the plugin's response (or error) is returned. Triggers `onCommand:<commandId>` activation if the plugin is in `stopped` state and lists that activation event. Disabled / crashed plugins reject with `-32602`. |
 
 Backend → Frontend (notifications):
 
@@ -161,6 +167,7 @@ Backend → Frontend (notifications):
 | `notification.superseded`  | `{ oldId, newId }` — fires before the matching `notification.show` when the new row has a `supersedes` field. |
 | `notification.readChanged` | `{ ids, readByDevice, ts }` — multi-device read-state sync. |
 | `notification.deleted`     | `{ ids }` — fires on `notification.delete` and on GC sweeps. |
+| `plugin.stateChanged`      | `{ id, state, crashReason? }` — fires on every plugin state transition. Filtered to peers that called `plugin.subscribe`. `state` uses the wire vocab from `plugin.list` (`running` \| `stopped` \| `crashed` \| `disabled`); `crashReason` is set when the state is `crashed`. |
 
 Notification storage notes:
 
@@ -170,7 +177,24 @@ Notification storage notes:
   cap is a v1 task.
 
 JSON-RPC error code `-32001` ("capability denied") is reserved for the
-future plugin host and unused in this iteration.
+future plugin host and unused in this iteration. `-32011`
+(`capabilityNotDeclared`) is in use today — plugins that call a host RPC
+their manifest didn't request hit this code at the host's capability
+gate.
+
+### Why there is no `plugin.install` / `plugin.uninstall` RPC
+
+The `plugin.*` namespace deliberately excludes install and uninstall.
+Plugin install is filesystem-only — users drop a `<plugin-id>/`
+directory under `~/.local/share/openvsmobile-next/plugins/` and the host
+picks it up on next start. There is no marketplace, no URL fetcher, and
+no RPC method that pulls untrusted code from the network. This matches
+the settled architectural decision in
+[`CLAUDE.md`](../CLAUDE.md) ("Plugin install is filesystem-only.
+Single-user system; the user trusts their own plugins by virtue of
+having put them there"). Adding network-pulling install would require a
+separate design discussion about trust, signing, and uninstall is not in
+scope until install is.
 
 ### Protocol notes
 

--- a/next/backend/src/index.ts
+++ b/next/backend/src/index.ts
@@ -53,10 +53,13 @@ async function main(): Promise<void> {
 
   // Plugin host. Discovers plugins on disk and spawns the ones with
   // `onStartup` activation; calls from plugins are capability-gated
-  // before reaching any host method. The host is independent of the
-  // WS surface in v0 — no `plugin.*` RPCs to the client yet (that lands
-  // in C2). See docs/design/mobile-code-platform.md §3.
-  const pluginHost = new PluginHost();
+  // before reaching any host method. The frontend reaches the host
+  // through the `plugin.*` RPCs in `rpc.ts`; state transitions fan out
+  // through `plugin.stateChanged`. See docs/design/mobile-code-platform.md §3.
+  const pluginHost = new PluginHost({
+    onStateChanged: (change) => state.broadcastPluginStateChanged(change),
+  });
+  state.pluginHost = pluginHost;
   await pluginHost.start();
 
   const httpServer = createServer((req, res) => {

--- a/next/backend/src/plugins/host.ts
+++ b/next/backend/src/plugins/host.ts
@@ -6,13 +6,18 @@
 // calls from each plugin. Everything plugin-related stays in this folder;
 // the rest of the backend reaches in via PluginHost only.
 //
-// The only host method exposed in C1 is `host.log({ level, msg })`. Any
+// Host methods exposed to plugins today: `host.log({ level, msg })`. Any
 // other namespace from a plugin gets capability-gated and (since no
 // other host RPCs are wired yet) ultimately resolves to either
 // `-32011 capabilityNotDeclared` (manifest didn't ask for the capability)
 // or `-32601 methodNotFound` (manifest declared it but the host has not
-// implemented the method yet — landing in C2/C3/C4/C5). The capability
+// implemented the method yet — landing in C3/C4/C5). The capability
 // check runs first, per the conventions doc.
+//
+// Surface exposed to the frontend (via `rpc.ts`): `plugin.list`,
+// `plugin.enable`, `plugin.disable`, `plugin.invokeCommand`. Each
+// frontend-visible state transition fans a `plugin.stateChanged`
+// notification out through the host's onStateChanged callback.
 
 import { existsSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
@@ -22,6 +27,7 @@ import { RPC_ERR } from "../rpc.js";
 import {
   loadManifest,
   type ManifestCapabilities,
+  type ManifestContributes,
   type PluginManifest,
 } from "./manifest.js";
 import {
@@ -29,6 +35,11 @@ import {
   PluginSpawnError,
   type JsonRpcInbound,
 } from "./process.js";
+import {
+  loadPluginState,
+  resolveDefaultStateFile,
+  savePluginState,
+} from "./persistence.js";
 import { StderrLog } from "./stderrLog.js";
 
 export type PluginState =
@@ -37,6 +48,12 @@ export type PluginState =
   | "crashed"
   | "errored"
   | "disabled";
+
+/// Vocabulary the frontend sees on `plugin.list` and `plugin.stateChanged`.
+/// Internal `registered` / `errored` collapse into "stopped" / "crashed" at
+/// the wire boundary — the wider internal vocabulary is for host
+/// bookkeeping, the wire surface is what the user can act on.
+export type WirePluginState = "running" | "stopped" | "crashed" | "disabled";
 
 export interface PluginRegistryEntry {
   id: string;
@@ -59,6 +76,26 @@ export interface HostLogEntry {
   ts: number;
 }
 
+/// Wire-shape entry returned by `plugin.list`. Mirrors the structure agreed
+/// in the issue ticket; mapping from the internal entry happens in
+/// `toWireInfo()` so the shape stays in one place.
+export interface PluginInfo {
+  id: string;
+  name: string;
+  version: string;
+  state: WirePluginState;
+  capabilities: ManifestCapabilities;
+  contributes: ManifestContributes;
+  crashReason?: string;
+}
+
+/// Payload emitted to subscribers on every state transition.
+export interface PluginStateChange {
+  id: string;
+  state: WirePluginState;
+  crashReason?: string;
+}
+
 export interface PluginHostOptions {
   /// Override discovery root. Tests point this at a tempdir; production
   /// reads it from `OPENVSMOBILE_PLUGINS_DIR` and falls back to the
@@ -67,15 +104,43 @@ export interface PluginHostOptions {
   /// Directory for plugin stderr logs. Default
   /// `~/.local/state/openvsmobile-next/plugins/`.
   logDir?: string;
+  /// Override the persistence file. Tests point this at a tempfile so they
+  /// don't read or write the user's real disabled list.
+  stateFile?: string;
+  /// SIGTERM-to-SIGKILL grace window (ms) for `disable()`. Default 10000,
+  /// per the issue spec. Tunable for tests.
+  killGraceMs?: number;
+  /// Timeout (ms) for a `plugin.invokeCommand` round-trip. Default 30000.
+  /// Tunable for tests.
+  invokeTimeoutMs?: number;
   /// Diagnostic logger. Defaults to console.error.
   logger?: (line: string) => void;
   /// Sink for `host.log` calls. The default fan-out routes them through
   /// `logger`. Tests pass a collector to assert delivery.
   onHostLog?: (entry: HostLogEntry) => void;
+  /// Called every time a registry entry's wire-state changes. The host
+  /// computes the wire state from the internal state + reason; downstream
+  /// fan-out lives in `ProcessState`.
+  onStateChanged?: (change: PluginStateChange) => void;
 }
 
 const DEFAULT_PLUGINS_DIR_REL = [".local", "share", "openvsmobile-next", "plugins"];
 const DEFAULT_LOG_DIR_REL = [".local", "state", "openvsmobile-next", "plugins"];
+
+const DEFAULT_KILL_GRACE_MS = 10_000;
+const DEFAULT_INVOKE_TIMEOUT_MS = 30_000;
+
+/// Error subclass thrown by the public mutation methods (`enable`,
+/// `disable`, `invokeCommand`) so the RPC layer can translate them to the
+/// right JSON-RPC error code without leaking host internals. The `code` is
+/// the JSON-RPC code; the message is human text.
+export class PluginHostError extends Error {
+  public readonly code: number;
+  constructor(code: number, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
 
 /// Capability key required by a method namespace. Methods under `host.*`
 /// require no capability (the host log is intentionally always
@@ -108,20 +173,61 @@ function pluginHasCapability(
   return caps[key] === true;
 }
 
+/// Internal → wire-state collapse. The frontend only needs the four
+/// outcomes a user can act on; the wider internal vocabulary stays inside
+/// the host.
+function toWireState(state: PluginState): WirePluginState {
+  switch (state) {
+    case "active":
+      return "running";
+    case "registered":
+      return "stopped";
+    case "disabled":
+      return "disabled";
+    case "crashed":
+    case "errored":
+      return "crashed";
+  }
+}
+
+interface PendingInvoke {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  pluginId: string;
+  timer: NodeJS.Timeout;
+}
+
 export class PluginHost {
   private readonly pluginsDir: string;
   private readonly logDir: string;
+  private readonly stateFile: string;
+  private readonly killGraceMs: number;
+  private readonly invokeTimeoutMs: number;
   private readonly logger: (line: string) => void;
   private readonly onHostLog: (entry: HostLogEntry) => void;
+  private readonly onStateChanged?: (change: PluginStateChange) => void;
   private readonly plugins = new Map<string, PluginRegistryEntry>();
-  /// Counter for outgoing requests we initiate toward plugins (e.g.
-  /// `initialize` in the C2 timeframe). Lives here so a single
-  /// monotonic source covers every plugin.
+  /// Persistent disabled set. Loaded from disk on construction; mirrored to
+  /// disk on every `enable` / `disable` call. The registry tracks both an
+  /// in-memory entry state (which can be `disabled`) and this set so a
+  /// plugin we discovered for the first time after a disable can still
+  /// land as `disabled` instead of being auto-spawned by `onStartup`.
+  private readonly disabled: Set<string>;
+  /// Counter for outgoing requests we initiate toward plugins
+  /// (`command.invoke` today, `initialize` once it lands). Lives here so a
+  /// single monotonic source covers every plugin.
   private nextOutboundId = 1;
+  /// Pending `command.invoke` requests keyed by outbound id. The plugin
+  /// must respond with the same id; we resolve / reject the awaiter and
+  /// drop the entry.
+  private readonly pendingInvokes = new Map<number, PendingInvoke>();
 
   constructor(opts: PluginHostOptions = {}) {
     this.pluginsDir = opts.pluginsDir ?? resolveDefaultPluginsDir();
     this.logDir = opts.logDir ?? resolveDefaultLogDir();
+    this.stateFile = opts.stateFile ?? resolveDefaultStateFile();
+    this.killGraceMs = opts.killGraceMs ?? DEFAULT_KILL_GRACE_MS;
+    this.invokeTimeoutMs = opts.invokeTimeoutMs ?? DEFAULT_INVOKE_TIMEOUT_MS;
     this.logger = opts.logger ?? ((line) => console.error(line));
     this.onHostLog =
       opts.onHostLog ??
@@ -129,12 +235,23 @@ export class PluginHost {
         this.logger(
           `[plugin:${entry.pluginId}] ${entry.level}: ${entry.msg}`,
         ));
+    if (opts.onStateChanged !== undefined) {
+      this.onStateChanged = opts.onStateChanged;
+    }
+    this.disabled = loadPluginState(this.stateFile, this.logger);
   }
 
-  /// Public read-only view of the registry. Tests + future `plugin.list`
-  /// reach for this.
+  /// Public read-only view of the registry. Tests + `plugin.list` reach
+  /// for this. Note that callers receive live references, not copies — do
+  /// not mutate.
   public list(): PluginRegistryEntry[] {
     return [...this.plugins.values()];
+  }
+
+  /// Wire-shape projection of the registry, exactly what `plugin.list`
+  /// returns to the client.
+  public listInfo(): PluginInfo[] {
+    return this.list().map((e) => this.toWireInfo(e));
   }
 
   public get(id: string): PluginRegistryEntry | undefined {
@@ -147,9 +264,16 @@ export class PluginHost {
     return this.pluginsDir;
   }
 
-  /// Discover everything on disk and start `onStartup` plugins. Safe to
-  /// call once at backend boot. If the plugins directory is missing
-  /// entirely we treat that as "no plugins installed" — not an error.
+  /// Persistence path. Exposed so tests can inspect the on-disk state
+  /// after `enable`/`disable` mutations.
+  public stateFilePath(): string {
+    return this.stateFile;
+  }
+
+  /// Discover everything on disk and start `onStartup` plugins that have
+  /// not been explicitly disabled. Safe to call once at backend boot. If
+  /// the plugins directory is missing entirely we treat that as "no
+  /// plugins installed" — not an error.
   public async start(): Promise<void> {
     await this.discover();
     for (const entry of this.plugins.values()) {
@@ -167,17 +291,22 @@ export class PluginHost {
   /// Tear every plugin process down. Best-effort; we send SIGTERM and
   /// move on. Called from the backend's shutdown handler.
   public shutdown(): void {
+    for (const [, pending] of this.pendingInvokes) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("backend shutting down"));
+    }
+    this.pendingInvokes.clear();
     for (const entry of this.plugins.values()) {
       if (entry.process !== undefined) entry.process.kill();
     }
   }
 
   /// Walk the plugins directory. Each direct child that contains a
-  /// `plugin.json` becomes a `registered` entry. Mismatched id, parse
-  /// errors, and missing manifest files are surfaced through the entry
-  /// state — invalid plugins land as `errored` so the host can still
-  /// report them to the future Plugins tab without erroring the whole
-  /// backend.
+  /// `plugin.json` becomes a `registered` entry (or `disabled` if the
+  /// state file said so). Mismatched id, parse errors, and missing
+  /// manifest files are surfaced through the entry state — invalid
+  /// plugins land as `errored` so the host can still report them to the
+  /// Plugins tab without erroring the whole backend.
   private async discover(): Promise<void> {
     let dirents: import("node:fs").Dirent[];
     try {
@@ -218,11 +347,18 @@ export class PluginHost {
       for (const w of warnings) {
         this.logger(`[plugin:${dirId}] ${w}`);
       }
+      // Honor the persisted disabled set: if the user disabled this
+      // plugin before the last restart, land it in `disabled` so
+      // `onStartup` activation doesn't fire and the wire state reads
+      // "disabled" from the first `plugin.list` call.
+      const initialState: PluginState = this.disabled.has(dirId)
+        ? "disabled"
+        : "registered";
       this.plugins.set(dirId, {
         id: dirId,
         dir,
         manifest,
-        state: "registered",
+        state: initialState,
       });
     } catch (err) {
       // Synthesize a minimal "errored" entry so the future Plugins tab
@@ -259,12 +395,15 @@ export class PluginHost {
     }
   }
 
-  /// Spawn a plugin's process and wire its message handler. Idempotent:
-  /// a re-activate on an already-active plugin is a no-op. After this
-  /// returns, the plugin's state is one of `active`, `crashed`, or
-  /// `errored`.
+  /// Spawn a plugin's process and wire its message handler. Idempotent on
+  /// `active`: a re-activate on an already-active plugin is a no-op.
+  /// Disabled / errored entries cannot be activated through this path —
+  /// the caller is responsible for transitioning through `enable()`
+  /// first.
   public async activate(entry: PluginRegistryEntry): Promise<void> {
     if (entry.state === "active") return;
+    if (entry.state === "disabled") return;
+    if (entry.state === "errored") return;
     const logPath = join(this.logDir, `${entry.id}.stderr.log`);
     const stderr = new StderrLog(logPath);
     const proc = new PluginProcess({
@@ -279,40 +418,81 @@ export class PluginHost {
       await proc.start();
     } catch (err) {
       if (err instanceof PluginSpawnError) {
-        entry.state = "errored";
-        entry.reason = err.message;
+        this.setState(entry, "errored", err.message);
         this.logger(`[plugin:${entry.id}] refused to spawn: ${err.message}`);
         return;
       }
       throw err;
     }
     entry.process = proc;
-    entry.state = "active";
+    this.setState(entry, "active");
     this.logger(`[plugin:${entry.id}] spawned pid=${proc.pid() ?? "?"}`);
   }
 
-  /// Used for the activating-state intermediate; today we flip directly
-  /// from `registered` to `active`. Kept as a placeholder so existing
-  /// callers don't break when the C2 `initialize` handshake lands.
+  /// Transition state, clearing any stale `reason` unless the caller
+  /// supplies a new one. Emits `onStateChanged` only when the wire-state
+  /// actually changes — internal `registered` → `errored` collapses to
+  /// `stopped` → `crashed`, but a `registered` → `registered` no-op is
+  /// suppressed.
+  private setState(
+    entry: PluginRegistryEntry,
+    next: PluginState,
+    reason?: string,
+  ): void {
+    const wireBefore = toWireState(entry.state);
+    const reasonBefore = entry.reason;
+    entry.state = next;
+    if (reason !== undefined) {
+      entry.reason = reason;
+    } else if (next !== "crashed" && next !== "errored") {
+      // Leaving crashed/errored → reason is no longer meaningful.
+      entry.reason = undefined;
+    }
+    const wireAfter = toWireState(next);
+    if (this.onStateChanged !== undefined) {
+      const reasonAfter = entry.reason;
+      if (wireBefore !== wireAfter || reasonBefore !== reasonAfter) {
+        const change: PluginStateChange = {
+          id: entry.id,
+          state: wireAfter,
+        };
+        if (entry.reason !== undefined) {
+          change.crashReason = entry.reason;
+        }
+        this.onStateChanged(change);
+      }
+    }
+  }
+
   private handlePluginExit(
     entry: PluginRegistryEntry,
     info: { code: number | null; signal: NodeJS.Signals | null },
   ): void {
-    // No automatic restart (settled decision; CLAUDE.md). We move the
-    // entry to `crashed` if it had been running, or leave `errored`
-    // alone (a stillborn child can fire `exit` after we already
-    // transitioned to errored via the spawn-error path).
+    // No automatic restart (settled decision; CLAUDE.md). Disabled plugins
+    // that were just terminated via `disable()` land here too — their
+    // state has already been set to `disabled` so we leave it alone. A
+    // crash of a previously-active plugin transitions to `crashed`.
+    entry.exit = info;
     if (entry.state === "active") {
-      entry.state = "crashed";
-      entry.reason = explainExit(info);
-      entry.exit = info;
+      this.setState(entry, "crashed", explainExit(info));
       this.logger(
         `[plugin:${entry.id}] crashed: ${entry.reason} (no automatic restart)`,
       );
-    } else {
-      entry.exit = info;
     }
     entry.process = undefined;
+    // Reject any pending invokes targeted at this plugin — without this
+    // their await would block until the timeout fires.
+    for (const [outboundId, pending] of this.pendingInvokes) {
+      if (pending.pluginId !== entry.id) continue;
+      clearTimeout(pending.timer);
+      this.pendingInvokes.delete(outboundId);
+      pending.reject(
+        new PluginHostError(
+          RPC_ERR.internal,
+          `plugin ${entry.id} exited before responding to command.invoke`,
+        ),
+      );
+    }
   }
 
   private handlePluginMessage(
@@ -320,17 +500,46 @@ export class PluginHost {
     msg: JsonRpcInbound,
   ): void {
     // Requests carry an id; notifications don't. Plugins may also send
-    // *responses* to host-initiated requests (we'll have those once
-    // `initialize` lands in C2); v0 has none so we just log them.
+    // responses to host-initiated requests (currently `command.invoke`);
+    // route those back to the pending awaiter.
     if (msg.method === undefined) {
-      // Response to a (currently nonexistent) host-initiated request.
-      // Logging until the C2 timeframe wires the response router.
-      this.logger(
-        `[plugin:${plugin.manifest.id}] discarding response (no outstanding host requests)`,
-      );
+      this.handlePluginResponse(plugin, msg);
       return;
     }
     void this.dispatchPluginRequest(plugin, msg);
+  }
+
+  private handlePluginResponse(
+    plugin: PluginProcess,
+    msg: JsonRpcInbound,
+  ): void {
+    const id = msg.id;
+    if (typeof id !== "number") {
+      this.logger(
+        `[plugin:${plugin.manifest.id}] discarding response with non-numeric id`,
+      );
+      return;
+    }
+    const pending = this.pendingInvokes.get(id);
+    if (pending === undefined) {
+      this.logger(
+        `[plugin:${plugin.manifest.id}] discarding response for unknown id ${id}`,
+      );
+      return;
+    }
+    clearTimeout(pending.timer);
+    this.pendingInvokes.delete(id);
+    if (msg.error !== undefined) {
+      const code = msg.error.code ?? RPC_ERR.internal;
+      pending.reject(
+        new PluginHostError(
+          code,
+          msg.error.message ?? "plugin returned an error response",
+        ),
+      );
+      return;
+    }
+    pending.resolve(msg.result);
   }
 
   private async dispatchPluginRequest(
@@ -379,9 +588,9 @@ export class PluginHost {
     }
   }
 
-  /// The actual host-method table. v0 has exactly one entry: `host.log`.
-  /// Adding methods here without also widening `requiredCapability`
-  /// would let plugins bypass the gate, so the two must move together.
+  /// The actual host-method table. Adding methods here without also
+  /// widening `requiredCapability` would let plugins bypass the gate, so
+  /// the two must move together.
   private async callHostMethod(
     plugin: PluginProcess,
     method: string,
@@ -391,10 +600,10 @@ export class PluginHost {
       this.handleHostLog(plugin.manifest.id, params);
       return {};
     }
-    // Pre-C2: capability passed, but the method itself doesn't exist
-    // yet. Surface as methodNotFound so a plugin author has a clear
-    // signal that they declared a capability but the host hasn't wired
-    // the corresponding API in this build.
+    // Capability passed, but the method itself doesn't exist yet.
+    // Surface as methodNotFound so a plugin author has a clear signal
+    // that they declared a capability but the host hasn't wired the
+    // corresponding API in this build.
     const err = new Error(`unknown host method: ${method}`) as Error & {
       code: number;
     };
@@ -430,11 +639,214 @@ export class PluginHost {
     this.onHostLog({ pluginId, level, msg, ts: Date.now() });
   }
 
-  /// Reserve an outbound id for a future host→plugin request. Not used
-  /// in v0; lives here so the C2 initialize handshake doesn't have to
-  /// invent its own counter.
+  /// Reserve an outbound id for a host→plugin request. Each pending
+  /// invoke must have a unique id so the response router can find it
+  /// again.
   public allocateOutboundId(): number {
     return this.nextOutboundId++;
+  }
+
+  // ----- Frontend-facing surface: enable / disable / invokeCommand -----
+
+  /// Project an internal registry entry to the wire-shape the frontend
+  /// sees. `crashReason` shows up for `crashed` (which collapses internal
+  /// `errored` too) so a broken manifest is observable on the UI.
+  public toWireInfo(entry: PluginRegistryEntry): PluginInfo {
+    const info: PluginInfo = {
+      id: entry.id,
+      name: entry.manifest.name,
+      version: entry.manifest.version,
+      state: toWireState(entry.state),
+      capabilities: entry.manifest.capabilities,
+      contributes: entry.manifest.contributes,
+    };
+    if (info.state === "crashed" && entry.reason !== undefined) {
+      info.crashReason = entry.reason;
+    }
+    return info;
+  }
+
+  /// Re-enable a plugin. Removes it from the persisted disabled set and,
+  /// if it was in-memory `disabled`, transitions it back to `registered`
+  /// (then immediately activates if the manifest declares `onStartup`).
+  /// Calling on an already-enabled plugin is a no-op that still returns
+  /// `{ ok: true }` so the client can fire-and-forget.
+  public async enable(id: string): Promise<void> {
+    const entry = this.plugins.get(id);
+    if (entry === undefined) {
+      throw new PluginHostError(
+        RPC_ERR.invalidParams,
+        `no such plugin: ${id}`,
+      );
+    }
+    if (this.disabled.has(id)) {
+      this.disabled.delete(id);
+      this.persist();
+    }
+    if (entry.state !== "disabled") return;
+    // Reset the entry to `registered` so the activation path sees a
+    // valid starting state. `errored` plugins keep their original
+    // disable→errored chain — we can't fix a broken manifest here.
+    this.setState(entry, "registered");
+    if (entry.manifest.activation.includes("onStartup")) {
+      await this.activate(entry);
+    }
+  }
+
+  /// Disable a plugin. Marks it disabled, persists, then terminates the
+  /// child process if one is running. SIGTERM → 10s grace → SIGKILL. The
+  /// `exit` handler will see `state === "disabled"` and leave it alone.
+  public async disable(id: string): Promise<void> {
+    const entry = this.plugins.get(id);
+    if (entry === undefined) {
+      throw new PluginHostError(
+        RPC_ERR.invalidParams,
+        `no such plugin: ${id}`,
+      );
+    }
+    if (!this.disabled.has(id)) {
+      this.disabled.add(id);
+      this.persist();
+    }
+    if (entry.state === "disabled") return;
+    const wasActive = entry.state === "active" && entry.process !== undefined;
+    // Flip state BEFORE the kill so the exit handler doesn't transition
+    // through `crashed` on the way out.
+    this.setState(entry, "disabled");
+    if (wasActive && entry.process !== undefined) {
+      await entry.process.terminate(this.killGraceMs);
+    }
+  }
+
+  /// Invoke a command on a plugin. Triggers `onCommand:<commandId>`
+  /// activation if the plugin is in the `stopped` (registered) state and
+  /// the activation event matches. Sends `command.invoke` to the plugin
+  /// over its JSON-RPC channel; awaits the plugin's response.
+  public async invokeCommand(
+    id: string,
+    commandId: string,
+    args: unknown,
+  ): Promise<unknown> {
+    const entry = this.plugins.get(id);
+    if (entry === undefined) {
+      throw new PluginHostError(
+        RPC_ERR.invalidParams,
+        `no such plugin: ${id}`,
+      );
+    }
+    if (entry.state === "disabled") {
+      throw new PluginHostError(
+        RPC_ERR.invalidParams,
+        `plugin ${id} is disabled`,
+      );
+    }
+    if (entry.state === "errored") {
+      throw new PluginHostError(
+        RPC_ERR.invalidParams,
+        `plugin ${id} is in errored state: ${entry.reason ?? "unknown"}`,
+      );
+    }
+    if (entry.state === "crashed") {
+      // The settled "no automatic restart" decision means we can't
+      // resurrect a crashed plugin even on an explicit command call.
+      // The user must re-enable (or fix the underlying problem) first.
+      throw new PluginHostError(
+        RPC_ERR.invalidParams,
+        `plugin ${id} crashed; restart it before invoking commands`,
+      );
+    }
+    if (entry.state === "registered") {
+      const matches = entry.manifest.activation.includes(
+        `onCommand:${commandId}`,
+      );
+      if (!matches) {
+        throw new PluginHostError(
+          RPC_ERR.invalidParams,
+          `plugin ${id} is not active and does not list onCommand:${commandId}`,
+        );
+      }
+      await this.activate(entry);
+      // Activation may have failed (errored after spawn). Re-check via
+      // a fresh lookup so the type narrowing doesn't lie — the if-block
+      // above gave the compiler "registered" but activate() mutates the
+      // entry in place.
+      const reread = this.plugins.get(id);
+      if (reread === undefined || reread.state !== "active") {
+        throw new PluginHostError(
+          RPC_ERR.internal,
+          `plugin ${id} failed to activate: ${reread?.reason ?? "unknown"}`,
+        );
+      }
+    }
+    // Whitelist commandId against the manifest's contributed commands.
+    // Plugins could in principle handle commands not listed in
+    // `contributes.commands`, but the manifest is the contract — making
+    // the host the source of truth here keeps the model honest.
+    const declared = entry.manifest.contributes.commands.find(
+      (c) => c.id === commandId,
+    );
+    if (declared === undefined) {
+      throw new PluginHostError(
+        RPC_ERR.invalidParams,
+        `plugin ${id} does not contribute command ${commandId}`,
+      );
+    }
+    if (entry.process === undefined) {
+      throw new PluginHostError(
+        RPC_ERR.internal,
+        `plugin ${id} is active but has no live process`,
+      );
+    }
+    return await this.sendCommandInvoke(
+      entry.process,
+      entry.id,
+      commandId,
+      args,
+    );
+  }
+
+  private sendCommandInvoke(
+    plugin: PluginProcess,
+    pluginId: string,
+    commandId: string,
+    args: unknown,
+  ): Promise<unknown> {
+    const outboundId = this.allocateOutboundId();
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingInvokes.delete(outboundId);
+        reject(
+          new PluginHostError(
+            RPC_ERR.internal,
+            `plugin ${pluginId} did not respond to command.invoke within ${this.invokeTimeoutMs}ms`,
+          ),
+        );
+      }, this.invokeTimeoutMs);
+      this.pendingInvokes.set(outboundId, {
+        resolve,
+        reject,
+        pluginId,
+        timer,
+      });
+      plugin.send({
+        jsonrpc: "2.0",
+        id: outboundId,
+        method: "command.invoke",
+        params: { id: commandId, args },
+      });
+    });
+  }
+
+  private persist(): void {
+    try {
+      savePluginState(this.stateFile, this.disabled);
+    } catch (err) {
+      // The on-disk file is best-effort: if we can't write it we still
+      // honor the in-memory state, but a future restart won't pick it up.
+      this.logger(
+        `[plugins] failed to write state file ${this.stateFile}: ${(err as Error).message}`,
+      );
+    }
   }
 }
 

--- a/next/backend/src/plugins/persistence.ts
+++ b/next/backend/src/plugins/persistence.ts
@@ -1,0 +1,85 @@
+// Disabled-plugin persistence. The host loads the set on boot so a user's
+// `plugin.disable` survives a backend restart; it writes back synchronously
+// after every change. The format is intentionally trivial — `{ disabled:
+// string[] }` — so a human can hand-edit the file if needed and so a future
+// schema bump can detect "this is v0" without a version field.
+//
+// Path: `~/.local/state/openvsmobile-next/plugin-state.json`, overridable via
+// `OPENVSMOBILE_PLUGIN_STATE_FILE` so tests don't touch the user's real state.
+
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const DEFAULT_STATE_FILE_REL = [
+  ".local",
+  "state",
+  "openvsmobile-next",
+  "plugin-state.json",
+];
+
+export interface PluginStateFile {
+  disabled: string[];
+}
+
+export function resolveDefaultStateFile(): string {
+  const override = process.env.OPENVSMOBILE_PLUGIN_STATE_FILE;
+  if (override !== undefined && override.length > 0) return override;
+  return join(homedir(), ...DEFAULT_STATE_FILE_REL);
+}
+
+/// Read the disabled-set from disk. Missing file, parse errors, or wrong
+/// shape are all treated as "no plugins disabled". The host logs the parse
+/// failure but doesn't refuse to boot — the user's plugins should keep
+/// working past a corrupted state file.
+export function loadPluginState(
+  path: string,
+  logger: (line: string) => void,
+): Set<string> {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      logger(`[plugins] cannot read state file ${path}: ${(err as Error).message}`);
+    }
+    return new Set();
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    logger(`[plugins] state file ${path} is not valid JSON: ${(err as Error).message}`);
+    return new Set();
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    logger(`[plugins] state file ${path} is not an object; ignoring`);
+    return new Set();
+  }
+  const disabled = (parsed as Record<string, unknown>).disabled;
+  if (!Array.isArray(disabled)) return new Set();
+  const out = new Set<string>();
+  for (const item of disabled) {
+    if (typeof item === "string" && item.length > 0) out.add(item);
+  }
+  return out;
+}
+
+/// Atomically rewrite the state file. We mkdir -p the parent and write
+/// through a `.tmp` neighbour + rename — same belt-and-braces pattern the
+/// runtime-info file uses so a crashed write never leaves a half-written
+/// file behind.
+export function savePluginState(path: string, disabled: Set<string>): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const body: PluginStateFile = { disabled: [...disabled].sort() };
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(body, null, 2), { mode: 0o600 });
+  // `renameSync` is atomic on POSIX filesystems.
+  renameSync(tmp, path);
+}

--- a/next/backend/src/plugins/process.ts
+++ b/next/backend/src/plugins/process.ts
@@ -63,6 +63,9 @@ export class PluginProcess {
   private readonly codec: FrameCodec;
   private child: ChildProcess | null = null;
   private exited = false;
+  /// Resolves the first time `onExit` fires. Lets `terminate()` callers
+  /// block on the actual exit instead of racing the kernel.
+  private exitWaiters: Array<() => void> = [];
 
   constructor(opts: PluginProcessOptions) {
     this.manifest = opts.manifest;
@@ -140,6 +143,49 @@ export class PluginProcess {
     }
   }
 
+  /// Wait until the child actually exits. Resolves immediately if the
+  /// process already exited (or was never running). Used by the disable
+  /// path so we can SIGTERM, await this, and SIGKILL on timeout.
+  public waitForExit(): Promise<void> {
+    if (this.exited || this.child === null) return Promise.resolve();
+    return new Promise((resolve) => {
+      this.exitWaiters.push(resolve);
+    });
+  }
+
+  /// SIGTERM the plugin; if it hasn't exited within `graceMs`, SIGKILL.
+  /// Resolves once the child has actually exited. `graceMs` is tunable so
+  /// tests don't have to wait the 10-second production default.
+  public async terminate(graceMs: number): Promise<void> {
+    if (this.child === null || this.exited) return;
+    try {
+      this.child.kill("SIGTERM");
+    } catch {
+      // best-effort — the kernel may have already torn the child down.
+    }
+    const exited = this.waitForExit();
+    let timer: NodeJS.Timeout | null = null;
+    const grace = new Promise<"timeout">((resolve) => {
+      timer = setTimeout(() => resolve("timeout"), graceMs);
+    });
+    const winner = await Promise.race([
+      exited.then(() => "exited" as const),
+      grace,
+    ]);
+    if (timer !== null) clearTimeout(timer);
+    if (winner === "timeout" && !this.exited && this.child !== null) {
+      this.logger(
+        `[plugin:${this.manifest.id}] SIGTERM did not exit within ${graceMs}ms; escalating to SIGKILL`,
+      );
+      try {
+        this.child.kill("SIGKILL");
+      } catch {
+        // best-effort
+      }
+      await this.waitForExit();
+    }
+  }
+
   /// PID of the live child, or null if the process never spawned or has
   /// exited. Useful for diagnostics; the host doesn't use it for
   /// dispatch.
@@ -178,6 +224,9 @@ export class PluginProcess {
     this.exited = true;
     this.stderr.close();
     this.onExit({ code, signal });
+    const waiters = this.exitWaiters;
+    this.exitWaiters = [];
+    for (const w of waiters) w();
   }
 
   private handleMessage(raw: unknown): void {

--- a/next/backend/src/rpc.ts
+++ b/next/backend/src/rpc.ts
@@ -30,6 +30,7 @@ import {
 } from "./git.js";
 import { parseUnifiedDiff, type DiffHunk } from "./diffParser.js";
 import { findFiles } from "./findFiles.js";
+import { PluginHostError } from "./plugins/host.js";
 import { stat as fsStat } from "node:fs/promises";
 import { join as pathJoin } from "node:path";
 
@@ -921,6 +922,98 @@ methods.set(METHOD_NOTIFICATION_MARK_IMPORTANT, (ctx, params) => {
   // error handling.
   ctx.state.notificationHub.markImportant(id, importantRaw);
   return { ok: true };
+});
+
+// ---- Plugin host ----
+//
+// Frontend surface for the plugin host. Subscription is per-connection — a
+// peer that hasn't called `plugin.subscribe` doesn't receive
+// `plugin.stateChanged` pushes. The host itself owns activation, kill
+// semantics, persistence, and host→plugin command.invoke routing; the
+// handlers here are thin glue that translates between RPC params and the
+// host's public methods.
+
+export const METHOD_PLUGIN_SUBSCRIBE = "plugin.subscribe";
+export const METHOD_PLUGIN_UNSUBSCRIBE = "plugin.unsubscribe";
+
+function requirePluginHost(ctx: RpcContext): NonNullable<RpcContext["state"]["pluginHost"]> {
+  const host = ctx.state.pluginHost;
+  if (host === null) {
+    throw new RpcError(RPC_ERR.internal, "plugin host not initialized");
+  }
+  return host;
+}
+
+/// Translate the host's PluginHostError into a wire RpcError so the
+/// JSON-RPC error code travels through unchanged. Anything else
+/// bubbles up to dispatch as an internal error.
+function rethrowPluginError(err: unknown): never {
+  if (err instanceof PluginHostError) {
+    throw new RpcError(err.code, err.message);
+  }
+  throw err;
+}
+
+methods.set(METHOD_PLUGIN_SUBSCRIBE, (ctx) => {
+  const sub = requireSubscriber(ctx);
+  sub.pluginsSubscribed = true;
+  return { ok: true };
+});
+
+methods.set(METHOD_PLUGIN_UNSUBSCRIBE, (ctx) => {
+  const sub = requireSubscriber(ctx);
+  sub.pluginsSubscribed = false;
+  return { ok: true };
+});
+
+methods.set("plugin.list", (ctx) => {
+  const host = requirePluginHost(ctx);
+  return { plugins: host.listInfo() };
+});
+
+methods.set("plugin.enable", async (ctx, params) => {
+  const host = requirePluginHost(ctx);
+  const p = asBag(params);
+  const id = requireString(p, "id");
+  try {
+    await host.enable(id);
+  } catch (err) {
+    rethrowPluginError(err);
+  }
+  return { ok: true };
+});
+
+methods.set("plugin.disable", async (ctx, params) => {
+  const host = requirePluginHost(ctx);
+  const p = asBag(params);
+  const id = requireString(p, "id");
+  try {
+    await host.disable(id);
+  } catch (err) {
+    rethrowPluginError(err);
+  }
+  return { ok: true };
+});
+
+methods.set("plugin.invokeCommand", async (ctx, params) => {
+  const host = requirePluginHost(ctx);
+  const p = asBag(params);
+  const id = requireString(p, "id");
+  const commandId = requireString(p, "commandId");
+  // `args` is opaque from the host's view — passed through untouched to
+  // the plugin's `command.invoke` handler. Missing / null is fine; we
+  // don't gate on shape.
+  const args = p.args;
+  let result: unknown;
+  try {
+    result = await host.invokeCommand(id, commandId, args);
+  } catch (err) {
+    rethrowPluginError(err);
+  }
+  // The plugin may legitimately respond with no result (e.g. for a
+  // fire-and-forget command). Surface that as an empty result object so
+  // the wire shape stays `{ result?: any }`.
+  return result === undefined ? {} : { result };
 });
 
 // -------- 6. Entry points --------

--- a/next/backend/src/state.ts
+++ b/next/backend/src/state.ts
@@ -23,6 +23,10 @@ import {
   NotificationHub,
   NotificationStore,
 } from "./notifications.js";
+import type {
+  PluginHost,
+  PluginStateChange,
+} from "./plugins/host.js";
 
 /// Each authenticated WebSocket registers a Subscriber. The connection is
 /// responsible for unregistering when the socket closes.
@@ -36,10 +40,15 @@ import {
 /// `notificationsSubscribed` toggles via `notification.subscribe` /
 /// `unsubscribe`. The fan-out helper consults it on every emit so a freshly-
 /// authenticated connection that hasn't subscribed receives nothing.
+///
+/// `pluginsSubscribed` is the same pattern for `plugin.stateChanged` pushes;
+/// off by default so a connection that doesn't care about the plugin surface
+/// (e.g. an older client) doesn't get the frames.
 export interface Subscriber {
   readonly ws: WebSocket;
   notificationDeviceId?: string;
   notificationsSubscribed?: boolean;
+  pluginsSubscribed?: boolean;
 }
 
 export interface ProcessStateOptions {
@@ -47,6 +56,12 @@ export interface ProcessStateOptions {
   /// callers leave this undefined and let `notifications.ts` resolve from
   /// $OPENVSMOBILE_NOTIFICATIONS_DB or the default location.
   notificationDbPath?: string;
+}
+
+export interface AttachPluginHostFanOut {
+  /// `plugin.stateChanged` fan-out target. The host calls this on every
+  /// state transition; ProcessState filters down to subscribed peers.
+  readonly emitStateChanged: (change: PluginStateChange) => void;
 }
 
 export class ProcessState {
@@ -66,6 +81,12 @@ export class ProcessState {
   /// Notification persistence + fan-out hub. Survives client disconnects
   /// (like everything else owned by ProcessState).
   public readonly notificationHub: NotificationHub;
+
+  /// Plugin host reference. Wired by `index.ts` after construction so
+  /// `ProcessState` doesn't have to know about plugin-host options.
+  /// `rpc.ts` reaches for this via `ctx.state.pluginHost` to satisfy
+  /// `plugin.list / enable / disable / invokeCommand`.
+  public pluginHost: PluginHost | null = null;
 
   private readonly subscribers = new Set<Subscriber>();
 
@@ -205,6 +226,16 @@ export class ProcessState {
     for (const sub of this.subscribers) {
       if (sub.notificationsSubscribed !== true) continue;
       sendNotification(sub.ws, method, params);
+    }
+  }
+
+  /// `plugin.stateChanged` fan-out — same per-subscriber subscription
+  /// gate as the notification surface. Exposed for the host to call via
+  /// the `onStateChanged` constructor hook (see `index.ts`).
+  public broadcastPluginStateChanged(change: PluginStateChange): void {
+    for (const sub of this.subscribers) {
+      if (sub.pluginsSubscribed !== true) continue;
+      sendNotification(sub.ws, "plugin.stateChanged", change);
     }
   }
 }

--- a/next/backend/test/fixtures/plugins/cmd/index.js
+++ b/next/backend/test/fixtures/plugins/cmd/index.js
@@ -1,0 +1,73 @@
+// Plugin that echoes `command.invoke` arguments. Understands both wire
+// framings (LSP Content-Length + newline-delimited JSON) because the
+// host's outbound framing follows whatever it detected on this plugin's
+// stdout — and stdout might not have emitted anything by the time the
+// first inbound frame arrives. Emitting a tiny startup notification
+// pushes the host's codec into newline mode in the common case; the
+// LSP branch below covers the race.
+
+process.stdout.write(
+  JSON.stringify({
+    jsonrpc: "2.0",
+    method: "host.log",
+    params: { level: "info", msg: "cmd-ready" },
+  }) + "\n",
+);
+
+let buffer = Buffer.alloc(0);
+process.stdin.on("data", (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+  drain();
+});
+
+function drain() {
+  while (true) {
+    if (buffer.length === 0) return;
+    if (buffer[0] === 0x43 || buffer[0] === 0x63) {
+      // 'C' / 'c' — LSP framing.
+      const headerEnd = buffer.indexOf("\r\n\r\n");
+      if (headerEnd === -1) return;
+      const header = buffer.subarray(0, headerEnd).toString("ascii");
+      const match = /Content-Length:\s*(\d+)/i.exec(header);
+      if (match === null) {
+        buffer = buffer.subarray(headerEnd + 4);
+        continue;
+      }
+      const len = Number(match[1]);
+      const bodyStart = headerEnd + 4;
+      if (buffer.length < bodyStart + len) return;
+      const body = buffer.subarray(bodyStart, bodyStart + len);
+      buffer = buffer.subarray(bodyStart + len);
+      handleLine(body.toString("utf8"));
+      continue;
+    }
+    // Newline-delimited.
+    const nl = buffer.indexOf(0x0a);
+    if (nl === -1) return;
+    const line = buffer.subarray(0, nl).toString("utf8");
+    buffer = buffer.subarray(nl + 1);
+    if (line.length > 0) handleLine(line);
+  }
+}
+
+function handleLine(line) {
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (msg.method === "command.invoke" && msg.id !== undefined) {
+    const args = msg.params && msg.params.args;
+    const commandId = msg.params && msg.params.id;
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: msg.id,
+      result: { echoed: args, commandId },
+    });
+    process.stdout.write(body + "\n");
+  }
+}
+
+// Stay alive long enough for the test to exercise us.
+setTimeout(() => {}, 60_000);

--- a/next/backend/test/fixtures/plugins/cmd/plugin.json
+++ b/next/backend/test/fixtures/plugins/cmd/plugin.json
@@ -1,0 +1,14 @@
+{
+  "id": "cmd",
+  "name": "Command fixture",
+  "version": "0.0.1",
+  "entry": { "kind": "node", "path": "index.js" },
+  "activation": ["onStartup", "onCommand:cmd.echoOnDemand"],
+  "capabilities": {},
+  "contributes": {
+    "commands": [
+      { "id": "cmd.echo", "title": "Echo" },
+      { "id": "cmd.echoOnDemand", "title": "Echo (on-demand)" }
+    ]
+  }
+}

--- a/next/backend/test/pluginRpc.test.ts
+++ b/next/backend/test/pluginRpc.test.ts
@@ -1,0 +1,391 @@
+// `plugin.*` RPC surface tests. Real plugin subprocesses (no mocks),
+// real persistence files in temp dirs, real WebSocket-shape stubs.
+//
+// Covers the acceptance criteria from issue #58:
+//   * enable → spawn → list shows running
+//   * disable → SIGTERM honored within the grace window
+//   * invokeCommand round-trips a string argument
+//   * persistence survives a host restart
+//   * plugin.stateChanged pushes only to subscribed peers
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { WebSocket } from "ws";
+import { cp, mkdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PluginHost } from "../src/plugins/host.js";
+import type { PluginInfo, WirePluginState } from "../src/plugins/host.js";
+import { dispatch, type RpcContext } from "../src/rpc.js";
+import { ProcessState } from "../src/state.js";
+import { FakeWebSocket, makeTempDir, rmTempDir, sleep } from "./_helpers.js";
+
+const FIXTURE_ROOT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+  "plugins",
+);
+
+interface Harness {
+  host: PluginHost;
+  state: ProcessState;
+  staging: string;
+  pluginsDir: string;
+  stateFile: string;
+}
+
+let staging: string | null = null;
+
+beforeEach(async () => {
+  staging = await makeTempDir("openvsmobile-pluginrpc-");
+});
+
+afterEach(async () => {
+  if (staging !== null) {
+    await rmTempDir(staging);
+    staging = null;
+  }
+});
+
+async function buildHarness(
+  fixtures: string[],
+  options: { stateFileContents?: string; killGraceMs?: number } = {},
+): Promise<Harness> {
+  if (staging === null) throw new Error("staging dir not set up");
+  const pluginsDir = join(staging, "plugins");
+  const logDir = join(staging, "logs");
+  const stateFile = join(staging, "plugin-state.json");
+  await mkdir(pluginsDir, { recursive: true });
+  await mkdir(logDir, { recursive: true });
+  for (const name of fixtures) {
+    await cp(join(FIXTURE_ROOT, name), join(pluginsDir, name), {
+      recursive: true,
+    });
+  }
+  if (options.stateFileContents !== undefined) {
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(stateFile, options.stateFileContents);
+  }
+  const state = new ProcessState();
+  const host = new PluginHost({
+    pluginsDir,
+    logDir,
+    stateFile,
+    killGraceMs: options.killGraceMs ?? 250,
+    invokeTimeoutMs: 2000,
+    logger: () => {},
+    onHostLog: () => {},
+    onStateChanged: (change) => state.broadcastPluginStateChanged(change),
+  });
+  state.pluginHost = host;
+  await host.start();
+  return { host, state, staging, pluginsDir, stateFile };
+}
+
+function makeContext(state: ProcessState, sock: FakeWebSocket): RpcContext {
+  const ctx: RpcContext = {
+    state,
+    expectedToken: "test-token",
+    serverVersion: "0.0.0-test",
+    ws: sock as unknown as WebSocket,
+    markAuthenticated: () => {},
+  };
+  // Mimic the connection layer: every authenticated dispatch carries a
+  // Subscriber object that the handlers can mutate.
+  const subscriber = {
+    ws: sock as unknown as WebSocket,
+  };
+  ctx.subscriber = subscriber;
+  state.addSubscriber(subscriber);
+  return ctx;
+}
+
+async function call<T = unknown>(
+  ctx: RpcContext,
+  method: string,
+  params: unknown,
+): Promise<T> {
+  return (await dispatch(ctx, {
+    jsonrpc: "2.0",
+    id: 1,
+    method,
+    params,
+  })) as T;
+}
+
+async function waitFor<T>(
+  predicate: () => T | undefined | Promise<T | undefined>,
+  budgetMs: number,
+  stepMs = 25,
+): Promise<T> {
+  const deadline = Date.now() + budgetMs;
+  while (Date.now() < deadline) {
+    const v = await predicate();
+    if (v !== undefined) return v;
+    await sleep(stepMs);
+  }
+  const v = await predicate();
+  if (v !== undefined) return v;
+  throw new Error(`waitFor timed out after ${budgetMs}ms`);
+}
+
+describe("plugin.* RPCs", () => {
+  it("enable transitions a disabled plugin to running and plugin.list reflects it", async () => {
+    // Pre-disable the fixture so the host loads it as disabled on start.
+    const harness = await buildHarness(["hello"], {
+      stateFileContents: JSON.stringify({ disabled: ["hello"] }),
+    });
+    try {
+      const sock = new FakeWebSocket();
+      const ctx = makeContext(harness.state, sock);
+      const before = await call<{ plugins: PluginInfo[] }>(
+        ctx,
+        "plugin.list",
+        {},
+      );
+      const entry = before.plugins.find((p) => p.id === "hello");
+      expect(entry?.state).toBe<WirePluginState>("disabled");
+
+      const result = await call<{ ok: true }>(ctx, "plugin.enable", {
+        id: "hello",
+      });
+      expect(result).toEqual({ ok: true });
+
+      // hello has onStartup activation → enable should spawn it. The
+      // spawn is awaited inside `enable()` so the state has flipped by
+      // the time we land here; the only async piece is the child
+      // process actually being up.
+      const running = await waitFor(() => {
+        const e = harness.host.get("hello");
+        return e?.state === "active" ? e : undefined;
+      }, 2000);
+      expect(running.process?.pid()).toBeTypeOf("number");
+
+      const after = await call<{ plugins: PluginInfo[] }>(
+        ctx,
+        "plugin.list",
+        {},
+      );
+      const helloAfter = after.plugins.find((p) => p.id === "hello");
+      expect(helloAfter?.state).toBe<WirePluginState>("running");
+    } finally {
+      harness.host.shutdown();
+    }
+  });
+
+  it("disable SIGTERMs the plugin within the grace window and updates state", async () => {
+    const harness = await buildHarness(["hello"], { killGraceMs: 250 });
+    try {
+      await waitFor(
+        () => (harness.host.get("hello")?.state === "active" ? true : undefined),
+        2000,
+      );
+      const proc = harness.host.get("hello")?.process;
+      expect(proc).toBeDefined();
+      const exitPromise = proc!.waitForExit();
+
+      const sock = new FakeWebSocket();
+      const ctx = makeContext(harness.state, sock);
+      const start = Date.now();
+      const result = await call<{ ok: true }>(ctx, "plugin.disable", {
+        id: "hello",
+      });
+      expect(result).toEqual({ ok: true });
+      // The hello fixture installs no SIGTERM handler, so the kernel
+      // terminates it on the first signal — much faster than the grace
+      // window. We assert that the wait returned before grace + a small
+      // buffer to catch a regression that forgets the SIGKILL escalation.
+      await exitPromise;
+      expect(Date.now() - start).toBeLessThan(2000);
+      expect(harness.host.get("hello")?.state).toBe("disabled");
+    } finally {
+      harness.host.shutdown();
+    }
+  });
+
+  it("invokeCommand round-trips an argument through the plugin's response", async () => {
+    const harness = await buildHarness(["cmd"]);
+    try {
+      await waitFor(
+        () => (harness.host.get("cmd")?.state === "active" ? true : undefined),
+        2000,
+      );
+      const sock = new FakeWebSocket();
+      const ctx = makeContext(harness.state, sock);
+      const result = await call<{ result?: unknown }>(
+        ctx,
+        "plugin.invokeCommand",
+        {
+          id: "cmd",
+          commandId: "cmd.echo",
+          args: "hello world",
+        },
+      );
+      expect(result).toEqual({
+        result: { echoed: "hello world", commandId: "cmd.echo" },
+      });
+    } finally {
+      harness.host.shutdown();
+    }
+  });
+
+  it("invokeCommand activates a stopped plugin when the manifest lists onCommand:<id>", async () => {
+    // Pre-disable to land in `disabled`, then enable so the in-memory
+    // state becomes `registered` (since the cmd fixture has onStartup,
+    // calling enable starts it; we want a stopped state, so we strip
+    // onStartup via a tweaked fixture). Easier path: manually transition
+    // through the host's public methods. The cmd fixture has onStartup
+    // so once it's enabled it starts running; we then disable it (state
+    // goes `disabled`), re-enable (state goes `registered` then immediately
+    // active via onStartup). That doesn't give us a stopped + onCommand
+    // scenario.
+    //
+    // To exercise on-demand activation we restart the host with a state
+    // file that keeps the plugin enabled but with no activation events
+    // matching onStartup. We do this by altering the staged manifest on
+    // disk before host.start() runs. To keep things small, copy the cmd
+    // fixture manually and rewrite its activation events.
+    if (staging === null) throw new Error("staging dir not set up");
+    const pluginsDir = join(staging, "plugins");
+    const logDir = join(staging, "logs");
+    const stateFile = join(staging, "plugin-state.json");
+    await mkdir(pluginsDir, { recursive: true });
+    await mkdir(logDir, { recursive: true });
+    await cp(join(FIXTURE_ROOT, "cmd"), join(pluginsDir, "cmd"), {
+      recursive: true,
+    });
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(
+      join(pluginsDir, "cmd", "plugin.json"),
+      JSON.stringify({
+        id: "cmd",
+        name: "Command fixture",
+        version: "0.0.1",
+        entry: { kind: "node", path: "index.js" },
+        activation: ["onCommand:cmd.echoOnDemand"],
+        capabilities: {},
+        contributes: {
+          commands: [{ id: "cmd.echoOnDemand", title: "Echo (on-demand)" }],
+        },
+      }),
+    );
+    const state = new ProcessState();
+    const host = new PluginHost({
+      pluginsDir,
+      logDir,
+      stateFile,
+      killGraceMs: 250,
+      invokeTimeoutMs: 2000,
+      logger: () => {},
+      onHostLog: () => {},
+    });
+    state.pluginHost = host;
+    await host.start();
+    try {
+      // No onStartup → lazy activation. Pre-call assertions:
+      expect(host.get("cmd")?.state).toBe("registered");
+      const sock = new FakeWebSocket();
+      const ctx = makeContext(state, sock);
+      const result = await call<{ result?: unknown }>(
+        ctx,
+        "plugin.invokeCommand",
+        {
+          id: "cmd",
+          commandId: "cmd.echoOnDemand",
+          args: { greeting: "hi" },
+        },
+      );
+      // Activation happened as part of the invoke.
+      expect(host.get("cmd")?.state).toBe("active");
+      expect(result.result).toMatchObject({
+        echoed: { greeting: "hi" },
+        commandId: "cmd.echoOnDemand",
+      });
+    } finally {
+      host.shutdown();
+    }
+  });
+
+  it("persists enabled/disabled state across a host restart", async () => {
+    const harness = await buildHarness(["hello"]);
+    try {
+      const sock = new FakeWebSocket();
+      const ctx = makeContext(harness.state, sock);
+      await call<{ ok: true }>(ctx, "plugin.disable", { id: "hello" });
+      // On-disk state file should now contain hello in `disabled`.
+      const onDisk = JSON.parse(
+        await readFile(harness.stateFile, "utf8"),
+      ) as { disabled: string[] };
+      expect(onDisk.disabled).toContain("hello");
+    } finally {
+      harness.host.shutdown();
+    }
+    // Reinstantiate the host (and a fresh ProcessState) pointing at the
+    // same plugins/state files. The plugin should land in `disabled`
+    // without anyone explicitly asking — that's the whole point of the
+    // persistence step.
+    if (staging === null) throw new Error("staging dir not set up");
+    const reloadedState = new ProcessState();
+    const reloaded = new PluginHost({
+      pluginsDir: join(staging, "plugins"),
+      logDir: join(staging, "logs"),
+      stateFile: join(staging, "plugin-state.json"),
+      killGraceMs: 250,
+      invokeTimeoutMs: 2000,
+      logger: () => {},
+      onHostLog: () => {},
+    });
+    reloadedState.pluginHost = reloaded;
+    await reloaded.start();
+    try {
+      expect(reloaded.get("hello")?.state).toBe("disabled");
+      const sock = new FakeWebSocket();
+      const ctx = makeContext(reloadedState, sock);
+      const list = await call<{ plugins: PluginInfo[] }>(
+        ctx,
+        "plugin.list",
+        {},
+      );
+      const hello = list.plugins.find((p) => p.id === "hello");
+      expect(hello?.state).toBe<WirePluginState>("disabled");
+    } finally {
+      reloaded.shutdown();
+    }
+  });
+
+  it("plugin.stateChanged fires for subscribed connections but not unsubscribed peers", async () => {
+    const harness = await buildHarness(["hello"]);
+    try {
+      // Two distinct peers — one subscribes, one doesn't.
+      const subSock = new FakeWebSocket();
+      const subCtx = makeContext(harness.state, subSock);
+      const unsubSock = new FakeWebSocket();
+      makeContext(harness.state, unsubSock); // registers as subscriber but never calls plugin.subscribe
+      await call<{ ok: true }>(subCtx, "plugin.subscribe", {});
+
+      // Trigger a state transition. Wait for the plugin to be running
+      // first so the disable transition is meaningful.
+      await waitFor(
+        () => (harness.host.get("hello")?.state === "active" ? true : undefined),
+        2000,
+      );
+      subSock.sent = []; // any pre-subscribe pushes don't count
+      unsubSock.sent = [];
+      await call<{ ok: true }>(subCtx, "plugin.disable", { id: "hello" });
+      // Disable goes through SIGTERM → exit; the wire-state goes from
+      // "running" to "disabled" in a single setState call (the exit
+      // handler is a no-op because state is already disabled), so the
+      // subscriber should see exactly one frame.
+      const subscribed = subSock.notifications("plugin.stateChanged");
+      expect(subscribed.length).toBeGreaterThanOrEqual(1);
+      const last = subscribed[subscribed.length - 1];
+      expect((last.params as { id: string; state: string }).id).toBe("hello");
+      expect((last.params as { id: string; state: string }).state).toBe(
+        "disabled",
+      );
+      // The unsubscribed peer must have received nothing.
+      expect(unsubSock.notifications("plugin.stateChanged")).toEqual([]);
+    } finally {
+      harness.host.shutdown();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #58. Exposes `plugin.list / enable / disable / invokeCommand` to the Flutter client over the existing JSON-RPC WebSocket, plus a `plugin.stateChanged` push frame filtered to peers that opt in via `plugin.subscribe`.

- Backend: enabled/disabled state persists to `~/.local/state/openvsmobile-next/plugin-state.json` (overridable via env). `disable()` runs SIGTERM → grace → SIGKILL with a tunable grace window. `invokeCommand` routes a new host→plugin `command.invoke` request through the existing JSON-RPC stdio channel, with pending-id tracking + timeout. `onCommand:<id>` triggers activation when the plugin is stopped and lists that event.
- Wire vocabulary collapses the internal `registered / errored` states to `stopped / crashed` per the issue spec; `crashReason` carries the manifest / spawn / exit detail.
- `plugin.install / uninstall` are intentionally **absent** per the settled decision in `CLAUDE.md` (plugin install is filesystem-only). `next/README.md` calls this out explicitly.
- Tests cover the acceptance bullets: enable→spawn→list, disable→SIGTERM honored, invokeCommand round-trip, on-demand activation, persistence across host restart, and stateChanged subscription filtering.

## Test plan

- [x] `cd next/backend && pnpm typecheck`
- [x] `cd next/backend && pnpm test` (113 pass, 6 new in `pluginRpc.test.ts`)
- [x] `cd next/app && flutter analyze` (only pre-existing unrelated info in `system_tray.dart`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)