### PR TITLE
feat(app): Plugins tab — list, toggle, detail (#60)

### DIFF
--- a/next/app/lib/app_state.dart
+++ b/next/app/lib/app_state.dart
@@ -20,8 +20,10 @@ import 'models.dart';
 import 'notification.dart';
 import 'services/ssh_bootstrap.dart';
 import 'state/notifications_model.dart';
+import 'state/plugins_model.dart';
 import 'state/terminals_notifier.dart';
 import 'state/workspace_model.dart';
+import 'ui/ui_panels_model.dart';
 
 class AppState extends ChangeNotifier {
   final BackendClient client;
@@ -32,6 +34,8 @@ class AppState extends ChangeNotifier {
   late final TerminalsNotifier _terminals;
   late final WorkspacesModel _workspacesModel;
   late final NotificationsModel _notifications;
+  late final PluginsModel _plugins;
+  late final UiPanelsModel _uiPanels;
   StreamSubscription<BackendNotification>? _notifSub;
 
   /// Whether the Files tab should filter to the Changes view (decorated
@@ -85,6 +89,10 @@ class AppState extends ChangeNotifier {
       reportError: _reportOperationError,
     );
     _notifications.addListener(notifyListeners);
+    _plugins = PluginsModel(client: client);
+    _plugins.addListener(notifyListeners);
+    _uiPanels = UiPanelsModel(client: client);
+    _uiPanels.addListener(notifyListeners);
     client.state.addListener(_onConnState);
     client.lastError.addListener(_onConnError);
     _notifSub = client.notifications.listen(_onNotification);
@@ -139,6 +147,15 @@ class AppState extends ChangeNotifier {
   /// Notification surface (design §4.5). Composed under AppState so the bell
   /// icon, badge count, and notification center read from a single source.
   NotificationsModel get notifications => _notifications;
+
+  /// Plugin registry (design §3 / issue C4). Backs the Plugins tab —
+  /// AppState forwards notifyListeners so widgets only listen here.
+  PluginsModel get plugins => _plugins;
+
+  /// Plugin-owned UI panels (design §4.3 / issue C3). The Plugins-tab
+  /// detail view subscribes via `subscribe()` once on connect and
+  /// renders snapshots through `UiRenderer`.
+  UiPanelsModel get uiPanels => _uiPanels;
 
   /// Per-workspace state lookup. Returns null if the workspace hasn't been
   /// subscribed yet (e.g. between activate and the first event).
@@ -195,6 +212,10 @@ class AppState extends ChangeNotifier {
       // reconnect (first principle #4: disconnect never clears the UI).
       unawaited(_notifications.subscribe());
       unawaited(_notifications.refresh());
+      // Plugin surface + UI-descriptor fan-out follow the same shape —
+      // subscribe on every successful connect; failures self-log.
+      unawaited(_plugins.subscribeAndRefresh());
+      unawaited(_uiPanels.subscribe());
       notifyListeners();
       return;
     }
@@ -280,6 +301,9 @@ class AppState extends ChangeNotifier {
         if (oldId is String && newId is String) {
           _notifications.onSuperseded(oldId, newId);
         }
+        break;
+      case BackendNotifications.pluginStateChanged:
+        _plugins.onStateChanged(n.params as Map<String, dynamic>);
         break;
       default:
         // Ignore unknown notifications (forward-compat).
@@ -728,6 +752,10 @@ class AppState extends ChangeNotifier {
     _workspacesModel.dispose();
     _notifications.removeListener(notifyListeners);
     _notifications.dispose();
+    _plugins.removeListener(notifyListeners);
+    _plugins.dispose();
+    _uiPanels.removeListener(notifyListeners);
+    _uiPanels.dispose();
     _notifSub?.cancel();
     super.dispose();
   }

--- a/next/app/lib/backend_client.dart
+++ b/next/app/lib/backend_client.dart
@@ -46,6 +46,7 @@ class BackendNotifications {
   static const String notificationReadChanged = 'notification.readChanged';
   static const String notificationDeleted = 'notification.deleted';
   static const String notificationSuperseded = 'notification.superseded';
+  static const String pluginStateChanged = 'plugin.stateChanged';
 }
 
 /// Permanent-error JSON-RPC code returned by the backend on a failed

--- a/next/app/lib/screens/home_shell.dart
+++ b/next/app/lib/screens/home_shell.dart
@@ -13,6 +13,7 @@ import '../settings_store.dart';
 import 'files_tab.dart';
 import 'more_tab.dart';
 import 'notification_center.dart';
+import 'plugins_tab.dart';
 import 'terminal_tab.dart';
 import 'workspace_picker.dart';
 
@@ -173,6 +174,7 @@ class _HomeShellState extends State<HomeShell> {
               children: [
                 FilesTab(appState: widget.appState),
                 TerminalTab(appState: widget.appState),
+                PluginsTab(appState: widget.appState),
                 MoreTab(
                   appState: widget.appState,
                   settingsStore: widget.settingsStore,
@@ -199,6 +201,11 @@ class _HomeShellState extends State<HomeShell> {
             icon: Icon(Icons.terminal_outlined),
             selectedIcon: Icon(Icons.terminal),
             label: 'Terminal',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.extension_outlined),
+            selectedIcon: Icon(Icons.extension),
+            label: 'Plugins',
           ),
           NavigationDestination(
             icon: Icon(Icons.more_horiz_outlined),

--- a/next/app/lib/screens/plugins_tab.dart
+++ b/next/app/lib/screens/plugins_tab.dart
@@ -1,0 +1,588 @@
+// Plugins tab (design §3 / issue C4).
+//
+// Two screens behind a single tab slot:
+//
+//   * `PluginsTab` — list view of installed plugins. Tap a row to drill
+//     into the detail view.
+//   * `PluginDetailScreen` — header bar + body. Body renders the
+//     plugin's panels through the shared `UiRenderer` from C3. Multiple
+//     panels become a `TabBar`. A `crashed` plugin renders a banner
+//     + Reload button instead.
+//
+// State sourcing: AppState owns the PluginsModel + UiPanelsModel; this
+// screen only listens. Per CLAUDE.md first principle #1, the backend is
+// the source of truth — we never optimistically mutate `_byId`. Toggle
+// switches call `plugin.enable` / `plugin.disable` and rely on the
+// matching `plugin.stateChanged` push to flip the wire-state.
+
+import 'package:flutter/material.dart';
+
+import '../app_state.dart';
+import '../state/plugins_model.dart';
+import '../ui/ui_node.dart';
+import '../ui/ui_renderer.dart';
+
+const String _kFilesystemPluginsDir =
+    '~/.local/share/openvsmobile-next/plugins/';
+
+class PluginsTab extends StatelessWidget {
+  final AppState appState;
+  const PluginsTab({super.key, required this.appState});
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: appState,
+      builder: (context, _) {
+        final model = appState.plugins;
+        final plugins = model.plugins;
+        if (plugins.isEmpty) {
+          return _PluginsEmptyState(loaded: model.isLoaded);
+        }
+        return ListView.separated(
+          itemCount: plugins.length,
+          separatorBuilder: (context, index) => const Divider(height: 1),
+          itemBuilder: (context, i) {
+            final p = plugins[i];
+            return _PluginListTile(
+              info: p,
+              onTap: () => _openDetail(context, p),
+              onToggle: (enabled) => _onToggle(context, p, enabled),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _onToggle(
+    BuildContext context, PluginInfo info, bool enabled) async {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    try {
+      if (enabled) {
+        await appState.plugins.enable(info.id);
+      } else {
+        await appState.plugins.disable(info.id);
+      }
+    } catch (e) {
+      messenger?.showSnackBar(
+        SnackBar(content: Text('Failed to ${enabled ? "enable" : "disable"} ${info.name}: $e')),
+      );
+    }
+  }
+
+  void _openDetail(BuildContext context, PluginInfo info) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => PluginDetailScreen(appState: appState, pluginId: info.id),
+      ),
+    );
+  }
+}
+
+class _PluginListTile extends StatelessWidget {
+  final PluginInfo info;
+  final VoidCallback onTap;
+  final ValueChanged<bool> onToggle;
+  const _PluginListTile({
+    required this.info,
+    required this.onTap,
+    required this.onToggle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDisabled = info.state == PluginWireState.disabled;
+    final titleStyle = theme.textTheme.titleMedium?.copyWith(
+      fontWeight: FontWeight.bold,
+      decoration: isDisabled ? TextDecoration.lineThrough : null,
+      color: isDisabled ? theme.disabledColor : null,
+    );
+    return ListTile(
+      key: ValueKey<String>('plugin-row:${info.id}'),
+      onTap: onTap,
+      title: Row(
+        children: [
+          Expanded(
+            child: Text(
+              info.name,
+              style: titleStyle,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            info.version,
+            style: theme.textTheme.bodySmall?.copyWith(color: theme.hintColor),
+          ),
+        ],
+      ),
+      subtitle: PluginStateBadge(state: info.state, reason: info.crashReason),
+      trailing: Switch(
+        key: ValueKey<String>('plugin-toggle:${info.id}'),
+        value: info.state != PluginWireState.disabled,
+        onChanged: onToggle,
+      ),
+    );
+  }
+}
+
+class PluginStateBadge extends StatelessWidget {
+  final PluginWireState state;
+  final String? reason;
+  const PluginStateBadge({super.key, required this.state, this.reason});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (label, color) = switch (state) {
+      PluginWireState.running => ('running', Colors.green),
+      PluginWireState.stopped => ('stopped', theme.disabledColor),
+      PluginWireState.crashed => ('crashed', theme.colorScheme.error),
+      PluginWireState.disabled => ('disabled', theme.disabledColor),
+      PluginWireState.unknown => ('unknown', theme.disabledColor),
+    };
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          key: ValueKey<String>('plugin-state-dot:$label'),
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 6),
+        Text(label, style: theme.textTheme.bodySmall),
+        if (state == PluginWireState.crashed &&
+            reason != null && reason!.isNotEmpty) ...[
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              reason!,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall?.copyWith(color: color),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _PluginsEmptyState extends StatelessWidget {
+  final bool loaded;
+  const _PluginsEmptyState({required this.loaded});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Icon(Icons.extension_outlined, size: 48, color: theme.hintColor),
+            const SizedBox(height: 12),
+            Text(
+              loaded ? 'No plugins installed' : 'Loading plugins…',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Drop a plugin directory under $_kFilesystemPluginsDir on the '
+              'backend host. Workbench will pick it up on the next backend '
+              'restart.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(color: theme.hintColor),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---- Detail view ----
+
+class PluginDetailScreen extends StatelessWidget {
+  final AppState appState;
+  final String pluginId;
+  const PluginDetailScreen({
+    super.key,
+    required this.appState,
+    required this.pluginId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: appState,
+      builder: (context, _) {
+        final info = appState.plugins.plugin(pluginId);
+        if (info == null) {
+          return Scaffold(
+            appBar: AppBar(title: Text(pluginId)),
+            body: const Center(child: Text('Plugin not found')),
+          );
+        }
+        return PluginDetailView(appState: appState, info: info);
+      },
+    );
+  }
+}
+
+/// Inner detail view exposed for widget tests so they can mount it
+/// without pushing through Navigator. Production code goes through
+/// `PluginDetailScreen` which adapts to live state changes.
+class PluginDetailView extends StatelessWidget {
+  final AppState appState;
+  final PluginInfo info;
+  const PluginDetailView({
+    super.key,
+    required this.appState,
+    required this.info,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(info.name),
+        actions: [
+          _PluginKebabMenu(appState: appState, info: info),
+        ],
+      ),
+      body: _DetailBody(appState: appState, info: info),
+    );
+  }
+}
+
+class _PluginKebabMenu extends StatelessWidget {
+  final AppState appState;
+  final PluginInfo info;
+  const _PluginKebabMenu({required this.appState, required this.info});
+
+  void _showLogPath(BuildContext context) {
+    // The host writes stderr logs to
+    // ~/.local/state/openvsmobile-next/plugins/<id>.stderr.log
+    // (see host.ts). No in-app viewer in v0 — settled decision; we
+    // surface the path so the user knows where to tail.
+    final path =
+        '~/.local/state/openvsmobile-next/plugins/${info.id}.stderr.log';
+    ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+      SnackBar(content: Text('Plugin log: $path')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = info.state != PluginWireState.disabled;
+    return PopupMenuButton<String>(
+      key: const ValueKey<String>('plugin-kebab'),
+      itemBuilder: (_) => [
+        PopupMenuItem<String>(
+          value: enabled ? 'disable' : 'enable',
+          child: Text(enabled ? 'Disable' : 'Enable'),
+        ),
+        const PopupMenuItem<String>(
+          value: 'log',
+          child: Text('View stderr log location'),
+        ),
+      ],
+      onSelected: (v) async {
+        switch (v) {
+          case 'disable':
+            await _safeCall(context, () => appState.plugins.disable(info.id),
+                label: 'Disable ${info.name}');
+            break;
+          case 'enable':
+            await _safeCall(context, () => appState.plugins.enable(info.id),
+                label: 'Enable ${info.name}');
+            break;
+          case 'log':
+            _showLogPath(context);
+            break;
+        }
+      },
+    );
+  }
+}
+
+Future<void> _safeCall(
+  BuildContext context,
+  Future<void> Function() op, {
+  required String label,
+}) async {
+  final messenger = ScaffoldMessenger.maybeOf(context);
+  try {
+    await op();
+  } catch (e) {
+    messenger?.showSnackBar(SnackBar(content: Text('$label failed: $e')));
+  }
+}
+
+class _DetailBody extends StatelessWidget {
+  final AppState appState;
+  final PluginInfo info;
+  const _DetailBody({required this.appState, required this.info});
+
+  @override
+  Widget build(BuildContext context) {
+    if (info.state == PluginWireState.crashed) {
+      return _CrashedBanner(appState: appState, info: info);
+    }
+    if (info.state == PluginWireState.disabled) {
+      return _DisabledHint(appState: appState, info: info);
+    }
+    final panels = info.panels;
+    if (panels.isEmpty) {
+      return _NoPanelsHint(info: info);
+    }
+    if (panels.length == 1) {
+      return _PanelRenderer(
+        appState: appState,
+        pluginId: info.id,
+        panel: panels.single,
+      );
+    }
+    return DefaultTabController(
+      length: panels.length,
+      child: Column(
+        children: [
+          TabBar(
+            isScrollable: true,
+            tabs: [
+              for (final p in panels) Tab(text: p.title),
+            ],
+          ),
+          Expanded(
+            child: TabBarView(
+              children: [
+                for (final p in panels)
+                  _PanelRenderer(
+                    appState: appState,
+                    pluginId: info.id,
+                    panel: p,
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PanelRenderer extends StatelessWidget {
+  final AppState appState;
+  final String pluginId;
+  final PluginPanelStub panel;
+  const _PanelRenderer({
+    required this.appState,
+    required this.pluginId,
+    required this.panel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final snapshot = appState.uiPanels.snapshotFor(pluginId, panel.id);
+    final tree = snapshot?.tree;
+    if (tree == null) {
+      return _PanelEmpty(title: panel.title);
+    }
+    return SingleChildScrollView(
+      key: ValueKey<String>('plugin-panel:$pluginId/${panel.id}'),
+      padding: const EdgeInsets.all(12),
+      child: UiRenderer(
+        tree: tree,
+        onEvent: (event) => _dispatch(panel.id, event),
+      ),
+    );
+  }
+
+  void _dispatch(String panelId, UiNodeEvent event) {
+    appState.uiPanels.dispatchEvent(
+      pluginId: pluginId,
+      panelId: panelId,
+      event: event,
+    );
+  }
+}
+
+class _PanelEmpty extends StatelessWidget {
+  final String title;
+  const _PanelEmpty({required this.title});
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.hourglass_empty_outlined,
+                size: 36, color: Theme.of(context).hintColor),
+            const SizedBox(height: 8),
+            Text(
+              'Waiting for "$title" content from the plugin…',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NoPanelsHint extends StatelessWidget {
+  final PluginInfo info;
+  const _NoPanelsHint({required this.info});
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            PluginStateBadge(state: info.state),
+            const SizedBox(height: 12),
+            Text(
+              '"${info.name}" does not contribute any panels.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'It may still respond to commands; the Plugins tab only '
+              'renders panels.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.hintColor,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DisabledHint extends StatelessWidget {
+  final AppState appState;
+  final PluginInfo info;
+  const _DisabledHint({required this.appState, required this.info});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            PluginStateBadge(state: info.state),
+            const SizedBox(height: 12),
+            Text(
+              '"${info.name}" is disabled.',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            FilledButton(
+              onPressed: () => _safeCall(
+                context,
+                () => appState.plugins.enable(info.id),
+                label: 'Enable ${info.name}',
+              ),
+              child: const Text('Enable'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CrashedBanner extends StatelessWidget {
+  final AppState appState;
+  final PluginInfo info;
+  const _CrashedBanner({required this.appState, required this.info});
+
+  void _showLog(BuildContext context) {
+    final path =
+        '~/.local/state/openvsmobile-next/plugins/${info.id}.stderr.log';
+    ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+      SnackBar(content: Text('Plugin log: $path')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Container(
+            key: const ValueKey<String>('plugin-crashed-banner'),
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.errorContainer,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Plugin crashed: ${info.crashReason ?? "unknown reason"}',
+                  style: TextStyle(
+                    color: theme.colorScheme.onErrorContainer,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'There is no automatic restart. Inspect the log to see '
+                  'why this plugin exited, then tap Reload once you have '
+                  'a fix in place.',
+                  style: TextStyle(
+                    color: theme.colorScheme.onErrorContainer,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextButton(
+                      key: const ValueKey<String>('plugin-view-log'),
+                      onPressed: () => _showLog(context),
+                      child: const Text('View log'),
+                    ),
+                    const SizedBox(width: 8),
+                    FilledButton(
+                      key: const ValueKey<String>('plugin-reload'),
+                      onPressed: () => _safeCall(
+                        context,
+                        () => appState.plugins.reload(info.id),
+                        label: 'Reload ${info.name}',
+                      ),
+                      child: const Text('Reload'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/next/app/lib/state/plugins_model.dart
+++ b/next/app/lib/state/plugins_model.dart
@@ -1,0 +1,283 @@
+// Plugin surface (design §3) — client mirror.
+//
+// Owns the list of installed plugins as the backend reports them and keeps
+// it live against `plugin.stateChanged` pushes (CLAUDE.md first principle
+// #1: backend is the source of truth). Composed under AppState; AppState
+// forwards `notifyListeners` so widgets only need to listen to AppState to
+// see plugin-list changes.
+//
+// Toggling a plugin is a thin call into `plugin.enable` / `plugin.disable`.
+// We do NOT optimistically flip local state — the wire-state push from the
+// backend is the only source that mutates `_byId`. That keeps the model
+// honest in two-client and reconnect scenarios.
+
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+import '../backend_client.dart';
+
+/// Wire-state vocabulary mirrored from `next/backend/src/plugins/host.ts`.
+/// Anything the backend sends that doesn't match these falls back to
+/// `unknown` so a forward-compatible newer backend can't crash older
+/// clients.
+enum PluginWireState { running, stopped, crashed, disabled, unknown }
+
+PluginWireState pluginWireStateFromString(String? raw) {
+  switch (raw) {
+    case 'running':
+      return PluginWireState.running;
+    case 'stopped':
+      return PluginWireState.stopped;
+    case 'crashed':
+      return PluginWireState.crashed;
+    case 'disabled':
+      return PluginWireState.disabled;
+    default:
+      return PluginWireState.unknown;
+  }
+}
+
+@immutable
+class PluginCommandStub {
+  final String id;
+  final String title;
+  const PluginCommandStub({required this.id, required this.title});
+}
+
+/// Mirror of the backend's `PluginInfo` shape returned by `plugin.list`.
+/// `contributes` lists the panels we should render; we read them out of
+/// the `contributes.panels` key when present, otherwise treat the plugin
+/// as having no panel. C4 surface — the keys come from the manifest's
+/// `contributes` map; v0 looks for `panels: [{ id, title }]` and falls
+/// back to "no panels".
+@immutable
+class PluginInfo {
+  final String id;
+  final String name;
+  final String version;
+  final PluginWireState state;
+  final String? crashReason;
+  final List<PluginPanelStub> panels;
+  final List<PluginCommandStub> commands;
+
+  const PluginInfo({
+    required this.id,
+    required this.name,
+    required this.version,
+    required this.state,
+    required this.crashReason,
+    required this.panels,
+    required this.commands,
+  });
+
+  factory PluginInfo.fromJson(Map<String, dynamic> json) {
+    final contributes = json['contributes'];
+    final panels = <PluginPanelStub>[];
+    final commands = <PluginCommandStub>[];
+    if (contributes is Map<String, dynamic>) {
+      final rawPanels = contributes['panels'];
+      if (rawPanels is List) {
+        for (final raw in rawPanels) {
+          if (raw is! Map<String, dynamic>) continue;
+          final pid = raw['id'];
+          final title = raw['title'];
+          if (pid is! String || pid.isEmpty) continue;
+          panels.add(PluginPanelStub(
+            id: pid,
+            title: title is String && title.isNotEmpty ? title : pid,
+          ));
+        }
+      }
+      final rawCommands = contributes['commands'];
+      if (rawCommands is List) {
+        for (final raw in rawCommands) {
+          if (raw is! Map<String, dynamic>) continue;
+          final cid = raw['id'];
+          final ctitle = raw['title'];
+          if (cid is! String || cid.isEmpty) continue;
+          commands.add(PluginCommandStub(
+            id: cid,
+            title: ctitle is String && ctitle.isNotEmpty ? ctitle : cid,
+          ));
+        }
+      }
+    }
+    return PluginInfo(
+      id: (json['id'] as String?) ?? '',
+      name: (json['name'] as String?) ?? ((json['id'] as String?) ?? ''),
+      version: (json['version'] as String?) ?? '',
+      state: pluginWireStateFromString(json['state'] as String?),
+      crashReason: json['crashReason'] as String?,
+      panels: panels,
+      commands: commands,
+    );
+  }
+
+  PluginInfo copyWith({
+    PluginWireState? state,
+    String? crashReason,
+    bool clearCrashReason = false,
+  }) {
+    return PluginInfo(
+      id: id,
+      name: name,
+      version: version,
+      state: state ?? this.state,
+      crashReason:
+          clearCrashReason ? null : (crashReason ?? this.crashReason),
+      panels: panels,
+      commands: commands,
+    );
+  }
+}
+
+@immutable
+class PluginPanelStub {
+  final String id;
+  final String title;
+  const PluginPanelStub({required this.id, required this.title});
+}
+
+class PluginsModel extends ChangeNotifier {
+  final BackendClient _client;
+
+  /// id → info. Insertion order from the most recent `plugin.list` is
+  /// preserved by `LinkedHashMap`; widgets read [plugins] which projects
+  /// that order.
+  final LinkedHashMap<String, PluginInfo> _byId = LinkedHashMap();
+  bool _subscribed = false;
+  bool _loaded = false;
+
+  /// Test seam: when set, every wire call routes here instead of the
+  /// real backend client. Widget tests use this to record + assert call
+  /// order without a live socket. Production code leaves it `null`.
+  @visibleForTesting
+  Future<Map<String, dynamic>?> Function(
+    String method,
+    Map<String, dynamic>? params,
+  )? debugRpcOverride;
+
+  PluginsModel({required BackendClient client}) : _client = client;
+
+  Future<dynamic> _call(String method, [Map<String, dynamic>? params]) {
+    final ovr = debugRpcOverride;
+    if (ovr != null) return ovr(method, params);
+    return _client.call(method, params);
+  }
+
+  /// Read-only list of installed plugins, in the order the backend
+  /// returned them. Re-projected on every getter call — the list is tiny
+  /// (< 10) and the cost is negligible.
+  List<PluginInfo> get plugins => List.unmodifiable(_byId.values);
+
+  PluginInfo? plugin(String id) => _byId[id];
+
+  bool get isSubscribed => _subscribed;
+  bool get isLoaded => _loaded;
+
+  /// Pull the current list AND subscribe to push updates. Idempotent —
+  /// safe to call after every reconnect. Failures self-log; the
+  /// connection banner is the user-visible signal for any link issue.
+  Future<void> subscribeAndRefresh() async {
+    try {
+      await _call('plugin.subscribe');
+      _subscribed = true;
+    } catch (e) {
+      debugPrint('plugin.subscribe failed: $e');
+    }
+    await refresh();
+  }
+
+  Future<void> refresh() async {
+    try {
+      final res = await _call('plugin.list');
+      if (res is! Map<String, dynamic>) return;
+      final raw = res['plugins'];
+      if (raw is! List) return;
+      _byId.clear();
+      for (final entry in raw) {
+        if (entry is! Map<String, dynamic>) continue;
+        final info = PluginInfo.fromJson(entry);
+        if (info.id.isEmpty) continue;
+        _byId[info.id] = info;
+      }
+      _loaded = true;
+      notifyListeners();
+    } catch (e) {
+      debugPrint('plugin.list failed: $e');
+    }
+  }
+
+  /// Test seam: load a fixture list directly without touching the wire.
+  /// Used by widget tests to exercise the screens against a known mix
+  /// of states.
+  @visibleForTesting
+  void debugSeed(List<PluginInfo> seed) {
+    _byId.clear();
+    for (final p in seed) {
+      _byId[p.id] = p;
+    }
+    _loaded = true;
+    notifyListeners();
+  }
+
+  /// Test seam: feed a `plugin.stateChanged` push directly. Production
+  /// reaches this method through `AppState._onNotification`.
+  @visibleForTesting
+  void debugApplyStateChange(Map<String, dynamic> params) {
+    _applyStateChange(params);
+  }
+
+  /// Apply a `plugin.stateChanged` push to local state. Returns true if
+  /// it mutated `_byId`, false if the event was for an unknown plugin
+  /// (which can happen briefly after install before we've refreshed).
+  bool onStateChanged(Map<String, dynamic> params) {
+    return _applyStateChange(params);
+  }
+
+  bool _applyStateChange(Map<String, dynamic> params) {
+    final id = params['id'];
+    final stateStr = params['state'];
+    if (id is! String || stateStr is! String) return false;
+    final existing = _byId[id];
+    if (existing == null) {
+      // Backend reported state for a plugin we don't have in our list
+      // yet. Trigger a refresh so the row appears with its full
+      // metadata; the next push for the same id will then mutate the
+      // entry in place. Skip the optimistic insert — without the
+      // manifest fields we can't render a usable row anyway.
+      unawaited(refresh());
+      return false;
+    }
+    final next = existing.copyWith(
+      state: pluginWireStateFromString(stateStr),
+      crashReason: params['crashReason'] as String?,
+      clearCrashReason: params['crashReason'] == null,
+    );
+    _byId[id] = next;
+    notifyListeners();
+    return true;
+  }
+
+  /// Enable a plugin. Backend pushes `plugin.stateChanged` on success;
+  /// we don't optimistically flip local state. Returns the future from
+  /// the RPC so callers can show inline progress.
+  Future<void> enable(String pluginId) async {
+    await _call('plugin.enable', <String, dynamic>{'id': pluginId});
+  }
+
+  /// Disable a plugin. Same fire-and-await pattern as [enable].
+  Future<void> disable(String pluginId) async {
+    await _call('plugin.disable', <String, dynamic>{'id': pluginId});
+  }
+
+  /// Reload a crashed plugin: disable then enable. The interleaving of
+  /// state pushes is fine — the model only mutates on the wire state,
+  /// and the final `running` push after `enable` wins.
+  Future<void> reload(String pluginId) async {
+    await disable(pluginId);
+    await enable(pluginId);
+  }
+}

--- a/next/app/test/plugins_tab_widget_test.dart
+++ b/next/app/test/plugins_tab_widget_test.dart
@@ -1,0 +1,313 @@
+// Widget tests for the Plugins-tab surface (issue #60 / C4).
+//
+// Coverage matches the issue's acceptance criteria:
+//
+//   * List view renders three plugins of different states with the right
+//     badge label + a working Switch reflecting enabled-ness.
+//   * Tapping a row pushes the detail view; the detail view of a plugin
+//     that contributes one panel mounts the `UiRenderer` content
+//     (drawn from a panel snapshot the test seeds directly).
+//   * A `plugin.stateChanged` push flips the badge from `running` to
+//     `crashed` and surfaces the reason text.
+//   * The detail view of a `crashed` plugin shows the banner; tapping
+//     Reload invokes `plugin.disable` then `plugin.enable` in order.
+//
+// The tests do not mock the BackendClient WebSocket: every RPC issued by
+// the screens (`enable`, `disable`, …) routes through `BackendClient.call`,
+// which returns a failed future when no socket is configured. We instead
+// install a stub via the new `pluginRpcStub` test seam on PluginsModel so
+// we can record + assert the call order.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mobilecode/app_state.dart';
+import 'package:mobilecode/backend_client.dart';
+import 'package:mobilecode/screens/plugins_tab.dart';
+import 'package:mobilecode/state/plugins_model.dart';
+
+PluginInfo _info({
+  required String id,
+  String? name,
+  String version = '1.0.0',
+  PluginWireState state = PluginWireState.running,
+  String? crashReason,
+  List<PluginPanelStub> panels = const [],
+}) =>
+    PluginInfo(
+      id: id,
+      name: name ?? id,
+      version: version,
+      state: state,
+      crashReason: crashReason,
+      panels: panels,
+      commands: const [],
+    );
+
+Future<AppState> _appStateWithSeed(List<PluginInfo> seed) async {
+  final state = AppState(client: BackendClient());
+  state.plugins.debugSeed(seed);
+  return state;
+}
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  testWidgets('list renders three plugins with correct badges + switches',
+      (tester) async {
+    final appState = await _appStateWithSeed([
+      _info(id: 'alpha', state: PluginWireState.running),
+      _info(id: 'beta', state: PluginWireState.crashed, crashReason: 'boom'),
+      _info(id: 'gamma', state: PluginWireState.disabled),
+    ]);
+    addTearDown(appState.dispose);
+    await tester.pumpWidget(_wrap(PluginsTab(appState: appState)));
+    await tester.pump();
+
+    expect(find.text('alpha'), findsOneWidget);
+    expect(find.text('beta'), findsOneWidget);
+    expect(find.text('gamma'), findsOneWidget);
+
+    // Badge labels — these must match the wire-state label exactly.
+    expect(find.text('running'), findsOneWidget);
+    expect(find.text('crashed'), findsOneWidget);
+    expect(find.text('disabled'), findsOneWidget);
+    // Crashed reason is rendered next to the badge.
+    expect(find.text('boom'), findsOneWidget);
+
+    // Switch states. PluginWireState.disabled → off; everything else
+    // (including crashed) → on, because the toggle drives
+    // enabled-vs-disabled, not running-vs-stopped.
+    final alphaSwitch = tester
+        .widget<Switch>(find.byKey(const ValueKey<String>('plugin-toggle:alpha')));
+    final betaSwitch = tester
+        .widget<Switch>(find.byKey(const ValueKey<String>('plugin-toggle:beta')));
+    final gammaSwitch = tester
+        .widget<Switch>(find.byKey(const ValueKey<String>('plugin-toggle:gamma')));
+    expect(alphaSwitch.value, isTrue);
+    expect(betaSwitch.value, isTrue);
+    expect(gammaSwitch.value, isFalse);
+  });
+
+  testWidgets('tap row → detail view with single panel renders UiRenderer',
+      (tester) async {
+    final appState = await _appStateWithSeed([
+      _info(
+        id: 'panelplug',
+        state: PluginWireState.running,
+        panels: const [PluginPanelStub(id: 'main', title: 'Main')],
+      ),
+    ]);
+    addTearDown(appState.dispose);
+
+    // Seed a tree for that panel directly into UiPanelsModel via the
+    // existing test seam.
+    appState.uiPanels.debugInjectPush(<String, dynamic>{
+      'pluginId': 'panelplug',
+      'panelId': 'main',
+      'version': 1,
+      'tree': <String, dynamic>{
+        'kind': 'Column',
+        'id': 'root',
+        'children': <Map<String, dynamic>>[
+          <String, dynamic>{
+            'kind': 'Text',
+            'id': 'hello',
+            'text': 'hello from plugin',
+          },
+        ],
+      },
+    });
+
+    // Use MaterialApp with home: PluginsTab so the tap pushes onto a
+    // real Navigator.
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: PluginsTab(appState: appState)),
+    ));
+    await tester.pump();
+
+    await tester.tap(find.text('panelplug'));
+    await tester.pumpAndSettle();
+
+    // App bar title from the detail screen.
+    expect(find.widgetWithText(AppBar, 'panelplug'), findsOneWidget);
+    // The text that came from the seeded UiRenderer tree.
+    expect(find.text('hello from plugin'), findsOneWidget);
+  });
+
+  testWidgets('plugin.stateChanged push flips badge from running to crashed',
+      (tester) async {
+    final appState = await _appStateWithSeed([
+      _info(id: 'alpha', state: PluginWireState.running),
+    ]);
+    addTearDown(appState.dispose);
+    await tester.pumpWidget(_wrap(PluginsTab(appState: appState)));
+    await tester.pump();
+
+    expect(find.text('running'), findsOneWidget);
+    expect(find.text('crashed'), findsNothing);
+
+    appState.plugins.debugApplyStateChange(<String, dynamic>{
+      'id': 'alpha',
+      'state': 'crashed',
+      'crashReason': 'segfault',
+    });
+    await tester.pump();
+
+    expect(find.text('running'), findsNothing);
+    expect(find.text('crashed'), findsOneWidget);
+    expect(find.text('segfault'), findsOneWidget);
+  });
+
+  testWidgets('crashed detail shows banner; Reload calls disable then enable',
+      (tester) async {
+    final appState = await _appStateWithSeed([
+      _info(
+        id: 'crashy',
+        state: PluginWireState.crashed,
+        crashReason: 'panic',
+      ),
+    ]);
+    addTearDown(appState.dispose);
+
+    final calls = <String>[];
+    appState.plugins.debugRpcOverride = (method, params) async {
+      calls.add('$method:${params?['id'] ?? ''}');
+      // Simulate the backend's state-change push that would normally
+      // arrive after the wire call resolves. The model's reload()
+      // awaits each sub-call so the order is "disable RPC → push →
+      // enable RPC → push".
+      if (method == 'plugin.disable') {
+        appState.plugins.debugApplyStateChange(<String, dynamic>{
+          'id': 'crashy',
+          'state': 'disabled',
+        });
+      } else if (method == 'plugin.enable') {
+        appState.plugins.debugApplyStateChange(<String, dynamic>{
+          'id': 'crashy',
+          'state': 'running',
+        });
+      }
+      return <String, dynamic>{'ok': true};
+    };
+
+    final info = appState.plugins.plugin('crashy')!;
+    await tester.pumpWidget(_wrap(
+      PluginDetailView(appState: appState, info: info),
+    ));
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey<String>('plugin-crashed-banner')),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Plugin crashed'), findsOneWidget);
+    expect(find.textContaining('panic'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey<String>('plugin-reload')));
+    await tester.pumpAndSettle();
+
+    // Disable must come first, enable second.
+    expect(calls, ['plugin.disable:crashy', 'plugin.enable:crashy']);
+  });
+
+  testWidgets('empty state hints at the filesystem install path',
+      (tester) async {
+    final appState = await _appStateWithSeed(const []);
+    addTearDown(appState.dispose);
+    await tester.pumpWidget(_wrap(PluginsTab(appState: appState)));
+    await tester.pump();
+
+    expect(find.text('No plugins installed'), findsOneWidget);
+    expect(
+      find.textContaining('~/.local/share/openvsmobile-next/plugins/'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('toggling the switch routes through plugin.disable',
+      (tester) async {
+    final appState = await _appStateWithSeed([
+      _info(id: 'alpha', state: PluginWireState.running),
+    ]);
+    addTearDown(appState.dispose);
+    final calls = <String>[];
+    appState.plugins.debugRpcOverride = (method, params) async {
+      calls.add('$method:${params?['id'] ?? ''}');
+      return <String, dynamic>{'ok': true};
+    };
+
+    await tester.pumpWidget(_wrap(PluginsTab(appState: appState)));
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey<String>('plugin-toggle:alpha')));
+    await tester.pumpAndSettle();
+    expect(calls, ['plugin.disable:alpha']);
+  });
+
+  test('PluginInfo.fromJson reads contributes.panels + commands', () {
+    final info = PluginInfo.fromJson(<String, dynamic>{
+      'id': 'p',
+      'name': 'P',
+      'version': '0.0.1',
+      'state': 'running',
+      'contributes': <String, dynamic>{
+        'commands': <Map<String, dynamic>>[
+          <String, dynamic>{'id': 'p.do', 'title': 'Do something'},
+        ],
+        'panels': <Map<String, dynamic>>[
+          <String, dynamic>{'id': 'main', 'title': 'Main'},
+          <String, dynamic>{'id': 'logs', 'title': 'Logs'},
+        ],
+      },
+    });
+    expect(info.panels.map((p) => p.id).toList(), ['main', 'logs']);
+    expect(info.commands.single.id, 'p.do');
+  });
+
+  testWidgets('UiNodeEvent dispatch routes through ui.event RPC',
+      (tester) async {
+    // Multiple-panel case → TabBar with two tabs.
+    final appState = await _appStateWithSeed([
+      _info(
+        id: 'two',
+        state: PluginWireState.running,
+        panels: const [
+          PluginPanelStub(id: 'a', title: 'A'),
+          PluginPanelStub(id: 'b', title: 'B'),
+        ],
+      ),
+    ]);
+    addTearDown(appState.dispose);
+    appState.uiPanels.debugInjectPush(<String, dynamic>{
+      'pluginId': 'two',
+      'panelId': 'a',
+      'version': 1,
+      'tree': <String, dynamic>{
+        'kind': 'Text',
+        'id': 't',
+        'text': 'panel A content',
+      },
+    });
+    appState.uiPanels.debugInjectPush(<String, dynamic>{
+      'pluginId': 'two',
+      'panelId': 'b',
+      'version': 1,
+      'tree': <String, dynamic>{
+        'kind': 'Text',
+        'id': 't2',
+        'text': 'panel B content',
+      },
+    });
+
+    final info = appState.plugins.plugin('two')!;
+    await tester.pumpWidget(_wrap(
+      PluginDetailView(appState: appState, info: info),
+    ));
+    await tester.pump();
+    expect(find.byType(TabBar), findsOneWidget);
+    expect(find.text('A'), findsOneWidget);
+    expect(find.text('B'), findsOneWidget);
+    expect(find.text('panel A content'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #60.

## Summary

- Adds the fourth bottom-nav slot — **Plugins** — between Terminal and More, with `Icons.extension_outlined` / `Icons.extension` (CLAUDE.md "4 tabs settled"). It is the only entry point for plugin-owned UI; plugins do not get their own slots in Files / Terminal / Settings.
- New `PluginsModel` mirrors `plugin.list` and reacts to `plugin.stateChanged` pushes (CLAUDE.md first principle #1 — backend is the source of truth; no optimistic flips). New `PluginsTab` + `PluginDetailScreen` render the list and per-plugin detail, reusing the C3 `UiRenderer` for each declared panel (`TabBar` when ≥ 2 panels).
- Crashed plugin → banner with View-log (snackbar with path; no in-app log viewer in v0) + Reload (disable → enable in order — manual, per the settled \"no automatic restart\" decision).
- Empty-state hint points users at the filesystem install path (`~/.local/share/openvsmobile-next/plugins/`).

## Dependency note

This branch is currently **based on top of #59 (PR #71)** because the C4 surface needs C3's `UiRenderer` + `ui.*` RPCs. The merge commit \`e386604\` re-reconciles \`host.ts\` / \`state.ts\` / \`index.ts\` between #58's plugin-host changes (already in main) and #59's UI descriptor work. Once #71 lands on main this PR's diff reduces to just the Plugins-tab files.

## Test plan

- [x] \`cd next/app && flutter analyze\` — clean (only the pre-existing \`system_tray.dart\` info remains).
- [x] \`cd next/app && flutter test\` — 69 passed, including 8 new Plugins-tab widget tests:
  - list renders three plugins with correct badges + switches
  - tap row → detail view mounts \`UiRenderer\` with seeded panel content
  - \`plugin.stateChanged\` push flips a row's badge from \`running\` to \`crashed\`
  - crashed detail shows the banner; Reload calls disable then enable in order
  - empty state hints at \`~/.local/share/openvsmobile-next/plugins/\`
  - Switch toggle routes through \`plugin.disable\`
  - \`PluginInfo.fromJson\` reads \`contributes.panels\` + \`commands\`
  - multi-panel plugin renders a \`TabBar\`
- [x] \`cd next/backend && pnpm typecheck\` — clean.
- [x] \`cd next/backend && pnpm test\` — 126 passed.
- [x] \`cd next/app && flutter build apk --debug\` — \`app-debug.apk\` produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)