### PR TITLE
feat(next): @openvsmobile/sdk + hello reference plugin

### DIFF
--- a/docs/design/mobile-code-platform.md
+++ b/docs/design/mobile-code-platform.md
@@ -233,42 +233,49 @@ Activation is **lazy**: a `registered`-state plugin sits idle until one of its e
 
 For `entry.kind: "node"` plugins, **the SDK is the only allowed import surface** outside Node's built-ins. The host spawns the plugin under Node's experimental permission model (or, where unavailable, with a custom `--require` shim that throws on disallowed `import`s) so that `import "axios"` inside a plugin fails fast. Plugins that need richer dependencies use `entry.kind: "binary"`.
 
-The SDK is a small local package shipped with the backend; plugins reference it via a host-injected resolver path. It exposes:
+The SDK is an in-repo workspace package (`next/backend/packages/sdk/`); plugins reference it as `@openvsmobile/sdk`. Resolution is "host-injected" in the literal sense: the host spawns Node with `--import` pointing at a side-effect loader (`@openvsmobile/sdk/runtime/sdk-loader.mjs`) which uses `module.register()` to map the bare specifier `@openvsmobile/sdk` to the package's compiled entry. This avoids NODE_PATH (which ESM does not consult) and avoids writing into user-controlled plugin directories.
+
+The SDK that ships in v0 is intentionally narrow — just enough to write the plugin contracts already on the wire (`host.log`, `ui.render`, `ui.event`, `command.invoke`) plus the §4.3 widget vocabulary. The richer surface area sketched below (`workspace.*`, `terminal.*`, `git.*`, `secrets.*`, `notify.*`) lands as those host RPCs come online, not before; the SDK does not export wrappers for methods the host doesn't yet implement, because the SDK-side capability double-check has no useful work to do when there's nothing on the other end.
 
 ```ts
-// rough sketch — exact API surface to be detailed before the host PR
-import {
-  defineCommand,        // contribute a command handler
-  definePanel,          // contribute a panel + render function
-  defineStatusItem,     // contribute a status bar item
-  workspace,            // fs.readFile / listDir / findFiles / onChange
-  terminal,             // spawn / write / onData / dispose
-  git,                  // diff / log (read-only)
-  notify,               // emit a notification (subject to ui:notification capability)
-  secrets,              // get / set, scoped to this plugin's id
-  log,                  // structured log → plugin-logs/<id>.log
-} from "@openvsmobile/sdk";
+// v0 surface — exactly what `next/examples/plugins/hello/` uses.
+import { createPlugin, ui } from "@openvsmobile/sdk";
+
+const plugin = createPlugin({
+  onActivate(ctx) {
+    ctx.renderPanel(
+      "home",
+      ui.section({
+        id: "home-section",
+        title: "Hello",
+        children: [
+          ui.text({ id: "greeting", text: "Hello, stranger." }),
+          ui.textField({ id: "name-field", label: "Your name" }),
+          ui.button({ id: "greet-btn", label: "Greet", style: "primary" }),
+        ],
+      }),
+    );
+  },
+  onUiEvent(ctx, event) { /* re-render with new state */ },
+  onCommand(ctx, commandId, args) { /* return value echoes back */ },
+});
+plugin.run();
 ```
 
+`ctx` exposes:
+
+- `log(level, msg)` → `host.log` (always allowed).
+- `renderPanel(panelId, tree)` → `ui.render` (gated by `capabilities.ui`).
+- `invokeCommand(targetPluginId, commandId, args)` → `plugin.invokeCommand` (cross-plugin call; gated by the host).
+
 Each SDK call is a thin wrapper that:
-1. Checks the plugin's declared capabilities (fail-fast `Error: capability "X" not declared`).
+1. Checks the plugin's declared capabilities (fail-fast `Error: capability "X" not declared`). *Reserved for richer capabilities; today the SDK trusts the manifest and lets the host's gate produce the error, since v0 only has `ui`.*
 2. Issues the stdio JSON-RPC call to the host.
 3. The host re-checks the capability declaration server-side (defense in depth).
 
 This double-check is deliberate: SDK-side check gives the plugin author a fast, in-process error during dev; host-side check gives the host an authoritative gate even if the plugin tampers with the SDK.
 
-UI rendering uses a builder API that produces the §4.3 widget tree:
-
-```ts
-definePanel("claude.chat", ({ context, fire }) =>
-  UiColumn({ id: "root", children: [
-    UiTextField({ id: "input", value: context.draft, onSubmit: "send" }),
-    UiButton({ id: "send", label: "Ask", onTap: "send" }),
-  ] })
-);
-```
-
-`fire` is the SDK helper that re-runs the plugin's render function and `ui.render`s the new tree to the host.
+UI rendering uses constructors on the `ui` namespace that mirror the §4.3 widget vocabulary one-for-one. Re-rendering is the plugin author's job: build a fresh tree with stable node ids and pass it back to `ctx.renderPanel`. v0 has no `definePanel` / `fire` indirection — the explicit call site is easier to reason about for a 30-line `index.js` and adds no boilerplate, and the §4.3 reconciler keys on node id either way.
 
 ### 3.5 Capability matrix
 
@@ -1077,10 +1084,10 @@ The first slice of the plugin host (issue C1) ships in `next/backend/src/plugins
 
 - Settings → Plugins list + log viewer + disable/reload UI.
 
-### Deferred — C5 (`@openvsmobile/sdk`)
+### Partially live — C5 (`@openvsmobile/sdk`)
 
-- §3.4 SDK package + import-surface restriction (Node `--experimental-permission` / `--require` shim).
-- SDK-side defense-in-depth capability checks.
+- §3.4 SDK package (`next/backend/packages/sdk/`) is in-tree, with the v0 surface area: `createPlugin({ onActivate, onCommand, onUiEvent })` + `ui.*` constructors covering the §4.3 widget vocabulary. Host injects the resolver via `node --import .../sdk-loader.mjs` so `import "@openvsmobile/sdk"` resolves regardless of where the plugin lives on disk. Exercised end-to-end by `next/examples/plugins/hello/`.
+- **Deferred to a later C5 slice**: import-surface restriction (Node `--experimental-permission` / `--require` shim that blocks `import "axios"`), and SDK-side defense-in-depth capability checks. The v0 SDK trusts its caller and leans on the host's capability gate as the authoritative check. Wider host RPCs (`workspace.*`, `terminal.*`, `git.*`, `secrets.*`, `notify.*`) and their matching SDK wrappers land alongside the issues that first need them.
 
 ### Intentional simplifications in v0
 

--- a/next/backend/package.json
+++ b/next/backend/package.json
@@ -8,13 +8,14 @@
     "node": ">=25"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
-    "build": "tsc",
+    "typecheck": "pnpm --filter \"./packages/*\" run typecheck && tsc --noEmit",
+    "build": "pnpm --filter \"./packages/*\" run build && tsc",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
-    "test": "vitest run"
+    "test": "pnpm --filter \"./packages/*\" run build && vitest run"
   },
   "dependencies": {
+    "@openvsmobile/sdk": "workspace:*",
     "better-sqlite3": "^12.10.0",
     "chokidar": "^4.0.3",
     "ignore": "^7.0.3",

--- a/next/backend/packages/sdk/package.json
+++ b/next/backend/packages/sdk/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@openvsmobile/sdk",
+  "version": "0.1.0",
+  "private": true,
+  "description": "openvsmobile node-plugin SDK — typed widget vocabulary + stdio JSON-RPC runtime.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "runtime",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4"
+  }
+}

--- a/next/backend/packages/sdk/runtime/sdk-loader.mjs
+++ b/next/backend/packages/sdk/runtime/sdk-loader.mjs
@@ -1,0 +1,7 @@
+// Side-effect-only loader: registers the SDK resolver hook on the main
+// thread before the plugin's entry executes. The host invokes this file
+// via `node --import file:///abs/path/to/sdk-loader.mjs index.js`.
+
+import { register } from "node:module";
+
+register("./sdk-resolver.mjs", import.meta.url);

--- a/next/backend/packages/sdk/runtime/sdk-resolver.mjs
+++ b/next/backend/packages/sdk/runtime/sdk-resolver.mjs
@@ -1,0 +1,28 @@
+// ESM resolver hook that maps the bare specifier `@openvsmobile/sdk`
+// to this package's compiled entry point.
+//
+// Why this exists: Node's ESM `import` does not consult NODE_PATH (per
+// the package resolution spec — bare specifiers walk `node_modules`
+// only). A plugin staged under an arbitrary tempdir / user directory
+// won't find the SDK without either filesystem manipulation or a
+// resolver hook. Per design §3.4 ("plugins reference it via a
+// host-injected resolver path") this is the host-injected path.
+//
+// The hook is registered by `sdk-loader.mjs` (run via `node --import`)
+// before the plugin's own code executes, so the very first
+// `import "@openvsmobile/sdk"` inside the plugin resolves cleanly.
+
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, resolve as resolvePath } from "node:path";
+
+const resolverDir = dirname(fileURLToPath(import.meta.url));
+const SDK_URL = pathToFileURL(
+  resolvePath(resolverDir, "..", "dist", "index.js"),
+).href;
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === "@openvsmobile/sdk") {
+    return { shortCircuit: true, url: SDK_URL, format: "module" };
+  }
+  return nextResolve(specifier, context);
+}

--- a/next/backend/packages/sdk/src/index.ts
+++ b/next/backend/packages/sdk/src/index.ts
@@ -1,0 +1,514 @@
+// @openvsmobile/sdk — node-side helper for plugin authors.
+//
+// Per CLAUDE.md, node plugins may only import `@openvsmobile/sdk` and
+// Node built-ins. This package's job is to make that import enough: it
+// wraps the stdio JSON-RPC framing and exports typed constructors for
+// the §4.3 UI widget vocabulary so a plugin's `index.js` reads as
+// business logic rather than wire-protocol glue.
+//
+// Wire-shape decisions worth knowing:
+//
+//   * Outbound framing is newline-delimited JSON. The backend's
+//     FrameCodec auto-detects on the first non-whitespace byte; emitting
+//     a single character of NDJSON pins us into newline mode for the
+//     lifetime of the channel. Content-Length framing is an option for
+//     binary-kind plugins that want it; node plugins gain nothing from
+//     it.
+//   * Host → plugin requests we honor: `command.invoke` (per §3.6
+//     activation handoff) and `ui.event` (per §4.3 user-interaction
+//     fan-in). Anything else gets a `methodNotFound` reply so a future
+//     host RPC can't fail silently on the plugin side.
+//   * Plugin → host requests we issue: `host.log` (always allowed),
+//     `ui.render` (gated by manifest `capabilities.ui`),
+//     `plugin.invokeCommand` (gated by the host as a cross-plugin call,
+//     wired here so the SDK contract stands even though no test
+//     exercises that path yet).
+//   * `run()` does not block. It wires stdin listeners, kicks off
+//     `onActivate` as a microtask, and returns. The plugin's process
+//     stays alive because of the stdin `data` listener; when the host
+//     closes stdin the event loop drains and the plugin exits.
+
+import { randomUUID } from "node:crypto";
+import { Buffer } from "node:buffer";
+
+// ---------------------------------------------------------------------
+// Widget vocabulary — mirrors `next/backend/src/plugins/ui.ts` so a
+// tree built with these constructors validates cleanly on the host
+// side. Field names are passed through verbatim; nothing the host
+// rejects can be encoded here.
+// ---------------------------------------------------------------------
+
+export type UiTextStyle = "body" | "title" | "caption" | "mono";
+export type UiButtonStyle = "primary" | "secondary" | "danger";
+
+export interface UiColumn {
+  kind: "Column";
+  id: string;
+  children: UiNode[];
+  gap?: number;
+}
+export interface UiRow {
+  kind: "Row";
+  id: string;
+  children: UiNode[];
+  gap?: number;
+}
+export interface UiSection {
+  kind: "Section";
+  id: string;
+  title?: string;
+  children: UiNode[];
+}
+export interface UiCard {
+  kind: "Card";
+  id: string;
+  children: UiNode[];
+}
+export interface UiList {
+  kind: "List";
+  id: string;
+  items: UiNode[];
+}
+export interface UiText {
+  kind: "Text";
+  id: string;
+  text: string;
+  style?: UiTextStyle;
+}
+export interface UiSpacer {
+  kind: "Spacer";
+  id: string;
+  size?: number;
+}
+export interface UiTextField {
+  kind: "TextField";
+  id: string;
+  label?: string;
+  value?: string;
+  placeholder?: string;
+}
+export interface UiButton {
+  kind: "Button";
+  id: string;
+  label: string;
+  style?: UiButtonStyle;
+}
+
+export type UiNode =
+  | UiColumn
+  | UiRow
+  | UiSection
+  | UiCard
+  | UiList
+  | UiText
+  | UiSpacer
+  | UiTextField
+  | UiButton;
+
+/// Constructors mirroring the §4.3 widget vocabulary. IDs may be
+/// omitted; an omitted id is replaced with `crypto.randomUUID()` so the
+/// host's "every node must have a unique id" validation always
+/// succeeds. When the plugin author supplies an id it is passed through
+/// verbatim — that is the only way to keep focus / scroll state alive
+/// across re-renders.
+export const ui = {
+  column(p: { id?: string; gap?: number; children: UiNode[] }): UiColumn {
+    const out: UiColumn = {
+      kind: "Column",
+      id: ensureId(p.id),
+      children: p.children,
+    };
+    if (p.gap !== undefined) out.gap = p.gap;
+    return out;
+  },
+  row(p: { id?: string; gap?: number; children: UiNode[] }): UiRow {
+    const out: UiRow = {
+      kind: "Row",
+      id: ensureId(p.id),
+      children: p.children,
+    };
+    if (p.gap !== undefined) out.gap = p.gap;
+    return out;
+  },
+  section(p: {
+    id?: string;
+    title?: string;
+    children: UiNode[];
+  }): UiSection {
+    const out: UiSection = {
+      kind: "Section",
+      id: ensureId(p.id),
+      children: p.children,
+    };
+    if (p.title !== undefined) out.title = p.title;
+    return out;
+  },
+  card(p: { id?: string; children: UiNode[] }): UiCard {
+    return { kind: "Card", id: ensureId(p.id), children: p.children };
+  },
+  list(p: { id?: string; items: UiNode[] }): UiList {
+    return { kind: "List", id: ensureId(p.id), items: p.items };
+  },
+  text(p: { id?: string; text: string; style?: UiTextStyle }): UiText {
+    const out: UiText = { kind: "Text", id: ensureId(p.id), text: p.text };
+    if (p.style !== undefined) out.style = p.style;
+    return out;
+  },
+  spacer(p: { id?: string; size?: number } = {}): UiSpacer {
+    const out: UiSpacer = { kind: "Spacer", id: ensureId(p.id) };
+    if (p.size !== undefined) out.size = p.size;
+    return out;
+  },
+  textField(
+    p: {
+      id?: string;
+      label?: string;
+      value?: string;
+      placeholder?: string;
+    } = {},
+  ): UiTextField {
+    const out: UiTextField = { kind: "TextField", id: ensureId(p.id) };
+    if (p.label !== undefined) out.label = p.label;
+    if (p.value !== undefined) out.value = p.value;
+    if (p.placeholder !== undefined) out.placeholder = p.placeholder;
+    return out;
+  },
+  button(p: {
+    id?: string;
+    label: string;
+    style?: UiButtonStyle;
+  }): UiButton {
+    const out: UiButton = {
+      kind: "Button",
+      id: ensureId(p.id),
+      label: p.label,
+    };
+    if (p.style !== undefined) out.style = p.style;
+    return out;
+  },
+};
+
+function ensureId(id: string | undefined): string {
+  if (id !== undefined && id.length > 0) return id;
+  return randomUUID();
+}
+
+// ---------------------------------------------------------------------
+// Plugin runtime
+// ---------------------------------------------------------------------
+
+export type LogLevel = "info" | "warn" | "error";
+
+export interface UiEventInput {
+  panelId: string;
+  nodeId: string;
+  type: string;
+  payload?: unknown;
+}
+
+export interface PluginContext {
+  /// Send a `host.log` notification. Always allowed regardless of the
+  /// manifest's capability set — the host log is the universal smoke
+  /// signal for plugin debugging.
+  log(level: LogLevel, msg: string): void;
+  /// Replace the panel's tree with `tree`. Round-trips into a
+  /// `ui.render` request on the host side. Requires the `ui` capability
+  /// in the manifest; without it the host returns `-32011
+  /// capabilityNotDeclared` and the call's promise (when the SDK uses
+  /// the response path) would reject — today this is a fire-and-forget
+  /// notification-shaped request, so the rejection surfaces on the next
+  /// `ui.event` round-trip.
+  renderPanel(panelId: string, tree: UiNode): void;
+  /// Invoke a command on another plugin via the host. Returns the
+  /// other plugin's result (or rejects with the host's JSON-RPC error).
+  /// The host gates cross-plugin invocation; nothing in v0 wires the
+  /// receiving side of `plugin.invokeCommand` from a plugin caller, so
+  /// this method exists for API completeness — calling it today will
+  /// likely reject with `methodNotFound` until the host adds dispatch.
+  invokeCommand(
+    targetPluginId: string,
+    commandId: string,
+    args?: unknown,
+  ): Promise<unknown>;
+}
+
+export interface PluginConfig {
+  /// Called once after the SDK has wired stdio. The activation hook is
+  /// the canonical place to emit the plugin's first `ui.render`.
+  onActivate?(ctx: PluginContext): void | Promise<void>;
+  /// Invoked when the host dispatches `command.invoke`. Return value is
+  /// echoed back in the JSON-RPC response so the caller can read it.
+  onCommand?(
+    ctx: PluginContext,
+    commandId: string,
+    args: unknown,
+  ): unknown | Promise<unknown>;
+  /// Invoked when the app pushes a `ui.event` at one of this plugin's
+  /// panels. The host has already validated the event's plugin id and
+  /// capability declaration; the SDK only adds field-shape checks.
+  onUiEvent?(
+    ctx: PluginContext,
+    event: UiEventInput,
+  ): void | Promise<void>;
+}
+
+export interface PluginRunOptions {
+  /// Override the inbound stream. Defaults to `process.stdin`. Tests
+  /// substitute a `PassThrough` so they can drive the SDK without
+  /// forking a child process.
+  stdin?: NodeJS.ReadableStream;
+  /// Override the outbound stream. Defaults to `process.stdout`.
+  stdout?: NodeJS.WritableStream;
+}
+
+export interface PluginRunner {
+  run(opts?: PluginRunOptions): void;
+}
+
+/// Internal JSON-RPC message shape — exposed only for type-narrowing
+/// inside the SDK; not exported.
+interface JsonRpcMessage {
+  jsonrpc: "2.0";
+  id?: string | number;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+const RPC_ERR_METHOD_NOT_FOUND = -32601;
+const RPC_ERR_INVALID_PARAMS = -32602;
+const RPC_ERR_INTERNAL = -32603;
+
+/// Build a plugin runner from author-supplied lifecycle callbacks.
+///
+/// The runner is intentionally a thin layer over JSON-RPC: it knows
+/// how to frame outbound messages, how to demux inbound requests vs.
+/// responses, and which inbound methods map to which callback. It does
+/// NOT try to be a UI reconciler or a state manager — re-renders are
+/// the plugin author's job, exactly as the design doc spells out (§4.3,
+/// "v0 full re-render reconciled by node id").
+export function createPlugin(config: PluginConfig): PluginRunner {
+  return {
+    run(opts?: PluginRunOptions): void {
+      const stdin = opts?.stdin ?? process.stdin;
+      const stdout = opts?.stdout ?? process.stdout;
+
+      let nextOutboundId = 1;
+      const pendingInvokes = new Map<
+        number,
+        { resolve: (v: unknown) => void; reject: (e: Error) => void }
+      >();
+
+      function writeMessage(msg: JsonRpcMessage): void {
+        stdout.write(JSON.stringify(msg) + "\n");
+      }
+
+      const ctx: PluginContext = {
+        log(level, msg): void {
+          // `host.log` is technically a notification per the wire
+          // contract, but the host accepts a request id too — it just
+          // replies `{}`. We omit the id to keep the channel quiet.
+          writeMessage({
+            jsonrpc: "2.0",
+            method: "host.log",
+            params: { level, msg },
+          });
+        },
+        renderPanel(panelId, tree): void {
+          // `ui.render` is request-shaped on the host side (the host
+          // emits a response); but the plugin doesn't actually need
+          // that response to function, so we drop the id and let the
+          // host treat it as fire-and-forget.
+          writeMessage({
+            jsonrpc: "2.0",
+            method: "ui.render",
+            params: { panelId, tree },
+          });
+        },
+        invokeCommand(targetPluginId, commandId, args): Promise<unknown> {
+          return new Promise<unknown>((resolve, reject) => {
+            const id = nextOutboundId++;
+            pendingInvokes.set(id, { resolve, reject });
+            writeMessage({
+              jsonrpc: "2.0",
+              id,
+              method: "plugin.invokeCommand",
+              params: { id: targetPluginId, commandId, args },
+            });
+          });
+        },
+      };
+
+      // Inbound: newline-delimited JSON. The host's FrameCodec
+      // auto-detects on our first byte, so as long as our first frame
+      // is NDJSON every subsequent frame the host sends back will use
+      // newline framing too.
+      // Typed as `Buffer<ArrayBufferLike>` so chunks coming off
+      // `stream.on("data")` — which are also `Buffer<ArrayBufferLike>` —
+      // can be concatenated without TypeScript's recent
+      // `ArrayBuffer` vs `ArrayBufferLike` narrowing kicking in.
+      let buffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+      function feed(chunk: Buffer<ArrayBufferLike>): void {
+        buffer =
+          buffer.length === 0 ? chunk : Buffer.concat([buffer, chunk]);
+        while (true) {
+          const nl = buffer.indexOf(0x0a);
+          if (nl === -1) return;
+          let line = buffer.subarray(0, nl);
+          buffer = buffer.subarray(nl + 1);
+          if (line.length > 0 && line[line.length - 1] === 0x0d) {
+            line = line.subarray(0, line.length - 1);
+          }
+          if (line.length === 0) continue;
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(line.toString("utf8"));
+          } catch {
+            // Malformed frame — drop. The host's logger will surface
+            // its own framing errors; we don't have a back-channel to
+            // complain on without echoing stderr noise into the host's
+            // captured log.
+            continue;
+          }
+          if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            continue;
+          }
+          void handleInbound(parsed as JsonRpcMessage);
+        }
+      }
+
+      async function handleInbound(msg: JsonRpcMessage): Promise<void> {
+        // Response to a request we issued.
+        if (msg.method === undefined) {
+          if (typeof msg.id !== "number") return;
+          const pending = pendingInvokes.get(msg.id);
+          if (pending === undefined) return;
+          pendingInvokes.delete(msg.id);
+          if (msg.error !== undefined) {
+            pending.reject(
+              new Error(msg.error.message ?? "host returned error"),
+            );
+            return;
+          }
+          pending.resolve(msg.result);
+          return;
+        }
+
+        // Host-initiated request.
+        if (msg.method === "command.invoke") {
+          if (config.onCommand === undefined) {
+            respond(msg.id, {
+              code: RPC_ERR_METHOD_NOT_FOUND,
+              message: "plugin has no onCommand handler",
+            });
+            return;
+          }
+          const params = (msg.params ?? {}) as {
+            id?: unknown;
+            args?: unknown;
+          };
+          if (typeof params.id !== "string") {
+            respond(msg.id, {
+              code: RPC_ERR_INVALID_PARAMS,
+              message: "command.invoke params.id must be a string",
+            });
+            return;
+          }
+          try {
+            const result = await config.onCommand(ctx, params.id, params.args);
+            respond(msg.id, undefined, result ?? {});
+          } catch (err) {
+            respond(msg.id, {
+              code: RPC_ERR_INTERNAL,
+              message: (err as Error).message,
+            });
+          }
+          return;
+        }
+
+        if (msg.method === "ui.event") {
+          // The host has already gated this on `capabilities.ui`. We
+          // only add shape checks so a malformed payload surfaces as
+          // `-32602` instead of crashing the callback.
+          const params = (msg.params ?? {}) as Partial<UiEventInput>;
+          if (
+            typeof params.panelId !== "string" ||
+            typeof params.nodeId !== "string" ||
+            typeof params.type !== "string"
+          ) {
+            respond(msg.id, {
+              code: RPC_ERR_INVALID_PARAMS,
+              message:
+                "ui.event params must include string panelId/nodeId/type",
+            });
+            return;
+          }
+          const event: UiEventInput = {
+            panelId: params.panelId,
+            nodeId: params.nodeId,
+            type: params.type,
+          };
+          if (params.payload !== undefined) event.payload = params.payload;
+          if (config.onUiEvent === undefined) {
+            respond(msg.id, undefined, {});
+            return;
+          }
+          try {
+            await config.onUiEvent(ctx, event);
+            respond(msg.id, undefined, {});
+          } catch (err) {
+            respond(msg.id, {
+              code: RPC_ERR_INTERNAL,
+              message: (err as Error).message,
+            });
+          }
+          return;
+        }
+
+        // Any other inbound method — methodNotFound so the host knows
+        // we deliberately don't handle it (vs. silently swallowing).
+        respond(msg.id, {
+          code: RPC_ERR_METHOD_NOT_FOUND,
+          message: `plugin SDK does not handle method "${msg.method}"`,
+        });
+      }
+
+      function respond(
+        id: string | number | undefined,
+        error?: { code: number; message: string },
+        result?: unknown,
+      ): void {
+        if (id === undefined) return; // notification — no reply expected
+        if (error !== undefined) {
+          writeMessage({ jsonrpc: "2.0", id, error });
+        } else {
+          writeMessage({ jsonrpc: "2.0", id, result: result ?? {} });
+        }
+      }
+
+      stdin.on("data", (chunk: Buffer | string) => {
+        feed(
+          typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk,
+        );
+      });
+
+      // Kick activation as a microtask so the caller's synchronous
+      // `plugin.run()` returns first. This matches "fire and forget"
+      // expectations from a typical plugin author.
+      if (config.onActivate !== undefined) {
+        const activate = config.onActivate;
+        queueMicrotask(() => {
+          void Promise.resolve()
+            .then(() => activate(ctx))
+            .catch((err: unknown) => {
+              ctx.log(
+                "error",
+                `onActivate threw: ${(err as Error).message ?? String(err)}`,
+              );
+            });
+        });
+      }
+    },
+  };
+}

--- a/next/backend/packages/sdk/test/sdk.test.ts
+++ b/next/backend/packages/sdk/test/sdk.test.ts
@@ -1,0 +1,275 @@
+// Unit tests for @openvsmobile/sdk.
+//
+// Two responsibilities the SDK absolutely must get right, per the
+// issue's acceptance criteria:
+//
+//   1. `ctx.renderPanel(...)` produces the wire shape the host's
+//      `ui.render` handler expects (panelId + tree as a typed UiNode).
+//   2. An inbound `ui.event` from the host is demuxed into the
+//      `onUiEvent` callback with the same payload.
+//
+// Both are exercised by feeding the SDK a `PassThrough` for stdin /
+// stdout instead of forking a child process — that keeps these tests
+// fast and avoids depending on the SDK's build artifacts (vitest runs
+// the TypeScript source directly).
+
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createPlugin,
+  ui,
+  type PluginContext,
+  type UiEventInput,
+} from "../src/index.js";
+
+interface Harness {
+  stdinIn: PassThrough;
+  stdoutOut: PassThrough;
+  outboundLines: string[];
+  /// Resolves once the SDK has flushed at least `n` outbound lines.
+  /// Watcher discipline: vitest test timeout (20s) is the outer fence —
+  /// we don't add our own timer here, the test will just fail if the
+  /// SDK never writes.
+  waitForOutbound(n: number): Promise<string[]>;
+  /// Push a JSON-RPC message into the SDK as if the host sent it.
+  pushInbound(msg: object): void;
+  /// Close stdin so the SDK's "stay alive" condition ends and Node can
+  /// drain. Tests that don't want to keep the SDK running call this.
+  close(): void;
+}
+
+const harnesses: Harness[] = [];
+
+afterEach(() => {
+  for (const h of harnesses.splice(0)) h.close();
+});
+
+function buildHarness(): Harness {
+  const stdinIn = new PassThrough();
+  const stdoutOut = new PassThrough();
+  const outboundLines: string[] = [];
+
+  const waiters: Array<{ n: number; resolve: (v: string[]) => void }> = [];
+
+  stdoutOut.setEncoding("utf8");
+  let pending = "";
+  stdoutOut.on("data", (chunk: string) => {
+    pending += chunk;
+    let nl: number;
+    while ((nl = pending.indexOf("\n")) !== -1) {
+      const line = pending.slice(0, nl);
+      pending = pending.slice(nl + 1);
+      if (line.length === 0) continue;
+      outboundLines.push(line);
+      for (const w of waiters.splice(0)) {
+        if (outboundLines.length >= w.n) {
+          w.resolve(outboundLines.slice());
+        } else {
+          waiters.push(w);
+        }
+      }
+    }
+  });
+
+  const h: Harness = {
+    stdinIn,
+    stdoutOut,
+    outboundLines,
+    waitForOutbound(n: number): Promise<string[]> {
+      if (outboundLines.length >= n) return Promise.resolve(outboundLines.slice());
+      return new Promise<string[]>((resolve) => {
+        waiters.push({ n, resolve });
+      });
+    },
+    pushInbound(msg: object): void {
+      stdinIn.write(JSON.stringify(msg) + "\n");
+    },
+    close(): void {
+      stdinIn.end();
+      stdoutOut.end();
+    },
+  };
+  harnesses.push(h);
+  return h;
+}
+
+describe("ui.* constructors", () => {
+  it("auto-generates ids when omitted and round-trips supplied ones", () => {
+    const auto = ui.text({ text: "hi" });
+    const fixed = ui.text({ id: "stable-id", text: "hi" });
+    expect(auto.id.length).toBeGreaterThan(0);
+    expect(fixed.id).toBe("stable-id");
+  });
+
+  it("rejects malformed widget by absence (TS surface) but accepts the §4.3 vocabulary", () => {
+    // No runtime assertion of "unknown kinds" — that's the host's
+    // validator. The SDK trusts what its caller passes. The test here
+    // is really documenting: the canonical happy-path tree round-
+    // trips into the JSON shape the host accepts.
+    const tree = ui.column({
+      id: "root",
+      gap: 8,
+      children: [
+        ui.section({
+          id: "sec",
+          title: "Greet",
+          children: [
+            ui.text({ id: "msg", text: "Hello" }),
+            ui.textField({ id: "name", label: "Your name", value: "" }),
+            ui.button({ id: "go", label: "Greet", style: "primary" }),
+          ],
+        }),
+        ui.spacer({ id: "sp", size: 16 }),
+      ],
+    });
+    expect(tree.kind).toBe("Column");
+    expect(tree.gap).toBe(8);
+    expect(tree.children).toHaveLength(2);
+    const section = tree.children[0];
+    if (section.kind !== "Section") throw new Error("unreachable");
+    expect(section.title).toBe("Greet");
+    expect(section.children.map((c) => c.kind)).toEqual([
+      "Text",
+      "TextField",
+      "Button",
+    ]);
+  });
+});
+
+describe("createPlugin: renderPanel round-trip", () => {
+  it("ctx.renderPanel emits a single ui.render request with the supplied panelId and tree", async () => {
+    const h = buildHarness();
+    let activated: PluginContext | null = null;
+    const plugin = createPlugin({
+      onActivate(ctx): void {
+        activated = ctx;
+        ctx.renderPanel(
+          "home",
+          ui.column({
+            id: "root",
+            children: [ui.text({ id: "greeting", text: "Hello" })],
+          }),
+        );
+      },
+    });
+    plugin.run({ stdin: h.stdinIn, stdout: h.stdoutOut });
+    const [first] = await h.waitForOutbound(1);
+    expect(activated).not.toBeNull();
+    const msg = JSON.parse(first as string) as {
+      jsonrpc: string;
+      method?: string;
+      params?: { panelId?: string; tree?: { kind?: string; id?: string } };
+    };
+    expect(msg.jsonrpc).toBe("2.0");
+    expect(msg.method).toBe("ui.render");
+    expect(msg.params?.panelId).toBe("home");
+    expect(msg.params?.tree?.kind).toBe("Column");
+    expect(msg.params?.tree?.id).toBe("root");
+  });
+
+  it("ctx.log emits a host.log notification with the supplied level + msg", async () => {
+    const h = buildHarness();
+    const plugin = createPlugin({
+      onActivate(ctx): void {
+        ctx.log("warn", "watch out");
+      },
+    });
+    plugin.run({ stdin: h.stdinIn, stdout: h.stdoutOut });
+    const [first] = await h.waitForOutbound(1);
+    const msg = JSON.parse(first as string) as {
+      method?: string;
+      params?: { level?: string; msg?: string };
+    };
+    expect(msg.method).toBe("host.log");
+    expect(msg.params).toEqual({ level: "warn", msg: "watch out" });
+  });
+});
+
+describe("createPlugin: ui.event dispatch", () => {
+  it("forwards inbound ui.event to onUiEvent with the same payload", async () => {
+    const h = buildHarness();
+    const captured: UiEventInput[] = [];
+    const plugin = createPlugin({
+      onUiEvent(_ctx, event): void {
+        captured.push(event);
+      },
+    });
+    plugin.run({ stdin: h.stdinIn, stdout: h.stdoutOut });
+    // Give the SDK a microtask to wire the listener before we push.
+    await Promise.resolve();
+    h.pushInbound({
+      jsonrpc: "2.0",
+      id: 42,
+      method: "ui.event",
+      params: {
+        panelId: "home",
+        nodeId: "name",
+        type: "changed",
+        payload: { value: "Ada" },
+      },
+    });
+    // SDK acks every request — wait for the ack to know the event has
+    // been demuxed and the callback finished.
+    const [ack] = await h.waitForOutbound(1);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toEqual({
+      panelId: "home",
+      nodeId: "name",
+      type: "changed",
+      payload: { value: "Ada" },
+    });
+    const ackMsg = JSON.parse(ack as string) as {
+      id?: unknown;
+      result?: unknown;
+      error?: unknown;
+    };
+    expect(ackMsg.id).toBe(42);
+    expect(ackMsg.result).toBeDefined();
+    expect(ackMsg.error).toBeUndefined();
+  });
+
+  it("acks a command.invoke and returns the handler's result", async () => {
+    const h = buildHarness();
+    const plugin = createPlugin({
+      onCommand(_ctx, commandId, args): unknown {
+        return { commandId, args };
+      },
+    });
+    plugin.run({ stdin: h.stdinIn, stdout: h.stdoutOut });
+    await Promise.resolve();
+    h.pushInbound({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "command.invoke",
+      params: { id: "hello.greet", args: { who: "world" } },
+    });
+    const [ack] = await h.waitForOutbound(1);
+    const ackMsg = JSON.parse(ack as string) as {
+      id?: unknown;
+      result?: { commandId?: string; args?: { who?: string } };
+    };
+    expect(ackMsg.id).toBe(7);
+    expect(ackMsg.result?.commandId).toBe("hello.greet");
+    expect(ackMsg.result?.args?.who).toBe("world");
+  });
+
+  it("replies methodNotFound when the host calls an unknown method", async () => {
+    const h = buildHarness();
+    const plugin = createPlugin({});
+    plugin.run({ stdin: h.stdinIn, stdout: h.stdoutOut });
+    await Promise.resolve();
+    h.pushInbound({
+      jsonrpc: "2.0",
+      id: 99,
+      method: "totally.bogus",
+      params: {},
+    });
+    const [ack] = await h.waitForOutbound(1);
+    const ackMsg = JSON.parse(ack as string) as {
+      id?: unknown;
+      error?: { code?: number; message?: string };
+    };
+    expect(ackMsg.id).toBe(99);
+    expect(ackMsg.error?.code).toBe(-32601);
+  });
+});

--- a/next/backend/packages/sdk/tsconfig.json
+++ b/next/backend/packages/sdk/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "exactOptionalPropertyTypes": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "test", "node_modules"]
+}

--- a/next/backend/pnpm-lock.yaml
+++ b/next/backend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@openvsmobile/sdk':
+        specifier: workspace:*
+        version: link:packages/sdk
       better-sqlite3:
         specifier: ^12.10.0
         version: 12.10.0
@@ -42,6 +45,12 @@ importers:
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@types/node@20.19.41)(vite@8.0.13(@types/node@20.19.41)(esbuild@0.28.0)(tsx@4.22.0))
+
+  packages/sdk:
+    devDependencies:
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.3
 
 packages:
 

--- a/next/backend/pnpm-workspace.yaml
+++ b/next/backend/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+# Workspace members. The backend's own package.json is the implicit root
+# member; `packages/*` brings the in-repo plugin SDK in alongside so
+# `@openvsmobile/sdk` resolves as a workspace dep instead of an npm fetch.
+packages:
+  - "packages/*"
+
 # pnpm 11+ requires explicit approval for packages that run lifecycle
 # scripts (build/install/postinstall). Without these entries pnpm refuses
 # to compile node-pty's native binding, so the bundled backend would crash

--- a/next/backend/src/plugins/process.ts
+++ b/next/backend/src/plugins/process.ts
@@ -7,8 +7,10 @@
 // and never auto-restarts (settled decision; see CLAUDE.md).
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { accessSync, constants as fsConstants } from "node:fs";
+import { accessSync, constants as fsConstants, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { execPath } from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { FrameCodec } from "./framing.js";
 import type { PluginManifest } from "./manifest.js";
 import { resolveEntryPath } from "./manifest.js";
@@ -95,7 +97,20 @@ export class PluginProcess {
       // says we MUST spawn with the same node binary the backend is
       // running on, so `execPath` is the right thing here.
       command = execPath;
-      args = [entryPath];
+      // Inject the SDK resolver as an `--import` side-effect module so
+      // the plugin's `import "@openvsmobile/sdk"` resolves regardless
+      // of where the plugin directory lives on disk. ESM does not
+      // consult NODE_PATH (Node spec — bare specifiers walk only
+      // `node_modules`), and we deliberately don't write a
+      // `node_modules` symlink into user-controlled plugin
+      // directories, so a resolver hook is the v0 mechanism for the
+      // "host-injected resolver path" from design §3.4.
+      args = [];
+      const loaderUrl = resolveSdkLoaderUrl();
+      if (loaderUrl !== null) {
+        args.push("--import", loaderUrl);
+      }
+      args.push(entryPath);
     } else {
       // binary mode: refuse to spawn anything that isn't executable. A
       // non-executable file would error at spawn time with a confusing
@@ -244,5 +259,47 @@ export class PluginProcess {
       return;
     }
     void this.onMessage(this, msg);
+  }
+}
+
+/// Cached `file://` URL of the SDK loader hook. `null` means the SDK
+/// isn't installed and we should let the spawn proceed without the
+/// `--import` flag — the plugin will fail loud with `MODULE_NOT_FOUND`
+/// on its own `import "@openvsmobile/sdk"`, which is the right
+/// diagnostic for "you didn't run `pnpm install`". Searching the
+/// filesystem on every spawn would be wasted work; the layout is fixed
+/// for the lifetime of the process.
+let cachedSdkLoaderUrl: string | null | undefined;
+
+/// Locate `@openvsmobile/sdk/runtime/sdk-loader.mjs` by walking up from
+/// this file looking for a `node_modules/@openvsmobile/sdk/` directory.
+/// The dev path is `<backend>/src/plugins/process.ts` →
+/// `<backend>/node_modules`; after `tsc` it's
+/// `<backend>/dist/plugins/process.js` → `<backend>/node_modules`; in a
+/// packaged tarball the same walk works because the SDK lives under
+/// `<root>/node_modules` either way.
+function resolveSdkLoaderUrl(): string | null {
+  if (cachedSdkLoaderUrl !== undefined) return cachedSdkLoaderUrl;
+  const selfDir = dirname(fileURLToPath(import.meta.url));
+  let d = selfDir;
+  while (true) {
+    const candidate = join(
+      d,
+      "node_modules",
+      "@openvsmobile",
+      "sdk",
+      "runtime",
+      "sdk-loader.mjs",
+    );
+    if (existsSync(candidate)) {
+      cachedSdkLoaderUrl = pathToFileURL(candidate).href;
+      return cachedSdkLoaderUrl;
+    }
+    const parent = dirname(d);
+    if (parent === d) {
+      cachedSdkLoaderUrl = null;
+      return null;
+    }
+    d = parent;
   }
 }

--- a/next/backend/test/hello.test.ts
+++ b/next/backend/test/hello.test.ts
@@ -1,0 +1,223 @@
+// End-to-end coverage for the `examples/plugins/hello` reference
+// plugin. Spawns the host pointing at the example directory, subscribes
+// to `ui.tree`, fakes the two `ui.event`s the example responds to
+// (changed → tap), and asserts the re-rendered tree contains the
+// expected greeting.
+//
+// This doubles as the platform-end smoke test for `@openvsmobile/sdk`:
+// any regression in SDK framing, ui.* constructors, or NODE_PATH
+// resolution on the spawn path surfaces here.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { WebSocket } from "ws";
+import { cp, mkdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  FakeWebSocket,
+  makeTempDir,
+  rmTempDir,
+  sleep,
+} from "./_helpers.js";
+import { dispatch, type RpcContext } from "../src/rpc.js";
+import { ProcessState } from "../src/state.js";
+import { PluginHost } from "../src/plugins/host.js";
+import type { UiPanelSnapshot } from "../src/plugins/ui.js";
+
+const THIS_FILE_DIR = dirname(fileURLToPath(import.meta.url));
+const EXAMPLE_HELLO_DIR = resolve(
+  THIS_FILE_DIR,
+  "..",
+  "..",
+  "examples",
+  "plugins",
+  "hello",
+);
+
+let staging: string | null = null;
+
+beforeEach(async () => {
+  staging = await makeTempDir("openvsmobile-hello-");
+});
+
+afterEach(async () => {
+  if (staging !== null) {
+    await rmTempDir(staging);
+    staging = null;
+  }
+});
+
+async function buildHarness(): Promise<{
+  host: PluginHost;
+  sock: FakeWebSocket;
+  ctx: RpcContext;
+  diagnostics: string[];
+}> {
+  if (staging === null) throw new Error("staging dir not set up");
+  const pluginsDir = join(staging, "plugins");
+  const logDir = join(staging, "logs");
+  await mkdir(pluginsDir, { recursive: true });
+  await mkdir(logDir, { recursive: true });
+  // Stage a copy of the in-repo example so the test owns its plugin
+  // dir and the host's writes (state file etc.) don't bleed into the
+  // committed `examples/plugins/hello/` tree.
+  await cp(EXAMPLE_HELLO_DIR, join(pluginsDir, "hello"), {
+    recursive: true,
+  });
+  const diagnostics: string[] = [];
+  const host = new PluginHost({
+    pluginsDir,
+    logDir,
+    logger: (line) => diagnostics.push(line),
+    onHostLog: () => {},
+  });
+  const state = new ProcessState({ pluginHost: host });
+  const sock = new FakeWebSocket();
+  const ctx: RpcContext = {
+    state,
+    expectedToken: "test-token",
+    serverVersion: "0.0.0-test",
+    ws: sock as unknown as WebSocket,
+    markAuthenticated: () => {},
+  };
+  await host.start();
+  return { host, sock, ctx, diagnostics };
+}
+
+async function call<T = unknown>(
+  ctx: RpcContext,
+  method: string,
+  params: unknown = {},
+): Promise<T> {
+  return (await dispatch(ctx, {
+    jsonrpc: "2.0",
+    id: 1,
+    method,
+    params,
+  })) as T;
+}
+
+async function waitFor<T>(
+  predicate: () => T | undefined | Promise<T | undefined>,
+  budgetMs: number,
+  stepMs = 25,
+): Promise<T> {
+  const deadline = Date.now() + budgetMs;
+  while (Date.now() < deadline) {
+    const v = await predicate();
+    if (v !== undefined) return v;
+    await sleep(stepMs);
+  }
+  const v = await predicate();
+  if (v !== undefined) return v;
+  throw new Error(`waitFor timed out after ${budgetMs}ms`);
+}
+
+function findText(node: unknown, id: string): string | undefined {
+  if (!node || typeof node !== "object") return undefined;
+  const n = node as {
+    id?: string;
+    kind?: string;
+    text?: string;
+    children?: unknown[];
+    items?: unknown[];
+  };
+  if (n.kind === "Text" && n.id === id && typeof n.text === "string") {
+    return n.text;
+  }
+  for (const arr of [n.children, n.items]) {
+    if (!Array.isArray(arr)) continue;
+    for (const c of arr) {
+      const found = findText(c, id);
+      if (found !== undefined) return found;
+    }
+  }
+  return undefined;
+}
+
+describe("examples/plugins/hello end-to-end", () => {
+  it(
+    "renders the home panel on activation, then re-renders with the typed name after a Greet tap",
+    async () => {
+      const harness = await buildHarness();
+      try {
+        await call<{ ok: boolean }>(harness.ctx, "ui.subscribe");
+        // Wait for the activation render to land. The fixture uses the
+        // SDK's `renderPanel`, which serializes a Section with a Text +
+        // TextField + Button — all three node ids are stable across
+        // renders, so we can assert on them directly.
+        const initial = await waitFor(() => {
+          const pushes = harness.sock.notifications("ui.tree");
+          const home = pushes.find((p) => {
+            const snap = p.params as UiPanelSnapshot;
+            return snap.pluginId === "hello" && snap.panelId === "home";
+          });
+          if (home === undefined) return undefined;
+          const snap = home.params as UiPanelSnapshot;
+          return snap.tree === null ? undefined : snap;
+        }, 5000);
+        expect(initial.pluginId).toBe("hello");
+        expect(findText(initial.tree, "greeting")).toBe("Hello, stranger.");
+
+        const versionBefore = initial.version;
+
+        // Simulate the app: user types into the TextField.
+        await call(harness.ctx, "ui.event", {
+          pluginId: "hello",
+          panelId: "home",
+          nodeId: "name-field",
+          type: "changed",
+          payload: { value: "Ada" },
+        });
+        // Then taps Greet.
+        await call(harness.ctx, "ui.event", {
+          pluginId: "hello",
+          panelId: "home",
+          nodeId: "greet-btn",
+          type: "tap",
+        });
+
+        // Expect a fresh ui.tree push with the personalised greeting.
+        const updated = await waitFor(() => {
+          const pushes = harness.sock.notifications("ui.tree");
+          for (let i = pushes.length - 1; i >= 0; i--) {
+            const snap = pushes[i].params as UiPanelSnapshot;
+            if (
+              snap.pluginId === "hello" &&
+              snap.panelId === "home" &&
+              snap.tree !== null &&
+              snap.version > versionBefore
+            ) {
+              return snap;
+            }
+          }
+          return undefined;
+        }, 5000);
+        expect(findText(updated.tree, "greeting")).toBe("Hello, Ada!");
+        // Node ids stable: the TextField's id must round-trip so focus
+        // and any client-side input state survive the re-render.
+        const findTextField = (node: unknown, id: string): unknown => {
+          if (!node || typeof node !== "object") return undefined;
+          const n = node as {
+            id?: string;
+            kind?: string;
+            children?: unknown[];
+            items?: unknown[];
+          };
+          if (n.kind === "TextField" && n.id === id) return node;
+          for (const arr of [n.children, n.items]) {
+            if (!Array.isArray(arr)) continue;
+            for (const c of arr) {
+              const f = findTextField(c, id);
+              if (f !== undefined) return f;
+            }
+          }
+          return undefined;
+        };
+        expect(findTextField(updated.tree, "name-field")).toBeDefined();
+      } finally {
+        harness.host.shutdown();
+      }
+    },
+  );
+});

--- a/next/backend/vitest.config.ts
+++ b/next/backend/vitest.config.ts
@@ -10,7 +10,13 @@ export default defineConfig({
     // chokidar inotify limits + git's index.lock. Single-threaded is fine
     // for our test count.
     fileParallelism: false,
-    include: ["test/**/*.test.ts"],
+    include: [
+      "test/**/*.test.ts",
+      // The plugin SDK lives under `packages/sdk/` as a workspace
+      // member; its unit tests run in the same vitest invocation so a
+      // single `pnpm test` covers both halves of the plugin platform.
+      "packages/*/test/**/*.test.ts",
+    ],
     // ESM is the default in this project. Vitest picks it up from package.json
     // ("type": "module") — no extra config needed.
   },

--- a/next/examples/plugins/hello/README.md
+++ b/next/examples/plugins/hello/README.md
@@ -1,0 +1,11 @@
+# hello — reference plugin
+
+Minimal node plugin demonstrating `@openvsmobile/sdk`. Renders one panel
+(`home`) with a greeting, a name `TextField`, and a `Greet` `Button`.
+Tap Greet → the greeting re-renders with the typed name; node ids stay
+stable so the TextField keeps focus and its value across renders.
+
+This plugin doubles as the platform's plugin-host end-to-end smoke
+test (`next/backend/test/hello.test.ts`). Drop the directory into
+`OPENVSMOBILE_PLUGINS_DIR` (default `~/.local/share/openvsmobile-next/plugins/`)
+and the backend will activate it at startup.

--- a/next/examples/plugins/hello/index.js
+++ b/next/examples/plugins/hello/index.js
@@ -1,0 +1,55 @@
+// Hello World — reference plugin built on @openvsmobile/sdk.
+//
+// Renders one panel `home` with a greeting, a name input, and a Greet
+// button. Each `ui.event` updates the in-memory name and re-renders;
+// node ids stay stable across renders so the TextField's focus + value
+// survive (design §4.3 reconciliation rule).
+//
+// Doubles as the platform's end-to-end integration coverage — see the
+// "hello plugin end-to-end" tests in next/backend/test/hello.test.ts.
+
+import { createPlugin, ui } from "@openvsmobile/sdk";
+
+let name = "";
+
+function renderHome(ctx) {
+  ctx.renderPanel(
+    "home",
+    ui.section({
+      id: "home-section",
+      title: "Hello World",
+      children: [
+        ui.text({
+          id: "greeting",
+          text: name.length > 0 ? `Hello, ${name}!` : "Hello, stranger.",
+          style: "title",
+        }),
+        ui.textField({
+          id: "name-field",
+          label: "Your name",
+          value: name,
+          placeholder: "Type a name",
+        }),
+        ui.button({ id: "greet-btn", label: "Greet", style: "primary" }),
+      ],
+    }),
+  );
+}
+
+const plugin = createPlugin({
+  onActivate(ctx) {
+    renderHome(ctx);
+  },
+  onUiEvent(ctx, event) {
+    if (event.nodeId === "name-field" && event.type === "changed") {
+      const value = event.payload && event.payload.value;
+      name = typeof value === "string" ? value : "";
+      return;
+    }
+    if (event.nodeId === "greet-btn" && event.type === "tap") {
+      renderHome(ctx);
+    }
+  },
+});
+
+plugin.run();

--- a/next/examples/plugins/hello/plugin.json
+++ b/next/examples/plugins/hello/plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "hello",
+  "name": "Hello World",
+  "version": "0.1.0",
+  "entry": { "kind": "node", "path": "index.js" },
+  "activation": ["onStartup"],
+  "capabilities": { "ui": true },
+  "contributes": {
+    "commands": [{ "id": "hello.greet", "title": "Greet" }]
+  }
+}


### PR DESCRIPTION
## Summary

- Ships `@openvsmobile/sdk` as an in-repo workspace package (`next/backend/packages/sdk/`) — TypeScript / ESM / zero runtime deps. Exposes `createPlugin({ onActivate, onCommand, onUiEvent })` plus a `ui.*` constructor namespace covering the §4.3 widget vocabulary.
- Adds `next/examples/plugins/hello/` — a ~50 LOC reference plugin that activates onStartup, renders a `home` panel with `Section / Text / TextField / Button`, and re-renders with `Hello, <name>!` after the Greet button is tapped. Stable node ids keep the TextField's focus + value alive across renders.
- Wires the host to inject the SDK at spawn time via `node --import .../sdk-loader.mjs` (`module.register()` resolver hook). ESM does not consult NODE_PATH, and writing `node_modules` into user-controlled plugin dirs would be intrusive; the loader hook is the design doc's "host-injected resolver path".
- Updates §3.4 of `docs/design/mobile-code-platform.md` to match the shipping API (was a forward-looking sketch using `defineCommand` / `definePanel` / `fire`; now matches `createPlugin` / `ctx.renderPanel`). §9a's C5 entry split into "partially live" + "still deferred (import-surface restriction, defense-in-depth checks, wider workspace/terminal/git/secrets/notify wrappers)".

Closes #61.

## Test plan

- [x] `pnpm typecheck` — clean across SDK + backend (recursive).
- [x] `pnpm test` — 134 tests pass. 7 new SDK unit tests in `packages/sdk/test/sdk.test.ts` cover `ui.*` constructors, `ctx.renderPanel` + `ctx.log` wire shapes, `ui.event` dispatch into `onUiEvent`, `command.invoke` result echo, and `methodNotFound` for unknown inbound methods. New integration test in `test/hello.test.ts` stages the example plugin, subscribes to `ui.tree`, fakes the `changed → tap` event pair, and asserts the re-rendered tree contains `Hello, Ada!` with stable node ids.
- [x] `flutter analyze` — no app changes in this PR. Pre-existing info-level warning in `lib/services/system_tray.dart` from `10eabe5` remains, unchanged.

### Verification (visual)

The acceptance criteria asks for a screenshot of the hello plugin rendering in the Plugins tab. That requires running the Android client end-to-end on a device — out of scope for the CI environment this PR was authored in. The `test/hello.test.ts` integration test is the verifiable proof: it stages the plugin, drives the host through the full activation → render → event → re-render cycle, and asserts the exact tree the Flutter `UiRenderer` would consume. The Plugins-tab renderer that visualises this tree shipped in 1a7bde7 (`feat(app): Plugins tab — list, toggle, detail with UiRenderer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)