### PR TITLE
feat(app): TerminalScrollAdapter — swipe routing for TUIs (#69)

### DIFF
--- a/next/app/lib/screens/terminal_detail.dart
+++ b/next/app/lib/screens/terminal_detail.dart
@@ -8,10 +8,12 @@
 // `AppState.terminalFor`, which keeps it across rebuilds so scrollback
 // survives.
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:xterm/xterm.dart';
 
 import '../app_state.dart';
+import '../services/terminal_scroll_adapter.dart';
 
 class TerminalDetailScreen extends StatelessWidget {
   final AppState appState;
@@ -72,31 +74,82 @@ class TerminalSessionView extends StatefulWidget {
 
 class _TerminalSessionViewState extends State<TerminalSessionView> {
   final TerminalController _ctrl = TerminalController();
+  final GlobalKey<TerminalViewState> _terminalViewKey =
+      GlobalKey<TerminalViewState>();
+  final ScrollController _scrollback = ScrollController();
+  late final TerminalScrollAdapter _scrollAdapter;
 
   /// Sticky-modifier state. When armed, the next keystroke routed through
   /// the Terminal's onOutput (soft keyboard or toolbar) has Ctrl applied,
   /// then auto-disarms. Termux-style.
   bool _ctrlArmed = false;
   void Function(String)? _origOnOutput;
+  TerminalMouseHandler? _origMouseHandler;
+  _WheelSuppressingMouseHandler? _mouseHandlerProxy;
+
+  int? _activePointer;
+  VelocityTracker? _dragTracker;
 
   @override
   void initState() {
     super.initState();
     _origOnOutput = widget.terminal.onOutput;
     widget.terminal.onOutput = _onOutputProxy;
+    // Suppress xterm.dart's built-in wheel emission so it doesn't
+    // double-fire alongside our adapter. The adapter emits SGR wheel
+    // reports regardless of which mouse mode the app requested (see
+    // adapter doc), and xterm's internal TerminalScrollGestureHandler
+    // would otherwise *also* emit a wheel report (in whatever encoding
+    // the app last requested) for the same touch drag.
+    _origMouseHandler = widget.terminal.mouseHandler;
+    _mouseHandlerProxy = _WheelSuppressingMouseHandler(_origMouseHandler);
+    widget.terminal.mouseHandler = _mouseHandlerProxy;
+    _scrollAdapter = TerminalScrollAdapter(
+      terminal: widget.terminal,
+      cellAt: _cellAt,
+      onScrollback: _noopScrollback,
+    );
   }
 
   @override
   void dispose() {
     // Be defensive: only restore if we're still the installed proxy. If
-    // some other layer rewired onOutput between init and now, leave it
-    // alone — touching it would clobber their handler.
+    // some other layer rewired onOutput / mouseHandler between init and
+    // now, leave it alone — touching it would clobber their handler.
     if (widget.terminal.onOutput == _onOutputProxy) {
       widget.terminal.onOutput = _origOnOutput;
     }
+    if (widget.terminal.mouseHandler == _mouseHandlerProxy) {
+      widget.terminal.mouseHandler = _origMouseHandler;
+    }
+    _scrollback.dispose();
     _ctrl.dispose();
     super.dispose();
   }
+
+  /// Pixel → 1-based cell coordinate via xterm.dart's render object.
+  /// Returns (1, 1) before the first frame paints (rare — gestures
+  /// require the view to already be hit-testable).
+  ({int col, int row}) _cellAt(Offset localPos) {
+    final state = _terminalViewKey.currentState;
+    if (state == null) return (col: 1, row: 1);
+    final cell = state.renderTerminal.getCellOffset(localPos);
+    return (col: cell.x + 1, row: cell.y + 1);
+  }
+
+  double _currentCellHeight() {
+    final state = _terminalViewKey.currentState;
+    if (state == null) return 16;
+    return state.renderTerminal.lineHeight;
+  }
+
+  /// Normal-buffer scrollback in production is driven by xterm.dart's own
+  /// outer Scrollable (which our Listener does not steal pointer events
+  /// from), so the adapter's scrollback sink is a no-op here. The
+  /// adapter still emits per-cell increments — they're verified by the
+  /// unit tests — but we don't double-scroll the controller alongside
+  /// xterm.
+  void _noopScrollback(int lines) {}
 
   /// Intercepts every byte heading to the PTY. When Ctrl is armed, swap
   /// a single ASCII letter / [\]^_ / ? for its control byte and disarm.
@@ -138,14 +191,39 @@ class _TerminalSessionViewState extends State<TerminalSessionView> {
 
   @override
   Widget build(BuildContext context) {
+    // Listener observes raw pointer events without entering the gesture
+    // arena, so xterm.dart's own tap / long-press / vertical-drag
+    // recognizers keep firing too. Concretely:
+    //   * tap-to-cursor (htop & friends) — xterm.dart's tap handler
+    //     fires from the same pointer events; we don't claim them.
+    //   * back-swipe horizontal pan (#63's IM-style nav) — we ignore
+    //     horizontal motion entirely.
+    //   * normal-buffer scrollback — xterm.dart's outer Scrollable
+    //     drives `_scrollback` natively; our adapter's `onScrollback`
+    //     sink is wired to a no-op in production so we don't double-
+    //     scroll.
+    //   * alt-buffer wheel reports — xterm.dart's internal wheel path
+    //     is silenced via `_WheelSuppressingMouseHandler` and
+    //     `simulateScroll: false`, leaving the adapter as the sole
+    //     source of escape sequences in alt buffer.
     return Column(
       children: [
         Expanded(
-          child: TerminalView(
-            widget.terminal,
-            controller: _ctrl,
-            autofocus: true,
-            backgroundOpacity: 1.0,
+          child: Listener(
+            behavior: HitTestBehavior.translucent,
+            onPointerDown: _onPointerDown,
+            onPointerMove: _onPointerMove,
+            onPointerUp: _onPointerUp,
+            onPointerCancel: _onPointerCancel,
+            child: TerminalView(
+              widget.terminal,
+              key: _terminalViewKey,
+              controller: _ctrl,
+              scrollController: _scrollback,
+              autofocus: true,
+              backgroundOpacity: 1.0,
+              simulateScroll: false,
+            ),
           ),
         ),
         _KeyToolbar(
@@ -155,6 +233,65 @@ class _TerminalSessionViewState extends State<TerminalSessionView> {
         ),
       ],
     );
+  }
+
+  void _onPointerDown(PointerDownEvent event) {
+    // Track only the first finger; subsequent touches (pinch, multitouch
+    // selection) are intentionally ignored by the scroll layer.
+    if (_activePointer != null) return;
+    _activePointer = event.pointer;
+    _dragTracker = VelocityTracker.withKind(event.kind);
+    _dragTracker!.addPosition(event.timeStamp, event.position);
+    _scrollAdapter.onDragStart(event.localPosition);
+  }
+
+  void _onPointerMove(PointerMoveEvent event) {
+    if (event.pointer != _activePointer) return;
+    _dragTracker?.addPosition(event.timeStamp, event.position);
+    _scrollAdapter.onDragUpdate(
+      deltaDy: event.delta.dy,
+      cellHeight: _currentCellHeight(),
+    );
+  }
+
+  void _onPointerUp(PointerUpEvent event) {
+    if (event.pointer != _activePointer) return;
+    final dy = _dragTracker?.getVelocity().pixelsPerSecond.dy ?? 0;
+    _scrollAdapter.onDragEnd(
+      velocityDy: dy,
+      rows: widget.terminal.viewHeight,
+    );
+    _activePointer = null;
+    _dragTracker = null;
+  }
+
+  void _onPointerCancel(PointerCancelEvent event) {
+    if (event.pointer != _activePointer) return;
+    _scrollAdapter.onDragEnd(
+      velocityDy: 0,
+      rows: widget.terminal.viewHeight,
+    );
+    _activePointer = null;
+    _dragTracker = null;
+  }
+}
+
+/// Wraps the terminal's default mouse handler to discard wheel-up /
+/// wheel-down events that xterm.dart's internal scroll handler would
+/// otherwise translate into the (potentially non-SGR) mouse-report
+/// encoding the app last requested. Real mouse clicks (left/right/
+/// middle/release) still pass through.
+class _WheelSuppressingMouseHandler implements TerminalMouseHandler {
+  _WheelSuppressingMouseHandler(this._inner);
+  final TerminalMouseHandler? _inner;
+
+  @override
+  String? call(TerminalMouseEvent event) {
+    if (event.button == TerminalMouseButton.wheelUp ||
+        event.button == TerminalMouseButton.wheelDown) {
+      return null;
+    }
+    return _inner?.call(event);
   }
 }
 

--- a/next/app/lib/services/terminal_scroll_adapter.dart
+++ b/next/app/lib/services/terminal_scroll_adapter.dart
@@ -1,0 +1,134 @@
+import 'dart:ui' show Offset;
+
+import 'package:xterm/xterm.dart';
+
+// Tunables — surfaced at the top of the file so workers can fine-tune
+// touch feel without spelunking through the dispatch logic. All values
+// are in physical pixels / pixels-per-second.
+const double kFastFlingVelocity = 800;
+const double kMediumDragVelocityMin = 300;
+const int kMediumDragBurstSize = 4;
+
+/// Routes vertical touch drags on the terminal viewport to one of three
+/// destinations based on the terminal's *own* state:
+///
+///   normal buffer        → host scrollback (no inertia synthesised by us
+///                          because scrollback drag is "direct manipulation"
+///                          — the user already lifted their finger; piling
+///                          on phantom ticks would surprise them)
+///   alt + no mouse       → arrow ↑ / ↓ per cell-height, PgUp / PgDn on fling
+///                          (apps without mouse reporting expect keystrokes)
+///   alt + reportScroll   → SGR wheel reports `\e[<64..65;col;rowM` at the
+///                          *drag-start* cell (matches desktop wheel
+///                          semantics: the wheel reports where you started,
+///                          not where the cursor currently is)
+///
+/// The asymmetry around inertia is deliberate: in normal-buffer scrollback
+/// the xterm.dart view owns a real scroll position, and our callers are
+/// expected to drive it directly. In alt-buffer paths the side-effect is
+/// the *application's* responsibility to interpret, and silently emitting
+/// "ghost" wheel/arrow events after the finger lifts would lie to the
+/// running TUI about user intent.
+class TerminalScrollAdapter {
+  TerminalScrollAdapter({
+    required this.terminal,
+    required this.cellAt,
+    required this.onScrollback,
+  });
+
+  /// State source. We never mirror buffer / mouseMode locally — the
+  /// terminal *is* the source of truth and reading it on each gesture
+  /// avoids a stale-flag class of bug.
+  final Terminal terminal;
+
+  /// Pixel → 1-based `(col, row)` mapper. Production wires this to the
+  /// xterm.dart render-object's `getCellOffset`; tests stub it.
+  final ({int col, int row}) Function(Offset) cellAt;
+
+  /// Normal-buffer scroll sink. Signed integer; positive matches a
+  /// downward drag direction. Callers translate sign into whatever
+  /// scrollback API the view exposes.
+  final void Function(int lines) onScrollback;
+
+  Offset _dragAnchor = Offset.zero;
+  double _residualDy = 0;
+  bool _dragActive = false;
+
+  /// Begins a drag. We record the *start* anchor (not the current pointer
+  /// position) because SGR wheel events semantically attach to where the
+  /// user started scrolling — matches how desktop emulators format them.
+  void onDragStart(Offset localPosition) {
+    _dragAnchor = localPosition;
+    _residualDy = 0;
+    _dragActive = true;
+  }
+
+  /// Accumulates raw drag-delta pixels and emits one unit per
+  /// `cellHeight` of accumulated travel. Sub-cell remainder is held in
+  /// `_residualDy` until the next update.
+  void onDragUpdate({required double deltaDy, required double cellHeight}) {
+    if (!_dragActive || cellHeight <= 0) return;
+    _residualDy += deltaDy;
+    final int units = (_residualDy / cellHeight).truncate();
+    if (units == 0) return;
+    _residualDy -= units * cellHeight;
+    _emitUnits(magnitude: units.abs(), down: units > 0);
+  }
+
+  /// Ends a drag. Fast fling (> [kFastFlingVelocity] in either direction)
+  /// triggers a coarse paging event scaled to the viewport. Slow
+  /// release discards any sub-cell residual — we do not carry residuals
+  /// across gestures because the user's mental model is "this swipe is
+  /// done".
+  void onDragEnd({required double velocityDy, required int rows}) {
+    if (!_dragActive) return;
+    _dragActive = false;
+    _residualDy = 0;
+
+    if (velocityDy.abs() < kFastFlingVelocity) return;
+    final bool down = velocityDy > 0;
+
+    if (!terminal.isUsingAltBuffer) {
+      // Normal-buffer fling intentionally not synthesised — the host
+      // ScrollController already received per-cell increments during the
+      // drag, and inertia would surprise the user (see class doc).
+      return;
+    }
+
+    if (terminal.mouseMode.reportScroll) {
+      final cell = cellAt(_dragAnchor);
+      final ticks = (rows / 2).floor().clamp(1, rows);
+      for (int i = 0; i < ticks; i++) {
+        terminal.onOutput?.call(_sgrWheel(cell, down: down));
+      }
+    } else {
+      terminal.keyInput(down ? TerminalKey.pageDown : TerminalKey.pageUp);
+    }
+  }
+
+  void _emitUnits({required int magnitude, required bool down}) {
+    if (!terminal.isUsingAltBuffer) {
+      onScrollback(down ? magnitude : -magnitude);
+      return;
+    }
+
+    if (terminal.mouseMode.reportScroll) {
+      final cell = cellAt(_dragAnchor);
+      for (int i = 0; i < magnitude; i++) {
+        terminal.onOutput?.call(_sgrWheel(cell, down: down));
+      }
+    } else {
+      for (int i = 0; i < magnitude; i++) {
+        terminal.keyInput(down ? TerminalKey.arrowDown : TerminalKey.arrowUp);
+      }
+    }
+  }
+
+  /// SGR-encoded mouse wheel report. Button 64 = wheel up, 65 = wheel
+  /// down. Press-only (`M`); xterm convention does not emit a release
+  /// for wheel buttons in practice.
+  String _sgrWheel(({int col, int row}) cell, {required bool down}) {
+    final int button = down ? 65 : 64;
+    return '\x1b[<$button;${cell.col};${cell.row}M';
+  }
+}

--- a/next/app/test/terminal_scroll_adapter_test.dart
+++ b/next/app/test/terminal_scroll_adapter_test.dart
@@ -1,0 +1,156 @@
+// Unit tests for TerminalScrollAdapter. The adapter is pure-Dart; we use
+// a real xterm.dart Terminal as the state source (cheaper than a mock; the
+// alt-buffer / mouseMode flags are easy to set via escape sequences) and
+// spy on its `onOutput` channel to capture emitted bytes.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/xterm.dart';
+
+import 'package:mobilecode/services/terminal_scroll_adapter.dart';
+
+void main() {
+  group('TerminalScrollAdapter', () {
+    late Terminal terminal;
+    late List<String> emitted;
+    late List<int> scrollback;
+
+    setUp(() {
+      terminal = Terminal(maxLines: 1000);
+      // Default ANSI cursor mode — arrow keys come out as `\e[A` / `\e[B`.
+      terminal.resize(80, 24);
+      emitted = <String>[];
+      scrollback = <int>[];
+      terminal.onOutput = emitted.add;
+    });
+
+    TerminalScrollAdapter buildAdapter({
+      ({int col, int row}) Function(Offset)? cellAt,
+    }) {
+      return TerminalScrollAdapter(
+        terminal: terminal,
+        cellAt: cellAt ?? (_) => (col: 10, row: 5),
+        onScrollback: scrollback.add,
+      );
+    }
+
+    void enterAltBuffer() => terminal.write('\x1b[?1049h');
+    void enableMouseScrollReporting() => terminal.write('\x1b[?1000h');
+
+    test('normal buffer: drag down 3 × cellHeight → 3 scrollback increments', () {
+      final adapter = buildAdapter();
+      adapter.onDragStart(const Offset(50, 50));
+      adapter.onDragUpdate(deltaDy: 16, cellHeight: 16);
+      adapter.onDragUpdate(deltaDy: 16, cellHeight: 16);
+      adapter.onDragUpdate(deltaDy: 16, cellHeight: 16);
+      adapter.onDragEnd(velocityDy: 0, rows: 24);
+
+      expect(scrollback, [1, 1, 1]);
+      expect(emitted, isEmpty);
+    });
+
+    test('alt + no mouse: drag down 3 × cellHeight → 3 × \\e[B (arrow down)', () {
+      enterAltBuffer();
+      expect(terminal.isUsingAltBuffer, isTrue);
+      expect(terminal.mouseMode, MouseMode.none);
+
+      final adapter = buildAdapter();
+      adapter.onDragStart(const Offset(50, 50));
+      adapter.onDragUpdate(deltaDy: 48, cellHeight: 16);
+      adapter.onDragEnd(velocityDy: 0, rows: 24);
+
+      expect(emitted, ['\x1b[B', '\x1b[B', '\x1b[B']);
+      expect(scrollback, isEmpty);
+    });
+
+    test('alt + mouse reportScroll: drag down 3 × cellHeight → 3 × SGR wheel-down', () {
+      enterAltBuffer();
+      enableMouseScrollReporting();
+      expect(terminal.mouseMode.reportScroll, isTrue);
+
+      // Stub cellAt to the spec's expected (10, 5) regardless of pixel
+      // position so the test is independent of any real render geometry.
+      final adapter = buildAdapter(cellAt: (_) => (col: 10, row: 5));
+      adapter.onDragStart(const Offset(120, 80));
+      adapter.onDragUpdate(deltaDy: 48, cellHeight: 16);
+      adapter.onDragEnd(velocityDy: 0, rows: 24);
+
+      expect(emitted, [
+        '\x1b[<65;10;5M',
+        '\x1b[<65;10;5M',
+        '\x1b[<65;10;5M',
+      ]);
+      expect(scrollback, isEmpty);
+    });
+
+    test('alt + no mouse: fast fling up (dy negative > 800 px/s) → one PgUp', () {
+      enterAltBuffer();
+
+      final adapter = buildAdapter();
+      adapter.onDragStart(const Offset(50, 50));
+      // No slow-drag accumulation; fling velocity alone triggers the paging
+      // event on dragEnd.
+      adapter.onDragEnd(velocityDy: -1200, rows: 24);
+
+      expect(emitted, ['\x1b[5~']);
+      expect(scrollback, isEmpty);
+    });
+
+    test('alt + mouse: fast fling → wheel-burst of rows/2 ticks at drag-start cell', () {
+      enterAltBuffer();
+      enableMouseScrollReporting();
+
+      final adapter = buildAdapter(cellAt: (_) => (col: 10, row: 5));
+      adapter.onDragStart(const Offset(120, 80));
+      adapter.onDragEnd(velocityDy: 1500, rows: 24);
+
+      // rows/2 = 12 wheel-down events.
+      expect(emitted.length, 12);
+      for (final s in emitted) {
+        expect(s, '\x1b[<65;10;5M');
+      }
+    });
+
+    test('sub-cellHeight residual is discarded at drag-end', () {
+      final adapter = buildAdapter();
+      adapter.onDragStart(const Offset(50, 50));
+      adapter.onDragUpdate(deltaDy: 8, cellHeight: 16);
+      adapter.onDragEnd(velocityDy: 0, rows: 24);
+
+      expect(scrollback, isEmpty);
+      expect(emitted, isEmpty);
+
+      // Next gesture must start cleanly — residual must not carry over.
+      adapter.onDragStart(const Offset(50, 50));
+      adapter.onDragUpdate(deltaDy: 8, cellHeight: 16);
+      adapter.onDragEnd(velocityDy: 0, rows: 24);
+
+      expect(scrollback, isEmpty);
+    });
+
+    test('alt + mouse: SGR anchor is taken at drag-start, not at update', () {
+      enterAltBuffer();
+      enableMouseScrollReporting();
+
+      // Make the mapper position-sensitive so we can see which Offset
+      // the adapter consulted.
+      var lastQueried = Offset.zero;
+      final adapter = TerminalScrollAdapter(
+        terminal: terminal,
+        cellAt: (o) {
+          lastQueried = o;
+          return (col: o.dx.toInt(), row: o.dy.toInt());
+        },
+        onScrollback: scrollback.add,
+      );
+
+      adapter.onDragStart(const Offset(7, 3));
+      adapter.onDragUpdate(deltaDy: 64, cellHeight: 16);
+      adapter.onDragEnd(velocityDy: 0, rows: 24);
+
+      // The drag-start offset was (7, 3); the adapter must not have used
+      // the update's accumulated position.
+      expect(lastQueried, const Offset(7, 3));
+      expect(emitted.every((s) => s == '\x1b[<65;7;3M'), isTrue);
+    });
+  });
+}

--- a/next/app/test/terminal_session_view_drag_test.dart
+++ b/next/app/test/terminal_session_view_drag_test.dart
@@ -1,0 +1,70 @@
+// Widget test for TerminalSessionView's vertical-drag wiring. Verifies
+// that a real touch drag, in alt-buffer + scroll-reporting mouse mode,
+// is converted to SGR wheel reports and dispatched via the terminal's
+// onOutput channel — i.e. the same channel that production routes to
+// `terminal.write` over the WebSocket.
+//
+// This is a thin integration test: it does NOT exercise the policy
+// matrix (covered exhaustively by terminal_scroll_adapter_test.dart)
+// and it does NOT mount the surrounding TerminalDetailScreen / AppBar
+// / keyboard toolbar. Only the gesture-handling Column subtree is
+// under test.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/xterm.dart';
+
+import 'package:mobilecode/screens/terminal_detail.dart';
+
+void main() {
+  testWidgets(
+    'alt + mouse reportScroll: vertical drag emits SGR wheel reports via onOutput',
+    (tester) async {
+      final terminal = Terminal(maxLines: 1000);
+      terminal.resize(80, 24);
+      // Enter alt buffer + enable mouse scroll reporting BEFORE installing
+      // the spy, since these writes are not what we want to capture.
+      terminal.write('\x1b[?1049h');
+      terminal.write('\x1b[?1000h');
+      expect(terminal.isUsingAltBuffer, isTrue);
+      expect(terminal.mouseMode.reportScroll, isTrue);
+
+      final captured = <String>[];
+      terminal.onOutput = captured.add;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalSessionView(terminal: terminal),
+          ),
+        ),
+      );
+      // Two pumps so xterm.dart's TerminalView has a chance to build its
+      // render object — the drag handler reads renderTerminal.lineHeight
+      // and renderTerminal.getCellOffset.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      final terminalFinder = find.byType(TerminalView);
+      expect(terminalFinder, findsOneWidget);
+
+      // A modest downward drag — enough to clear at least one cellHeight
+      // and trigger at least one SGR wheel-down report. Exact count
+      // depends on the rendered cell height in the test environment, so
+      // we assert on shape, not magnitude.
+      await tester.drag(terminalFinder, const Offset(0, 120));
+      await tester.pump();
+
+      expect(captured, isNotEmpty,
+          reason: 'drag should have emitted at least one SGR wheel report');
+      for (final s in captured) {
+        // SGR wheel-down at some cell (col, row >= 1).
+        expect(
+          RegExp(r'^\x1b\[<65;\d+;\d+M$').hasMatch(s),
+          isTrue,
+          reason: 'unexpected emission: ${s.codeUnits}',
+        );
+      }
+    },
+  );
+}


### PR DESCRIPTION
Closes #69.

## Summary
- New pure-Dart `TerminalScrollAdapter` (in `next/app/lib/services/`) routes a vertical touch swipe in the immersive terminal to one of three destinations, chosen from the terminal's own state:
  - **normal buffer** → xterm.dart's outer Scrollable scrolls natively (adapter sink is a no-op).
  - **alt + no mouse** → arrow ↑/↓ per cell-height, PgUp/PgDn on fast fling (`> 800 px/s`).
  - **alt + reportScroll** → SGR wheel reports `\e[<64|65;col;rowM` at the *drag-start* cell; rows/2 burst on fling.
- Integrated into `TerminalSessionView` via a `Listener` (not a GestureDetector) so xterm.dart's own tap / long-press / back-swipe gestures keep firing.
- xterm.dart's built-in wheel emission is silenced via a `_WheelSuppressingMouseHandler` proxy and `simulateScroll: false`, so we never double-fire alongside the adapter in alt buffer.

## xterm.dart 4.x APIs used (per AC last bullet)
| Need | API |
|---|---|
| Detect alt buffer | `Terminal.isUsingAltBuffer` |
| Detect wheel-reporting mode | `Terminal.mouseMode.reportScroll` |
| Rows for fling burst sizing | `Terminal.viewHeight` |
| Suppress xterm wheel emission | `Terminal.mouseHandler` (proxy) |
| Pixel → cell mapping / cell height | `TerminalViewState.renderTerminal.getCellOffset` / `.lineHeight` |
| Disable xterm's alt-buffer arrow simulation | `TerminalView(simulateScroll: false)` |

The spec said \"mouse mode \`normal\`\". xterm.dart's `MouseMode` enum doesn't have that exact name; the equivalent is anything with `reportScroll == true` (`upDownScroll`, `upDownScrollDrag`, `upDownScrollMove`). The adapter switches on that boolean, not enum identity.

## Test plan
- [x] `flutter test test/terminal_scroll_adapter_test.dart` — 7 unit tests cover every branch (normal-buffer scrollback, alt+no-mouse arrows, alt+mouse SGR, fling-to-PgUp, fling-to-wheel-burst, residual-discarded, drag-start-anchor invariance).
- [x] `flutter test test/terminal_session_view_drag_test.dart` — widget test mounts `TerminalSessionView` in alt+mouse mode, drives `tester.drag`, asserts SGR wheel reports flow through `terminal.onOutput`.
- [x] `flutter test` — full app suite, 89 tests pass (no regressions).
- [x] `flutter analyze` — clean for changed files (pre-existing `system_tray.dart` info-level lint unrelated).
- [x] `pnpm typecheck` (backend) — clean, no backend changes.
- [ ] **Manual on-device verification** of the four user-facing AC bullets (zellij scroll, less paging, vim mouse=a no-cursor-jump, plain bash scrollback) — this branch is headless; the worker can't drive a real PTY. The unit + widget tests verify the byte sequences match what those TUIs expect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)